### PR TITLE
fix(game): add bounds checking to assignment matrix access

### DIFF
--- a/convex/game.ts
+++ b/convex/game.ts
@@ -3,6 +3,7 @@ import { mutation, query } from './_generated/server';
 import { internal } from './_generated/api';
 import {
   generateAssignmentMatrix,
+  getMatrixRound,
   secureShuffle,
 } from './lib/assignmentMatrix';
 import { WORD_COUNTS } from './lib/gameRules';
@@ -140,7 +141,10 @@ export const getCurrentAssignment = query({
     if (!game) return null;
 
     const currentRound = game.currentRound;
-    const roundAssignments = game.assignmentMatrix[currentRound];
+    const roundAssignments = getMatrixRound(
+      game.assignmentMatrix,
+      currentRound
+    );
 
     // Find which poem index this user is assigned to
     const poemIndex = roundAssignments.findIndex((uid) => uid === user._id);
@@ -226,7 +230,9 @@ export const submitLine = mutation({
     }
 
     // Validate assignment (immutable matrix - always stable)
-    const assignedUserId = game.assignmentMatrix[lineIndex][poem.indexInRoom];
+    const assignedUserId = getMatrixRound(game.assignmentMatrix, lineIndex)[
+      poem.indexInRoom
+    ];
     if (assignedUserId !== user._id) throw new Error('Not your turn');
 
     // Validate line length (prevent storage abuse)
@@ -320,7 +326,9 @@ export const submitLine = mutation({
           poems.map((p) => ({
             _id: p._id,
             // Author = first line writer from assignment matrix
-            authorUserId: game.assignmentMatrix[0][p.indexInRoom],
+            authorUserId: getMatrixRound(game.assignmentMatrix, 0)[
+              p.indexInRoom
+            ],
           })),
           humanAndAiPlayers
         );
@@ -564,9 +572,10 @@ export const getRoundProgress = query({
 
     // Build player -> poem assignments for current round
     const playerAssignments = roomPlayers.map((player) => {
-      const poemIndex = game.assignmentMatrix[game.currentRound].findIndex(
-        (uid) => uid === player.userId
-      );
+      const poemIndex = getMatrixRound(
+        game.assignmentMatrix,
+        game.currentRound
+      ).findIndex((uid) => uid === player.userId);
       return {
         player,
         poemIndex,

--- a/convex/lib/assignmentMatrix.ts
+++ b/convex/lib/assignmentMatrix.ts
@@ -1,3 +1,4 @@
+import { ConvexError } from 'convex/values';
 import { Id } from '../_generated/dataModel';
 
 /**
@@ -82,6 +83,22 @@ function findSwapTarget<T>(
     }
   }
   return -1; // No suitable swap target found
+}
+
+/**
+ * Bounds-checked access to an assignment matrix row.
+ * Throws ConvexError if round is out of bounds (corrupted state or logic bug).
+ */
+export function getMatrixRound(
+  matrix: Id<'users'>[][],
+  round: number
+): Id<'users'>[] {
+  if (round < 0 || round >= matrix.length) {
+    throw new ConvexError(
+      `Invalid game state: round ${round} out of bounds (matrix has ${matrix.length} rounds)`
+    );
+  }
+  return matrix[round];
 }
 
 // Implements the assignment matrix generation algorithm from TASK.md 2.3.2

--- a/tests/assignmentMatrix.test.ts
+++ b/tests/assignmentMatrix.test.ts
@@ -1,5 +1,8 @@
 import { test, expect, describe } from 'vitest';
-import { generateAssignmentMatrix } from '../convex/lib/assignmentMatrix';
+import {
+  generateAssignmentMatrix,
+  getMatrixRound,
+} from '../convex/lib/assignmentMatrix';
 import { Id } from '../convex/_generated/dataModel';
 
 // Helper to create mock user IDs
@@ -98,5 +101,38 @@ describe('generateAssignmentMatrix', () => {
     // The `hasConflicts` will always be true for 1 player.
     // The test mainly ensures it doesn't crash or run forever.
     // Further refinement of the algorithm's conflict handling for N=1 might be needed.
+  });
+});
+
+describe('getMatrixRound', () => {
+  const matrix = [
+    ['u0', 'u1'],
+    ['u1', 'u0'],
+  ] as Id<'users'>[][];
+
+  test('returns the correct round row for valid index', () => {
+    expect(getMatrixRound(matrix, 0)).toEqual(['u0', 'u1']);
+    expect(getMatrixRound(matrix, 1)).toEqual(['u1', 'u0']);
+  });
+
+  test('throws ConvexError for round >= matrix length', () => {
+    expect(() => getMatrixRound(matrix, 2)).toThrow(
+      'Invalid game state: round 2 out of bounds'
+    );
+    expect(() => getMatrixRound(matrix, 9)).toThrow(
+      'Invalid game state: round 9 out of bounds'
+    );
+  });
+
+  test('throws ConvexError for negative round', () => {
+    expect(() => getMatrixRound(matrix, -1)).toThrow(
+      'Invalid game state: round -1 out of bounds'
+    );
+  });
+
+  test('throws ConvexError for empty matrix', () => {
+    expect(() => getMatrixRound([], 0)).toThrow(
+      'Invalid game state: round 0 out of bounds'
+    );
   });
 });

--- a/tests/convex/game.test.ts
+++ b/tests/convex/game.test.ts
@@ -37,13 +37,19 @@ vi.mock('../../convex/lib/room', () => ({
 }));
 
 // assignmentMatrix uses crypto.getRandomValues internally - mock at non-deterministic boundary
-vi.mock('../../convex/lib/assignmentMatrix', () => ({
-  generateAssignmentMatrix: () => [
-    [0, 1],
-    [1, 0],
-  ],
-  secureShuffle: <T>(arr: T[]) => arr, // Identity for deterministic tests
-}));
+// getMatrixRound is deterministic, so use real implementation
+vi.mock('../../convex/lib/assignmentMatrix', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../convex/lib/assignmentMatrix')>();
+  return {
+    ...actual,
+    generateAssignmentMatrix: () => [
+      [0, 1],
+      [1, 0],
+    ],
+    secureShuffle: <T>(arr: T[]) => arr, // Identity for deterministic tests
+  };
+});
 
 // wordCount is deterministic - use real implementation (no mock)
 


### PR DESCRIPTION
## Summary
All assignment matrix access points now validate bounds before indexing, preventing uncaught TypeError on corrupted game state. Uses `getMatrixRound()` helper that throws descriptive `ConvexError` on out-of-bounds access.

Closes #143

## Changes
- Added `getMatrixRound()` helper to `convex/lib/assignmentMatrix.ts`
- Updated all 8 matrix access points in `convex/game.ts` (4) and `convex/ai.ts` (4)
- Updated `game.test.ts` mock to use real `getMatrixRound` implementation
- Added 4 unit tests for bounds checking behavior

## Acceptance Criteria
- [x] Bounds check added to all matrix access points
- [x] Uses ConvexError (not plain Error) for client-distinguishable error
- [x] Test: out-of-bounds round throws descriptive error

## Manual QA
```bash
pnpm vitest run tests/assignmentMatrix.test.ts
# Look for: "getMatrixRound" describe block with 4 tests
```

## Test Coverage
- `tests/assignmentMatrix.test.ts`: 4 new tests (valid index, out-of-bounds, negative, empty matrix)
- 532 total tests pass (528 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked assignment matrix access to use a bounds-checked helper across the game flow.

* **Bug Fixes**
  * Added explicit validation and error handling for invalid assignment round lookups to prevent out-of-bounds access.

* **Tests**
  * Added unit tests for the new bounds-checked helper and updated game tests to use a deterministic assignment mock.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->