### PR TITLE
fix(ci): pin trufflehog scanner version

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -27,4 +27,5 @@ jobs:
           path: ./
           base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          extra_args: --results=verified,unknown --fail
+          version: v3.91.2
+          extra_args: --results=verified,unknown

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -27,5 +27,5 @@ jobs:
           path: ./
           base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          version: v3.91.2
+          version: 3.91.2
           extra_args: --results=verified,unknown


### PR DESCRIPTION
Repairs the TruffleHog workflow introduced in #181 so it can actually run on every PR.\n\n- remove the duplicated --fail flag passed through extra_args\n- pin the scanner image version to v3.91.2 instead of pulling latest\n\nThis is a blocker fix for the remaining open dependency PRs, which are all currently failing the same workflow bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security scanning workflow configuration to explicitly lock the scanning tool to a specific version, ensuring consistent behavior across all builds. The workflow has been adjusted to allow the build and deployment process to continue when security scanning detects potential issues, providing development teams with greater flexibility in reviewing and managing security findings before taking action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->