### PR TITLE
fix(error): consolidate duplicate captureError implementations

### DIFF
--- a/hooks/useSharePoem.ts
+++ b/hooks/useSharePoem.ts
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useMutation } from 'convex/react';
 import { api } from '../convex/_generated/api';
 import { Id } from '../convex/_generated/dataModel';
-import { captureError } from '../lib/sentry';
+import { captureError } from '@/lib/error';
 
 export function useSharePoem(poemId: Id<'poems'>) {
   const [copied, setCopied] = useState(false);

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
+import { isSentryEnabled } from './sentry';
 
 /**
  * Capture an error to Sentry with optional context.
@@ -13,11 +14,16 @@ export function captureError(
   error: unknown,
   context?: Record<string, unknown>
 ) {
+  if (!isSentryEnabled) {
+    console.error('Error captured (Sentry disabled):', error, context);
+    return;
+  }
+
   Sentry.captureException(error, {
     contexts: context ? { custom: context } : undefined,
   });
 
-  // Log to console in development for visibility when Sentry is not configured
+  // Log to console in development for visibility
   if (process.env.NODE_ENV === 'development') {
     console.error('Captured error:', error, context);
   }

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/nextjs';
 import type { ErrorEvent } from '@sentry/nextjs';
 
 /**
@@ -20,20 +19,6 @@ const RAW_DSN =
 const isProduction = process.env.NODE_ENV === 'production';
 
 export const isSentryEnabled = RAW_DSN.length > 0;
-
-export function captureError(
-  error: unknown,
-  context?: Record<string, unknown>
-) {
-  if (!isSentryEnabled) {
-    console.error('Error captured (Sentry disabled):', error, context);
-    return;
-  }
-
-  Sentry.captureException(error, {
-    extra: context,
-  });
-}
 
 export const sentryOptions = {
   dsn: RAW_DSN || undefined,

--- a/tests/hooks/useSharePoem.test.ts
+++ b/tests/hooks/useSharePoem.test.ts
@@ -10,9 +10,9 @@ vi.mock('convex/react', () => ({
   useMutation: () => mockLogShare,
 }));
 
-// Mock sentry
+// Mock lib/error's captureError
 const mockCaptureError = vi.fn();
-vi.mock('../../lib/sentry', () => ({
+vi.mock('@/lib/error', () => ({
   captureError: (err: unknown, context: unknown) =>
     mockCaptureError(err, context),
 }));

--- a/tests/lib/sentry.test.ts
+++ b/tests/lib/sentry.test.ts
@@ -16,7 +16,6 @@ describe('sentryOptions', () => {
   describe('without DSN', () => {
     let sentryOptions: typeof import('@/lib/sentry').sentryOptions;
     let isSentryEnabled: typeof import('@/lib/sentry').isSentryEnabled;
-    let captureError: typeof import('@/lib/sentry').captureError;
 
     beforeAll(async () => {
       vi.resetModules();
@@ -27,7 +26,6 @@ describe('sentryOptions', () => {
       const mod = await import('@/lib/sentry');
       sentryOptions = mod.sentryOptions;
       isSentryEnabled = mod.isSentryEnabled;
-      captureError = mod.captureError;
 
       process.env = ORIGINAL_ENV;
     });
@@ -35,23 +33,6 @@ describe('sentryOptions', () => {
     it('disables instrumentation when no DSN is configured', () => {
       expect(isSentryEnabled).toBe(false);
       expect(sentryOptions.enabled).toBe(false);
-    });
-
-    it('captureError logs to console when Sentry is disabled', () => {
-      const consoleSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {});
-      const testError = new Error('Test error');
-      const context = { userId: 'user_123' };
-
-      captureError(testError, context);
-
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'Error captured (Sentry disabled):',
-        testError,
-        context
-      );
-      consoleSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary
- Remove `captureError` from `lib/sentry.ts` and consolidate all error capturing in `lib/error.ts`
- Add `isSentryEnabled` guard to `lib/error.ts` for consistent behavior when Sentry is disabled
- Update `useSharePoem` hook to import from `@/lib/error`

## Changes
| File | Change |
|------|--------|
| `lib/sentry.ts` | Remove `captureError` export, remove unused `Sentry` namespace import |
| `lib/error.ts` | Import `isSentryEnabled` and add guard before calling Sentry |
| `hooks/useSharePoem.ts` | Update import to `@/lib/error` |
| Test files | Update mocks to reflect new module structure |

## Test Plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no errors)
- [x] `pnpm test:ci` passes with full coverage

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Error handling now respects a global Sentry disable flag, logging errors locally to console when Sentry is disabled.

* **Refactor**
  * Reorganized error capture module structure and import paths.

* **Tests**
  * Enhanced test coverage for disabled Sentry scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->