### PR TITLE
fix(game): unify reader assignment algorithm

### DIFF
--- a/convex/game.ts
+++ b/convex/game.ts
@@ -319,13 +319,15 @@ export const submitLine = mutation({
           humanAndAiPlayers
         );
 
-        // Patch all poems with assigned readers
-        for (const poem of poems) {
-          await ctx.db.patch(poem._id, {
-            completedAt: Date.now(),
-            assignedReaderId: readerAssignments.get(poem._id),
-          });
-        }
+        // Patch all poems with assigned readers (parallel for performance)
+        await Promise.all(
+          poems.map((poem) =>
+            ctx.db.patch(poem._id, {
+              completedAt: Date.now(),
+              assignedReaderId: readerAssignments.get(poem._id),
+            })
+          )
+        );
       }
     }
   },


### PR DESCRIPTION
## Summary

- Unified reader assignment to use `assignPoemReaders` deep module in both human-only and AI-included game paths
- Eliminated divergent modulo-based algorithm in `game.ts` that could theoretically allow self-reads
- Improved code clarity with type guards and better variable naming

## Before

`game.ts` used simple `(i + 1) % players.length` seat offset with ad-hoc AI-to-host fallback:
```typescript
const readerIndex = (i + 1) % players.length;
const readerPlayer = players.find((p) => p.seatIndex === readerIndex);
// If natural reader is AI, assign to host instead
const finalReaderId = readerUser?.kind === 'AI' ? room.hostUserId : readerPlayer?.userId;
```

`ai.ts` used the proper `assignPoemReaders` module with derangement constraints.

## After

Both paths now use `assignPoemReaders`:
- Guarantees no player reads their own poem (derangement constraint)
- Consistent AI exclusion (filtered upfront, not ad-hoc fallback)
- Single source of truth for reader assignment logic

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:ci` passes (501 tests)
- [x] Pre-push hooks pass

Closes #89

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized poem reader assignment into a single, consistent mechanism with unified human/AI handling.
  * Switched to batch-style assignment updates for all poems, enabling parallelized updates and improved performance.
  * Final reader determination now uses the centralized assignments, including AI/host fallbacks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->