### PR TITLE
fix(lint): add coverage/ to ESLint ignores

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,8 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     // Generated files
     "convex/_generated/**",
+    // Test coverage output
+    "coverage/**",
   ]),
 ]);
 


### PR DESCRIPTION
## Summary
ESLint warnings from `coverage/` directory files (unused eslint-disable directives) blocked CI with `--max-warnings 0`. Added `coverage/**` to global ignores.

Closes #130

## Changes
- Added `coverage/**` to `eslint.config.mjs` global ignores alongside existing `convex/_generated/**`

## Acceptance Criteria
- [x] `pnpm lint` exits 0 with no warnings
- [x] `pnpm typecheck` passes
- [x] All 528 tests pass

## Manual QA
```bash
pnpm lint  # Should exit clean, 0 warnings
```

## Test Coverage
No new tests needed — this is a config-only change. Existing test suite (528 tests) passes unchanged.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Development tooling updated to ignore the test coverage output directory during linting, reducing noise from generated coverage files and preventing irrelevant lint warnings. This is a non-functional tooling change and does not affect runtime behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->