### PR TITLE
fix: require auth for getRoom query

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,3 @@
+# Architecture
+
+Canonical doc lives at `docs/ARCHITECTURE.md`.


### PR DESCRIPTION
## Summary
- require auth for getRoom and limit room data for non-participants
- block non-participants when game is active or room is full
- update getRoom tests for auth/joinable cases

## Testing
- pnpm vitest run tests/convex/rooms.test.ts
- pnpm test
- pnpm typecheck

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guest-token authentication for room access and stronger participant-aware access control; participants see full room details, non-participants see limited info and only joinable rooms.
* **Bug Fixes / Behavior**
  * Non-participants blocked from rooms that are full or have an active game; host checks now use authenticated user context.
* **Tests**
  * Expanded tests covering participant vs non-participant flows and guest-token scenarios.
* **Documentation**
  * Added an architecture note linking to canonical docs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->