### PR TITLE
fix(security): remove legacy guestId fallback to prevent auth bypass

### DIFF
--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -24,7 +24,7 @@ export const createRoom = mutation({
   args: {
     displayName: v.string(),
     guestToken: v.optional(v.string()),
-    guestId: v.optional(v.string()), // Legacy fallback; prefer guestToken
+    guestId: v.optional(v.string()), // Deprecated: throws error, kept for clear messaging
   },
   handler: async (ctx, { displayName, guestToken, guestId }) => {
     const user = await ensureUserHelper(ctx, {
@@ -70,7 +70,7 @@ export const joinRoom = mutation({
     code: v.string(),
     displayName: v.string(),
     guestToken: v.optional(v.string()),
-    guestId: v.optional(v.string()),
+    guestId: v.optional(v.string()), // Deprecated: throws error, kept for clear messaging
   },
   handler: async (ctx, { code, displayName, guestToken, guestId }) => {
     const user = await ensureUserHelper(ctx, {

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -20,9 +20,7 @@ const resolveGuestId = async (args: {
   }
 
   if (args.guestId) {
-    // Legacy fallback for older clients that still send a raw guestId.
-    // Keep this path temporary; prefer signed guestToken for integrity.
-    return args.guestId;
+    throw new ConvexError('guestId auth deprecated. Please refresh browser.');
   }
 
   return null;
@@ -50,16 +48,6 @@ export const ensureUserHelper = async (
 
   const guestId = await resolveGuestId(args);
 
-  // Legacy guestId path: avoid duplicating users from repeated requests
-  if (!clerkUserId && guestId) {
-    const legacyGuest = await ctx.db
-      .query('users')
-      .withIndex('by_guest', (q) => q.eq('guestId', guestId))
-      .first();
-
-    if (legacyGuest) return legacyGuest;
-  }
-
   if (!clerkUserId && !guestId) {
     throw new ConvexError('Missing user identifier');
   }
@@ -81,7 +69,7 @@ export const ensureUser = mutation({
   args: {
     clerkUserId: v.optional(v.string()), // Deprecated
     guestToken: v.optional(v.string()),
-    guestId: v.optional(v.string()), // Legacy fallback
+    guestId: v.optional(v.string()), // Deprecated: throws error, kept for clear messaging
     displayName: v.string(),
   },
   handler: async (ctx, args): Promise<UserDoc> => {

--- a/tests/convex/users.test.ts
+++ b/tests/convex/users.test.ts
@@ -64,29 +64,15 @@ describe('ensureUserHelper', () => {
     expect(user.guestId).toBe(guestId);
   });
 
-  it('accepts legacy guestId when no token is provided', async () => {
+  it('rejects legacy guestId with deprecation error', async () => {
     mockGetUser.mockResolvedValue(null);
-    mockDb.insert.mockResolvedValue('user2');
-    mockDb.get.mockResolvedValue({
-      _id: 'user2',
-      guestId: 'legacy-guest',
-      displayName: 'Legacy',
-      createdAt: 123,
-    });
 
-    const user = await ensureUserHelper(mockCtx, {
-      displayName: ' Legacy  ',
-      guestId: 'legacy-guest',
-    });
-
-    expect(mockDb.insert).toHaveBeenCalledWith(
-      'users',
-      expect.objectContaining({
+    await expect(
+      ensureUserHelper(mockCtx, {
+        displayName: 'Legacy',
         guestId: 'legacy-guest',
-        displayName: 'Legacy', // trimmed
       })
-    );
-    expect(user.displayName).toBe('Legacy');
+    ).rejects.toThrow('guestId auth deprecated. Please refresh browser.');
   });
 
   it('throws when no identity information supplied', async () => {


### PR DESCRIPTION
## Summary
- Removes legacy unsigned `guestId` parameter that allowed attackers to impersonate any guest user
- Now throws `ConvexError` with clear deprecation message when old clients attempt to use raw guestId
- Removes dead code path for legacy guest lookup

## Changes
- `convex/users.ts`: `resolveGuestId()` now throws on guestId instead of accepting it
- `convex/users.ts`: Removed legacy guestId lookup path in `ensureUserHelper`
- `convex/rooms.ts`: Updated comments to mark guestId params as deprecated
- `tests/convex/users.test.ts`: Updated test to verify deprecation error is thrown

## Test plan
- [x] Unit tests pass (496 tests)
- [x] Typecheck passes
- [x] Lint passes
- [x] Pre-push hooks pass

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Legacy guest authentication has been deprecated and now requires users to refresh their browser to access current authentication methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->