### PR TITLE
fix(game): prevent double round advancement race condition

### DIFF
--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -406,6 +406,11 @@ export const commitAiLine = internalMutation({
     const allSubmitted = lineChecks.every((line) => line !== null);
 
     if (allSubmitted) {
+      // Idempotent guard: re-read game to prevent double-advancement.
+      // See convex/game.ts submitLine for detailed rationale.
+      const freshGame = await ctx.db.get(gameId);
+      if (!freshGame || freshGame.currentRound !== lineIndex) return;
+
       if (lineIndex < 8) {
         // Advance round
         await ctx.db.patch(gameId, { currentRound: lineIndex + 1 });

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -285,6 +285,13 @@ export const submitLine = mutation({
     const allSubmitted = lineChecks.every((line) => line !== null);
 
     if (allSubmitted) {
+      // Idempotent guard: re-read game to prevent double-advancement
+      // when concurrent mutations (human + AI) both see allSubmitted.
+      // Convex serializes mutations on the same document, so the second
+      // caller sees the already-advanced state.
+      const freshGame = await ctx.db.get(game._id);
+      if (!freshGame || freshGame.currentRound !== lineIndex) return;
+
       if (lineIndex < 8) {
         await ctx.db.patch(game._id, { currentRound: lineIndex + 1 });
 

--- a/tests/convex/game.test.ts
+++ b/tests/convex/game.test.ts
@@ -563,6 +563,105 @@ describe('game', () => {
         })
       );
     });
+
+    it('does not double-advance round when concurrent submissions both see allSubmitted', async () => {
+      mockGetUser.mockResolvedValue({ _id: 'user1' });
+      mockDb.get
+        .mockResolvedValueOnce({
+          roomId: 'room1',
+          indexInRoom: 0,
+          gameId: 'game1',
+        }) // poem
+        .mockResolvedValueOnce({
+          _id: 'game1',
+          status: 'IN_PROGRESS',
+          currentRound: 0,
+          assignmentMatrix: [['user1', 'user2']],
+        }) // game
+        .mockResolvedValueOnce({ _id: 'room1' }) // room
+        // Idempotent guard re-read: round already advanced by concurrent mutation
+        .mockResolvedValueOnce({
+          _id: 'game1',
+          status: 'IN_PROGRESS',
+          currentRound: 1,
+          assignmentMatrix: [['user1', 'user2']],
+        });
+
+      // No duplicate line
+      mockDb.first
+        .mockResolvedValueOnce(null) // duplicate check
+        .mockResolvedValueOnce({ _id: 'line1' }) // poem1 line check
+        .mockResolvedValueOnce({ _id: 'line2' }); // poem2 line check
+
+      // Poems in game
+      mockDb.collect.mockResolvedValue([{ _id: 'poem1' }, { _id: 'poem2' }]);
+
+      // @ts-expect-error - calling handler
+      await submitLine.handler(mockCtx, {
+        poemId: 'poem1',
+        lineIndex: 0,
+        text: 'hello',
+        guestToken: 'token',
+      });
+
+      // Line should still be inserted
+      expect(mockDb.insert).toHaveBeenCalled();
+      // But round should NOT be advanced (guard detected concurrent advancement)
+      expect(mockDb.patch).not.toHaveBeenCalledWith(
+        'game1',
+        expect.objectContaining({ currentRound: 1 })
+      );
+      // And AI turn should NOT be scheduled
+      expect(mockCtx.scheduler.runAfter).not.toHaveBeenCalled();
+    });
+
+    it('advances round when guard confirms no concurrent advancement', async () => {
+      mockGetUser.mockResolvedValue({ _id: 'user1' });
+      mockDb.get
+        .mockResolvedValueOnce({
+          roomId: 'room1',
+          indexInRoom: 0,
+          gameId: 'game1',
+        }) // poem
+        .mockResolvedValueOnce({
+          _id: 'game1',
+          status: 'IN_PROGRESS',
+          currentRound: 0,
+          assignmentMatrix: [['user1', 'user2']],
+        }) // game
+        .mockResolvedValueOnce({ _id: 'room1' }) // room
+        // Idempotent guard re-read: round still at 0, safe to advance
+        .mockResolvedValueOnce({
+          _id: 'game1',
+          status: 'IN_PROGRESS',
+          currentRound: 0,
+          assignmentMatrix: [['user1', 'user2']],
+        });
+
+      // No duplicate line
+      mockDb.first
+        .mockResolvedValueOnce(null) // duplicate check
+        .mockResolvedValueOnce({ _id: 'line1' }) // poem1 line check
+        .mockResolvedValueOnce({ _id: 'line2' }); // poem2 line check
+
+      // Poems in game
+      mockDb.collect.mockResolvedValue([{ _id: 'poem1' }, { _id: 'poem2' }]);
+
+      // @ts-expect-error - calling handler
+      await submitLine.handler(mockCtx, {
+        poemId: 'poem1',
+        lineIndex: 0,
+        text: 'hello',
+        guestToken: 'token',
+      });
+
+      // Round SHOULD be advanced
+      expect(mockDb.patch).toHaveBeenCalledWith('game1', {
+        currentRound: 1,
+      });
+      // AI turn SHOULD be scheduled
+      expect(mockCtx.scheduler.runAfter).toHaveBeenCalled();
+    });
   });
 
   describe('getRevealPhaseState', () => {


### PR DESCRIPTION
## Summary
Concurrent `submitLine` and `commitAiLine` mutations could both detect "all poems submitted" and advance the round twice, causing duplicate AI scheduling or skipped rounds. Added idempotent re-read guard before advancement.

Closes #142

## Changes
- Added idempotent guard in `convex/game.ts` `submitLine`: re-reads game state before advancing, returns early if round already advanced
- Added same guard in `convex/ai.ts` `commitAiLine`
- Added 2 regression tests: concurrent double-advance (blocked) and normal single advance (allowed)

## Acceptance Criteria
- [x] Round advances exactly once per round
- [x] AI turns scheduled exactly once per round
- [x] Test: concurrent submissions don't cause double-advance

## Manual QA
```bash
pnpm vitest run tests/convex/game.test.ts
# Look for: "does not double-advance round when concurrent submissions..."
# Look for: "advances round when guard confirms no concurrent advancement"
```

## Test Coverage
- `tests/convex/game.test.ts`: 2 new tests covering the idempotent guard behavior
- 530 total tests pass (528 existing + 2 new)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an idempotent guard to prevent race-induced double-advancement of rounds when multiple submissions occur concurrently.

* **Tests**
  * Added tests ensuring concurrent submissions don't incorrectly advance the round.
  * Added tests verifying correct advancement and scheduling when no concurrent advancement occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->