### PR TITLE
fix(shares): throw on invalid poem ID in logShare (#152)

### DIFF
--- a/convex/shares.ts
+++ b/convex/shares.ts
@@ -1,4 +1,4 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 import { mutation } from './_generated/server';
 
 export const logShare = mutation({
@@ -8,8 +8,7 @@ export const logShare = mutation({
   handler: async (ctx, { poemId }) => {
     const poem = await ctx.db.get(poemId);
     if (!poem) {
-      // Silent fail if poem doesn't exist
-      return;
+      throw new ConvexError('Poem not found');
     }
 
     await ctx.db.insert('shares', {


### PR DESCRIPTION
Closes #152

## Summary

 was silently returning when the poem ID was not found in the database. This masked bad calls — callers would never know the share wasn't recorded.

## Changes

- : Added  import from `convex/values` and replaced the silent `return` with `throw new ConvexError('Poem not found')`.

## Client-side safety

The only call site (`hooks/useSharePoem.ts`) already uses fire-and-forget style:
```ts
logShare({ poemId }).catch(() => {});
```
The error is swallowed silently — no crash, no user-visible disruption. This is acceptable for analytics-style logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to properly report when a poem is not found instead of failing silently, providing clearer feedback to users when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->