### PR TITLE
[codex] harden room flow handoffs

### DIFF
--- a/app/room/[code]/page.tsx
+++ b/app/room/[code]/page.tsx
@@ -2,17 +2,14 @@
 
 import { use } from 'react';
 import { useQuery } from 'convex/react';
-import { api } from '../../../convex/_generated/api';
-import { Lobby } from '../../../components/Lobby';
-import { WritingScreen } from '../../../components/WritingScreen';
-import { RevealPhase } from '../../../components/RevealPhase';
-import { RoomChrome } from '../../../components/RoomChrome';
-import { AuthErrorState } from '../../../components/AuthErrorState';
-import {
-  LoadingMessages,
-  LoadingState,
-} from '../../../components/ui/LoadingState';
-import { useUser } from '../../../lib/auth';
+import { api } from '@/convex/_generated/api';
+import { AuthErrorState } from '@/components/AuthErrorState';
+import { Lobby } from '@/components/Lobby';
+import { RevealPhase } from '@/components/RevealPhase';
+import { RoomChrome } from '@/components/RoomChrome';
+import { WritingScreen } from '@/components/WritingScreen';
+import { LoadingMessages, LoadingState } from '@/components/ui/LoadingState';
+import { useUser } from '@/lib/auth';
 
 interface RoomPageProps {
   params: Promise<{ code: string }>;

--- a/app/room/[code]/page.tsx
+++ b/app/room/[code]/page.tsx
@@ -6,7 +6,12 @@ import { api } from '../../../convex/_generated/api';
 import { Lobby } from '../../../components/Lobby';
 import { WritingScreen } from '../../../components/WritingScreen';
 import { RevealPhase } from '../../../components/RevealPhase';
+import { RoomChrome } from '../../../components/RoomChrome';
 import { AuthErrorState } from '../../../components/AuthErrorState';
+import {
+  LoadingMessages,
+  LoadingState,
+} from '../../../components/ui/LoadingState';
 import { useUser } from '../../../lib/auth';
 
 interface RoomPageProps {
@@ -28,7 +33,7 @@ export default function RoomPage({ params }: RoomPageProps) {
   if (isLoading || roomState === undefined) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-[var(--color-background)]">
-        <span className="text-[var(--color-text-muted)]">Loading...</span>
+        <LoadingState message={LoadingMessages.LOADING_ROOM} />
       </div>
     );
   }
@@ -58,5 +63,10 @@ export default function RoomPage({ params }: RoomPageProps) {
     content = <RevealPhase roomCode={code} />;
   }
 
-  return content;
+  return (
+    <>
+      <RoomChrome roomCode={code} />
+      {content}
+    </>
+  );
 }

--- a/components/PoemDisplay.tsx
+++ b/components/PoemDisplay.tsx
@@ -4,6 +4,7 @@ import { Fragment, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { Heart } from 'lucide-react';
 import { Button } from './ui/Button';
+import { Alert } from './ui/Alert';
 import { cn } from '@/lib/utils';
 import { Id } from '@/convex/_generated/dataModel';
 import { useSharePoem } from '@/hooks/useSharePoem';
@@ -78,7 +79,7 @@ export function PoemDisplay({
     effectiveAlreadyRevealed ? lines.length : 0
   );
   const [selectedLine, setSelectedLine] = useState<number | null>(null);
-  const { handleShare, copied } = useSharePoem(poemId);
+  const { handleShare, copied, shared, shareError } = useSharePoem(poemId);
 
   const normalizedLines: PoemLine[] = lines.map((line) =>
     typeof line === 'string' ? { text: line } : line
@@ -292,33 +293,41 @@ export function PoemDisplay({
 
       {/* Footer / Actions - Fixed at bottom */}
       <div
+        data-testid="poem-actions"
         className={cn(
           'px-6 md:px-12 lg:px-24 py-6 border-t border-border-subtle',
-          'flex items-center justify-center gap-4',
+          'flex flex-col items-center gap-4',
           'transition-opacity duration-500',
           allRevealed ? 'opacity-100' : 'opacity-0 pointer-events-none'
         )}
       >
-        <Button
-          onClick={handleShare}
-          variant="primary"
-          size="lg"
-          className="min-w-[140px] h-12"
-          stampAnimate={copied}
-        >
-          {copied ? 'Copied!' : 'Share'}
-        </Button>
-        {/* Reveal variant: Close button; Archive variant: navigation handles close */}
-        {!isArchive && onDone && (
-          <Button
-            onClick={onDone}
-            variant="ghost"
-            size="lg"
-            className="min-w-[100px] h-12 text-text-muted hover:text-text-primary"
-          >
-            Close
-          </Button>
+        {shareError && (
+          <Alert variant="error" className="w-full max-w-md">
+            {shareError}
+          </Alert>
         )}
+        <div className="flex items-center justify-center gap-4">
+          <Button
+            onClick={handleShare}
+            variant="primary"
+            size="lg"
+            className="min-w-[140px] h-12"
+            stampAnimate={copied}
+          >
+            {shared ? 'Shared!' : copied ? 'Copied!' : 'Share'}
+          </Button>
+          {/* Reveal variant: Close button; Archive variant: navigation handles close */}
+          {!isArchive && onDone && (
+            <Button
+              onClick={onDone}
+              variant="ghost"
+              size="lg"
+              className="min-w-[100px] h-12 text-text-muted hover:text-text-primary"
+            >
+              Close
+            </Button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/components/RoomChrome.tsx
+++ b/components/RoomChrome.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { Archive, Palette, Share2 } from 'lucide-react';
+import { HelpModal } from './HelpModal';
+import { ThemeSelector } from './ThemeSelector';
+import { Alert } from './ui/Alert';
+import { cn } from '@/lib/utils';
+import { useShareLink } from '@/hooks/useShareLink';
+import { trackRoomInviteShared } from '@/lib/analytics';
+
+interface RoomChromeProps {
+  roomCode: string;
+}
+
+function chromeButtonClasses(emphasized = false) {
+  return cn(
+    'inline-flex h-10 items-center justify-center rounded-full border px-3',
+    'transition-all duration-[var(--duration-normal)]',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2',
+    emphasized
+      ? 'border-primary bg-primary text-text-inverse hover:bg-primary-hover'
+      : 'border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-primary)] hover:border-[var(--color-primary)] hover:text-[var(--color-primary)]'
+  );
+}
+
+export function RoomChrome({ roomCode }: RoomChromeProps) {
+  const [showThemes, setShowThemes] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const { handleShare, copied, shared, shareError } = useShareLink({
+    getShareData: () => ({
+      url: `${window.location.origin}/join?code=${roomCode}`,
+      title: 'Join my Linejam room',
+      text: `Join my Linejam room with code ${roomCode}.`,
+    }),
+    onShared: (method) => {
+      trackRoomInviteShared({ method, roomCode });
+    },
+    failureMessage: 'Failed to share invite. Please try again.',
+  });
+
+  useEffect(() => {
+    if (!showThemes) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setShowThemes(false);
+      }
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setShowThemes(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [showThemes]);
+
+  return (
+    <>
+      <HelpModal isOpen={showHelp} onClose={() => setShowHelp(false)} />
+
+      <div className="pointer-events-none fixed right-4 top-4 z-50 flex max-w-[calc(100vw-2rem)] flex-col items-end gap-2">
+        {shareError && (
+          <Alert
+            variant="error"
+            className="pointer-events-auto max-w-sm bg-[var(--color-surface)]/95 shadow-[var(--shadow-lg)] backdrop-blur"
+          >
+            {shareError}
+          </Alert>
+        )}
+
+        <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)]/92 p-2 shadow-[var(--shadow-lg)] backdrop-blur">
+          <button
+            type="button"
+            onClick={handleShare}
+            className={chromeButtonClasses(true)}
+            aria-label="Share room invite"
+          >
+            <Share2 className="mr-2 h-4 w-4" />
+            <span>{shared ? 'Shared!' : copied ? 'Copied!' : 'Invite'}</span>
+          </button>
+
+          <Link
+            href="/me/poems"
+            className={chromeButtonClasses()}
+            aria-label="View your poem archive"
+          >
+            <Archive className="h-4 w-4" />
+          </Link>
+
+          <button
+            type="button"
+            onClick={() => setShowHelp(true)}
+            className={chromeButtonClasses()}
+            aria-label="How to play"
+          >
+            <span className="text-lg font-medium">?</span>
+          </button>
+
+          <div className="relative" ref={dropdownRef}>
+            <button
+              type="button"
+              onClick={() => setShowThemes((current) => !current)}
+              className={chromeButtonClasses()}
+              aria-label="Choose theme"
+              aria-expanded={showThemes}
+              aria-haspopup="true"
+            >
+              <Palette className="h-4 w-4" />
+            </button>
+
+            {showThemes && (
+              <div className="absolute right-0 top-full mt-2 w-[320px] max-w-[calc(100vw-2rem)] rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-lg)]">
+                <ThemeSelector onClose={() => setShowThemes(false)} />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/WritingScreen.tsx
+++ b/components/WritingScreen.tsx
@@ -1,16 +1,18 @@
+'use client';
+
 import { useEffect, useRef, useState } from 'react';
 import { useQuery, useMutation } from 'convex/react';
-import type { Id } from '../convex/_generated/dataModel';
-import { api } from '../convex/_generated/api';
-import { useRoomQueryArgs } from '../hooks/useRoomQueryArgs';
-import { countWords } from '../lib/wordCount';
-import { captureError } from '../lib/error';
-import { cn } from '../lib/utils';
-import { Button } from './ui/Button';
-import { Alert } from './ui/Alert';
-import { WordSlots } from './ui/WordSlots';
-import { LoadingState, LoadingMessages } from './ui/LoadingState';
-import { WaitingScreen } from './WaitingScreen';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import { useRoomQueryArgs } from '@/hooks/useRoomQueryArgs';
+import { captureError } from '@/lib/error';
+import { cn } from '@/lib/utils';
+import { countWords } from '@/lib/wordCount';
+import { Alert } from '@/components/ui/Alert';
+import { Button } from '@/components/ui/Button';
+import { LoadingMessages, LoadingState } from '@/components/ui/LoadingState';
+import { WordSlots } from '@/components/ui/WordSlots';
+import { WaitingScreen } from '@/components/WaitingScreen';
 
 interface WritingScreenProps {
   roomCode: string;

--- a/components/WritingScreen.tsx
+++ b/components/WritingScreen.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQuery, useMutation } from 'convex/react';
+import type { Id } from '../convex/_generated/dataModel';
 import { api } from '../convex/_generated/api';
 import { useRoomQueryArgs } from '../hooks/useRoomQueryArgs';
 import { countWords } from '../lib/wordCount';
@@ -15,15 +16,39 @@ interface WritingScreenProps {
   roomCode: string;
 }
 
-export function WritingScreen({ roomCode }: WritingScreenProps) {
-  const { guestToken, shouldSkip, queryArgs } = useRoomQueryArgs(roomCode);
-  const assignment = useQuery(api.game.getCurrentAssignment, queryArgs);
-  const submitLine = useMutation(api.game.submitLine);
+type RoomQueryArgs = ReturnType<typeof useRoomQueryArgs>['queryArgs'];
 
+interface WritingAssignment {
+  poemId: Id<'poems'>;
+  lineIndex: number;
+  targetWordCount: number;
+  previousLineText?: string | null;
+}
+
+interface WritingComposerProps {
+  assignment: WritingAssignment;
+  guestToken?: string | null;
+  queryArgs: RoomQueryArgs;
+  roomCode: string;
+}
+
+function numberToWord(n: number): string {
+  const words = ['zero', 'one', 'two', 'three', 'four', 'five'];
+  return words[n] ?? String(n);
+}
+
+function WritingComposer({
+  assignment,
+  guestToken,
+  queryArgs,
+  roomCode,
+}: WritingComposerProps) {
+  const submitLine = useMutation(api.game.submitLine);
   const [text, setText] = useState('');
   const [submissionState, setSubmissionState] = useState<
-    'idle' | 'submitting' | 'confirmed' | 'waiting'
+    'idle' | 'submitting' | 'confirmed'
   >('idle');
+  const [showWaitingScreen, setShowWaitingScreen] = useState(false);
 
   // Pre-fetch waiting screen data during confirmation for smooth transition
   // When submissionState becomes 'confirmed', Convex starts fetching getRoundProgress
@@ -33,37 +58,19 @@ export function WritingScreen({ roomCode }: WritingScreenProps) {
     api.game.getRoundProgress,
     submissionState === 'confirmed' ? queryArgs : 'skip'
   );
-  const [submittedRound, setSubmittedRound] = useState<number | null>(null);
-  const [lastSeenRound, setLastSeenRound] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [liveRegionMessage, setLiveRegionMessage] = useState('');
   const [hasFocus, setHasFocus] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const submitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Reset text when assignment changes (new round)
-  const currentRound = assignment?.lineIndex;
-  if (currentRound !== undefined && currentRound !== lastSeenRound) {
-    setText('');
-    setSubmissionState('idle');
-    setLastSeenRound(currentRound);
-  }
-
-  // Calculate validation state (needed for live region, even when showing waiting screen)
-  const currentWordCount = assignment ? countWords(text) : 0;
-  const targetCount = assignment?.targetWordCount ?? 0;
+  const currentWordCount = countWords(text);
+  const targetCount = assignment.targetWordCount;
   const isValid = currentWordCount === targetCount;
-
-  // Convert number to words for placeholder
-  const numberToWord = (n: number): string => {
-    const words = ['zero', 'one', 'two', 'three', 'four', 'five'];
-    return words[n] ?? String(n);
-  };
   const placeholderText = `write ${numberToWord(targetCount)} word${targetCount === 1 ? '' : 's'}…`;
 
   // Announce validation state changes to screen readers (debounced)
   useEffect(() => {
-    if (!assignment) return; // Don't announce when no assignment
-
     const timeoutId = setTimeout(() => {
       if (isValid) {
         setLiveRegionMessage('Ready to submit');
@@ -79,19 +86,17 @@ export function WritingScreen({ roomCode }: WritingScreenProps) {
     }, 500); // Debounce 500ms to avoid announcing every keystroke
 
     return () => clearTimeout(timeoutId);
-  }, [assignment, isValid, currentWordCount, targetCount]);
+  }, [isValid, currentWordCount, targetCount]);
 
-  // Show loading state while auth is initializing (only if we don't have a token yet)
-  if (shouldSkip || assignment === undefined) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-[var(--color-background)]">
-        <LoadingState message={LoadingMessages.LOADING_ROOM} />
-      </div>
-    );
-  }
+  useEffect(() => {
+    return () => {
+      if (submitTimeoutRef.current) {
+        clearTimeout(submitTimeoutRef.current);
+      }
+    };
+  }, []);
 
-  // Show waiting screen if no assignment or just submitted
-  if (assignment === null || submittedRound === assignment.lineIndex) {
+  if (showWaitingScreen) {
     return <WaitingScreen roomCode={roomCode} guestToken={guestToken} />;
   }
 
@@ -111,9 +116,9 @@ export function WritingScreen({ roomCode }: WritingScreenProps) {
       setSubmissionState('confirmed');
 
       // After 1500ms, transition to waiting screen
-      setTimeout(() => {
-        setSubmittedRound(assignment.lineIndex);
-        setSubmissionState('waiting');
+      submitTimeoutRef.current = setTimeout(() => {
+        setShowWaitingScreen(true);
+        submitTimeoutRef.current = null;
       }, 1500);
     } catch (error) {
       captureError(error, { roomCode, poemId: assignment.poemId });
@@ -226,5 +231,32 @@ export function WritingScreen({ roomCode }: WritingScreenProps) {
         </div>
       </div>
     </div>
+  );
+}
+
+export function WritingScreen({ roomCode }: WritingScreenProps) {
+  const { guestToken, shouldSkip, queryArgs } = useRoomQueryArgs(roomCode);
+  const assignment = useQuery(api.game.getCurrentAssignment, queryArgs);
+
+  if (shouldSkip || assignment === undefined) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[var(--color-background)]">
+        <LoadingState message={LoadingMessages.LOADING_ROOM} />
+      </div>
+    );
+  }
+
+  if (assignment === null) {
+    return <WaitingScreen roomCode={roomCode} guestToken={guestToken} />;
+  }
+
+  return (
+    <WritingComposer
+      key={`${assignment.poemId}:${assignment.lineIndex}`}
+      assignment={assignment}
+      guestToken={guestToken}
+      queryArgs={queryArgs}
+      roomCode={roomCode}
+    />
   );
 }

--- a/convex/lib/room.ts
+++ b/convex/lib/room.ts
@@ -1,6 +1,9 @@
 import { QueryCtx, MutationCtx } from '../_generated/server';
 import { Doc, Id } from '../_generated/dataModel';
 
+type RoomStatus = Doc<'rooms'>['status'];
+type RoomActivityInput = Pick<Doc<'rooms'>, '_id' | 'status'>;
+
 /**
  * Look up a room by its code (case-insensitive).
  * Returns null if not found.
@@ -51,25 +54,32 @@ export async function getCompletedGame(
     .first();
 }
 
+function deriveIdleRoomStatus(room: Pick<Doc<'rooms'>, 'status'>): RoomStatus {
+  return room.status === 'COMPLETED' ? 'COMPLETED' : 'LOBBY';
+}
+
 /**
- * Derive room status from game state.
- * - If there's an IN_PROGRESS game → 'IN_PROGRESS'
- * - If there are COMPLETED games but no IN_PROGRESS → 'COMPLETED' (reveal phase)
- * - Otherwise → 'LOBBY'
+ * Resolve the authoritative room activity view.
+ * The room document owns idle state (`LOBBY` vs `COMPLETED`);
+ * an active game is the only source that can override it.
  */
+export async function getRoomActivity(
+  ctx: QueryCtx | MutationCtx,
+  room: RoomActivityInput
+): Promise<{ activeGame: Doc<'games'> | null; status: RoomStatus }> {
+  const activeGame = await getActiveGame(ctx, room._id);
+  return {
+    activeGame,
+    status: activeGame ? 'IN_PROGRESS' : deriveIdleRoomStatus(room),
+  };
+}
+
 export async function deriveRoomStatus(
   ctx: QueryCtx | MutationCtx,
-  roomId: Id<'rooms'>,
-  activeGame?: Doc<'games'> | null
-): Promise<'LOBBY' | 'IN_PROGRESS' | 'COMPLETED'> {
-  const resolvedActiveGame =
-    activeGame === undefined ? await getActiveGame(ctx, roomId) : activeGame;
-  if (resolvedActiveGame) return 'IN_PROGRESS';
-
-  const completedGame = await getCompletedGame(ctx, roomId);
-  if (completedGame) return 'COMPLETED';
-
-  return 'LOBBY';
+  room: RoomActivityInput
+): Promise<RoomStatus> {
+  const { status } = await getRoomActivity(ctx, room);
+  return status;
 }
 
 /**

--- a/convex/lib/room.ts
+++ b/convex/lib/room.ts
@@ -59,10 +59,12 @@ export async function getCompletedGame(
  */
 export async function deriveRoomStatus(
   ctx: QueryCtx | MutationCtx,
-  roomId: Id<'rooms'>
+  roomId: Id<'rooms'>,
+  activeGame?: Doc<'games'> | null
 ): Promise<'LOBBY' | 'IN_PROGRESS' | 'COMPLETED'> {
-  const activeGame = await getActiveGame(ctx, roomId);
-  if (activeGame) return 'IN_PROGRESS';
+  const resolvedActiveGame =
+    activeGame === undefined ? await getActiveGame(ctx, roomId) : activeGame;
+  if (resolvedActiveGame) return 'IN_PROGRESS';
 
   const completedGame = await getCompletedGame(ctx, roomId);
   if (completedGame) return 'COMPLETED';

--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -4,8 +4,8 @@ import { ensureUserHelper } from './users';
 import { getUser, checkParticipation } from './lib/auth';
 import { checkRateLimit } from './lib/rateLimit';
 import {
-  deriveRoomStatus,
   getRoomByCode,
+  getRoomActivity,
   requireRoomByCode,
   getActiveGame,
 } from './lib/room';
@@ -150,8 +150,7 @@ export const getRoom = query({
 
     const room = await getRoomByCode(ctx, code);
     if (!room) return null;
-    const activeGame = await getActiveGame(ctx, room._id);
-    const status = await deriveRoomStatus(ctx, room._id, activeGame);
+    const { activeGame, status } = await getRoomActivity(ctx, room);
 
     const isParticipant = await checkParticipation(ctx, room._id, user._id);
     if (isParticipant) return { ...room, status };
@@ -183,7 +182,7 @@ export const getRoomState = query({
 
     const room = await getRoomByCode(ctx, code);
     if (!room) return null;
-    const status = await deriveRoomStatus(ctx, room._id);
+    const { status } = await getRoomActivity(ctx, room);
 
     const isParticipant = await checkParticipation(ctx, room._id, user._id);
     if (!isParticipant) return null;

--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -3,7 +3,12 @@ import { mutation, query } from './_generated/server';
 import { ensureUserHelper } from './users';
 import { getUser, checkParticipation } from './lib/auth';
 import { checkRateLimit } from './lib/rateLimit';
-import { getRoomByCode, requireRoomByCode, getActiveGame } from './lib/room';
+import {
+  deriveRoomStatus,
+  getRoomByCode,
+  requireRoomByCode,
+  getActiveGame,
+} from './lib/room';
 
 const generateRoomCode = (): string => {
   const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -145,9 +150,10 @@ export const getRoom = query({
 
     const room = await getRoomByCode(ctx, code);
     if (!room) return null;
+    const status = await deriveRoomStatus(ctx, room._id);
 
     const isParticipant = await checkParticipation(ctx, room._id, user._id);
-    if (isParticipant) return room;
+    if (isParticipant) return { ...room, status };
 
     const activeGame = await getActiveGame(ctx, room._id);
     if (activeGame) return null;
@@ -161,7 +167,7 @@ export const getRoom = query({
 
     return {
       code: room.code,
-      status: room.status,
+      status,
     };
   },
 });
@@ -177,6 +183,7 @@ export const getRoomState = query({
 
     const room = await getRoomByCode(ctx, code);
     if (!room) return null;
+    const status = await deriveRoomStatus(ctx, room._id);
 
     const isParticipant = await checkParticipation(ctx, room._id, user._id);
     if (!isParticipant) return null;
@@ -201,7 +208,7 @@ export const getRoomState = query({
 
     const isHost = user._id === room.hostUserId;
 
-    return { room, players, isHost };
+    return { room: { ...room, status }, players, isHost };
   },
 });
 

--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -150,12 +150,12 @@ export const getRoom = query({
 
     const room = await getRoomByCode(ctx, code);
     if (!room) return null;
-    const status = await deriveRoomStatus(ctx, room._id);
+    const activeGame = await getActiveGame(ctx, room._id);
+    const status = await deriveRoomStatus(ctx, room._id, activeGame);
 
     const isParticipant = await checkParticipation(ctx, room._id, user._id);
     if (isParticipant) return { ...room, status };
 
-    const activeGame = await getActiveGame(ctx, room._id);
     if (activeGame) return null;
 
     const roomPlayers = await ctx.db

--- a/hooks/useShareLink.ts
+++ b/hooks/useShareLink.ts
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export type ShareMethod = 'clipboard' | 'native-share';
+
+type ShareStatus = 'idle' | 'copied' | 'shared' | 'error';
+
+interface ShareData {
+  url: string;
+  title?: string;
+  text?: string;
+}
+
+interface UseShareLinkOptions {
+  getShareData: () => ShareData;
+  onShared?: (method: ShareMethod) => void | Promise<void>;
+  onError?: (error: unknown) => void;
+  failureMessage?: string;
+  successDurationMs?: number;
+}
+
+export function useShareLink({
+  getShareData,
+  onShared,
+  onError,
+  failureMessage = 'Failed to share link. Please try again.',
+  successDurationMs = 2000,
+}: UseShareLinkOptions) {
+  const [status, setStatus] = useState<ShareStatus>('idle');
+  const [shareError, setShareError] = useState<string | null>(null);
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current) {
+        clearTimeout(resetTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const resetStatusSoon = () => {
+    if (resetTimeoutRef.current) {
+      clearTimeout(resetTimeoutRef.current);
+    }
+    resetTimeoutRef.current = setTimeout(() => {
+      setStatus('idle');
+      resetTimeoutRef.current = null;
+    }, successDurationMs);
+  };
+
+  const notifyShared = (method: ShareMethod) => {
+    if (!onShared) return;
+    Promise.resolve(onShared(method)).catch(() => {});
+  };
+
+  const handleShare = async () => {
+    setShareError(null);
+
+    const { url, title, text } = getShareData();
+
+    try {
+      if (typeof navigator.share === 'function') {
+        try {
+          await navigator.share({ title, text, url });
+          setStatus('shared');
+          notifyShared('native-share');
+          resetStatusSoon();
+          return;
+        } catch (error) {
+          if (error instanceof DOMException && error.name === 'AbortError') {
+            return;
+          }
+        }
+      }
+
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+        setStatus('copied');
+        notifyShared('clipboard');
+        resetStatusSoon();
+        return;
+      }
+
+      throw new Error('Clipboard is unavailable');
+    } catch (error) {
+      setStatus('error');
+      setShareError(failureMessage);
+      onError?.(error);
+    }
+  };
+
+  return {
+    copied: status === 'copied',
+    shared: status === 'shared',
+    shareError,
+    handleShare,
+  };
+}

--- a/hooks/useSharePoem.ts
+++ b/hooks/useSharePoem.ts
@@ -1,11 +1,11 @@
 'use client';
 
 import { useMutation } from 'convex/react';
-import { api } from '../convex/_generated/api';
-import { Id } from '../convex/_generated/dataModel';
+import { api } from '@/convex/_generated/api';
+import { Id } from '@/convex/_generated/dataModel';
 import { captureError } from '@/lib/error';
 import { trackPoemShared } from '@/lib/analytics';
-import { useShareLink } from './useShareLink';
+import { useShareLink } from '@/hooks/useShareLink';
 
 export function useSharePoem(poemId: Id<'poems'>) {
   const logShare = useMutation(api.shares.logShare);

--- a/hooks/useSharePoem.ts
+++ b/hooks/useSharePoem.ts
@@ -1,30 +1,28 @@
 'use client';
 
-import { useState } from 'react';
 import { useMutation } from 'convex/react';
 import { api } from '../convex/_generated/api';
 import { Id } from '../convex/_generated/dataModel';
 import { captureError } from '@/lib/error';
 import { trackPoemShared } from '@/lib/analytics';
+import { useShareLink } from './useShareLink';
 
 export function useSharePoem(poemId: Id<'poems'>) {
-  const [copied, setCopied] = useState(false);
   const logShare = useMutation(api.shares.logShare);
 
-  const handleShare = async () => {
-    const url = `${window.location.origin}/poem/${poemId}`;
-
-    try {
-      await navigator.clipboard.writeText(url);
-      setCopied(true);
-      // Fire-and-forget analytics
+  return useShareLink({
+    getShareData: () => ({
+      url: `${window.location.origin}/poem/${poemId}`,
+      title: 'Linejam poem',
+      text: 'Read this poem from our Linejam session.',
+    }),
+    onShared: (method) => {
       logShare({ poemId }).catch(() => {});
-      trackPoemShared({ method: 'clipboard' });
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
+      trackPoemShared({ method });
+    },
+    onError: (err) => {
       captureError(err, { operation: 'sharePoem', poemId });
-    }
-  };
-
-  return { handleShare, copied };
+    },
+    failureMessage: 'Failed to share poem. Please try again.',
+  });
 }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -32,7 +32,12 @@ type GameCompletedProps = {
 };
 
 type PoemSharedProps = {
-  method: 'clipboard';
+  method: 'clipboard' | 'native-share';
+};
+
+type RoomInviteSharedProps = {
+  method: 'clipboard' | 'native-share';
+  roomCode: string;
 };
 
 type AiPlayerAddedProps = {
@@ -72,6 +77,13 @@ export function trackGameCompleted(props: GameCompletedProps) {
  */
 export function trackPoemShared(props: PoemSharedProps) {
   track('poem_shared', props);
+}
+
+/**
+ * Track room invite sharing from the in-room chrome.
+ */
+export function trackRoomInviteShared(props: RoomInviteSharedProps) {
+  track('room_invite_shared', props);
 }
 
 /**

--- a/tests/components/PoemDisplay.test.tsx
+++ b/tests/components/PoemDisplay.test.tsx
@@ -183,8 +183,7 @@ describe('PoemDisplay component', () => {
       );
 
       // Initially footer should be hidden (opacity-0 pointer-events-none)
-      const shareButton = screen.getByRole('button', { name: /Share/i });
-      expect(shareButton.parentElement).toHaveClass('opacity-0');
+      expect(screen.getByTestId('poem-actions')).toHaveClass('opacity-0');
 
       // Reveal all 9 lines one by one (with extra pause after line 4)
       for (let i = 0; i < 9; i++) {
@@ -195,7 +194,7 @@ describe('PoemDisplay component', () => {
       }
 
       // Footer should now be visible
-      expect(shareButton.parentElement).toHaveClass('opacity-100');
+      expect(screen.getByTestId('poem-actions')).toHaveClass('opacity-100');
     });
   });
 

--- a/tests/components/RoomChrome.test.tsx
+++ b/tests/components/RoomChrome.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+const mockTrackRoomInviteShared = vi.fn();
+
+vi.mock('@/lib/analytics', () => ({
+  trackRoomInviteShared: (props: unknown) => mockTrackRoomInviteShared(props),
+}));
+
+vi.mock('@/components/HelpModal', () => ({
+  HelpModal: ({ isOpen }: { isOpen: boolean; onClose: () => void }) =>
+    isOpen ? <div>Help modal</div> : null,
+}));
+
+vi.mock('@/components/ThemeSelector', () => ({
+  ThemeSelector: () => <div>Theme chooser</div>,
+}));
+
+import { RoomChrome } from '@/components/RoomChrome';
+
+describe('RoomChrome component', () => {
+  let originalClipboard: Clipboard;
+  let originalLocation: Location;
+  let originalShare: Navigator['share'];
+  const mockWriteText = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalClipboard = navigator.clipboard;
+    originalLocation = window.location;
+    originalShare = navigator.share;
+
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: mockWriteText,
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    Object.defineProperty(navigator, 'share', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    Object.defineProperty(window, 'location', {
+      value: {
+        origin: 'https://example.com',
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+    });
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'share', {
+      value: originalShare,
+      configurable: true,
+    });
+  });
+
+  it('renders room controls', () => {
+    render(<RoomChrome roomCode="ABCD" />);
+
+    expect(
+      screen.getByRole('button', { name: /Share room invite/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /View your poem archive/i })
+    ).toHaveAttribute('href', '/me/poems');
+    expect(
+      screen.getByRole('button', { name: /How to play/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Choose theme/i })
+    ).toBeInTheDocument();
+  });
+
+  it('copies a join link when native share is unavailable', async () => {
+    render(<RoomChrome roomCode="ABCD" />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Share room invite/i })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith(
+        'https://example.com/join?code=ABCD'
+      );
+      expect(screen.getByText('Copied!')).toBeInTheDocument();
+      expect(mockTrackRoomInviteShared).toHaveBeenCalledWith({
+        method: 'clipboard',
+        roomCode: 'ABCD',
+      });
+    });
+  });
+
+  it('uses native share when available', async () => {
+    const nativeShare = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', {
+      value: nativeShare,
+      writable: true,
+      configurable: true,
+    });
+    render(<RoomChrome roomCode="ABCD" />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: /Share room invite/i })
+      );
+    });
+
+    expect(nativeShare).toHaveBeenCalledWith({
+      title: 'Join my Linejam room',
+      text: 'Join my Linejam room with code ABCD.',
+      url: 'https://example.com/join?code=ABCD',
+    });
+    expect(screen.getByText('Shared!')).toBeInTheDocument();
+    expect(mockTrackRoomInviteShared).toHaveBeenCalledWith({
+      method: 'native-share',
+      roomCode: 'ABCD',
+    });
+  });
+
+  it('opens help and theme surfaces', async () => {
+    const user = userEvent.setup();
+    render(<RoomChrome roomCode="ABCD" />);
+
+    await user.click(screen.getByRole('button', { name: /How to play/i }));
+    expect(screen.getByText('Help modal')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Choose theme/i }));
+    expect(screen.getByText('Theme chooser')).toBeInTheDocument();
+  });
+});

--- a/tests/components/RoomChrome.test.tsx
+++ b/tests/components/RoomChrome.test.tsx
@@ -7,7 +7,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
+import userEvent from '@testing-library/user-event';
 
 const mockTrackRoomInviteShared = vi.fn();
 
@@ -21,7 +21,14 @@ vi.mock('@/components/HelpModal', () => ({
 }));
 
 vi.mock('@/components/ThemeSelector', () => ({
-  ThemeSelector: () => <div>Theme chooser</div>,
+  ThemeSelector: ({ onClose }: { onClose: () => void }) => (
+    <div>
+      <div>Theme chooser</div>
+      <button type="button" onClick={onClose}>
+        Close theme chooser
+      </button>
+    </div>
+  ),
 }));
 
 import { RoomChrome } from '@/components/RoomChrome';
@@ -150,5 +157,42 @@ describe('RoomChrome component', () => {
 
     await user.click(screen.getByRole('button', { name: /Choose theme/i }));
     expect(screen.getByText('Theme chooser')).toBeInTheDocument();
+  });
+
+  it('closes the theme chooser on outside click and escape', async () => {
+    const user = userEvent.setup();
+    render(<RoomChrome roomCode="ABCD" />);
+
+    await user.click(screen.getByRole('button', { name: /Choose theme/i }));
+    expect(screen.getByText('Theme chooser')).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    await waitFor(() => {
+      expect(screen.queryByText('Theme chooser')).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /Choose theme/i }));
+    expect(screen.getByText('Theme chooser')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => {
+      expect(screen.queryByText('Theme chooser')).not.toBeInTheDocument();
+    });
+  });
+
+  it('closes the theme chooser when the selector requests it', async () => {
+    const user = userEvent.setup();
+    render(<RoomChrome roomCode="ABCD" />);
+
+    await user.click(screen.getByRole('button', { name: /Choose theme/i }));
+    expect(screen.getByText('Theme chooser')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: /Close theme chooser/i })
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Theme chooser')).not.toBeInTheDocument();
+    });
   });
 });

--- a/tests/components/WritingScreen.test.tsx
+++ b/tests/components/WritingScreen.test.tsx
@@ -339,6 +339,16 @@ describe('WritingScreen component', () => {
     expect(screen.getByText(/Ready|Others are writing/i)).toBeInTheDocument();
   });
 
+  it('renders the loading state while the assignment query is unresolved', () => {
+    mockUseQuery.mockReturnValue(undefined);
+
+    render(<WritingScreen roomCode="ABCD" />);
+
+    expect(
+      screen.getByText(/Preparing your writing desk/i)
+    ).toBeInTheDocument();
+  });
+
   it('textarea has aria-invalid when word count is wrong', () => {
     // Arrange & Act - Empty textarea with target of 1 word
     render(<WritingScreen roomCode="ABCD" />);
@@ -507,6 +517,15 @@ describe('WritingScreen component', () => {
       // Assert - Wait for debounced live region to update
       const liveRegion = getLiveRegion(container);
       expect(liveRegion).toHaveTextContent('Add 3 words');
+    });
+
+    it('keeps the live region silent before the player starts typing', async () => {
+      const { container } = render(<WritingScreen roomCode="ABCD" />);
+
+      await flushDebounce();
+
+      const liveRegion = getLiveRegion(container);
+      expect(liveRegion).toHaveTextContent('');
     });
   });
 

--- a/tests/components/WritingScreen.test.tsx
+++ b/tests/components/WritingScreen.test.tsx
@@ -509,4 +509,38 @@ describe('WritingScreen component', () => {
       expect(liveRegion).toHaveTextContent('Add 3 words');
     });
   });
+
+  describe('round transitions', () => {
+    it('resets the draft when the assignment advances to the next round', async () => {
+      const user = setupUser();
+      const { rerender } = render(<WritingScreen roomCode="ABCD" />);
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+
+      await user.type(textarea, 'Word');
+      expect(textarea.value).toBe('Word');
+
+      mockUseQuery.mockImplementation((query) => {
+        const functionName = getFunctionName(
+          query as Parameters<typeof getFunctionName>[0]
+        );
+        if (functionName === 'game:getRoundProgress') {
+          return { round: 1, players: [] };
+        }
+        return {
+          ...mockAssignmentRound5,
+          lineIndex: 1,
+          targetWordCount: 2,
+        };
+      });
+
+      rerender(<WritingScreen roomCode="ABCD" />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Round 2 \/ 9/)).toBeInTheDocument();
+        expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe(
+          ''
+        );
+      });
+    });
+  });
 });

--- a/tests/convex/roomLifecycle.test.ts
+++ b/tests/convex/roomLifecycle.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../convex/_generated/server', () => ({
+  mutation: (args: unknown) => args,
+  query: (args: unknown) => args,
+  internalMutation: (args: unknown) => args,
+}));
+
+const mockGetUser = vi.fn();
+const mockCheckParticipation = vi.fn();
+vi.mock('../../convex/lib/auth', () => ({
+  getUser: (...args: unknown[]) => mockGetUser(...args),
+  checkParticipation: (...args: unknown[]) => mockCheckParticipation(...args),
+}));
+
+vi.mock('../../convex/users', () => ({
+  ensureUserHelper: vi.fn(),
+}));
+
+vi.mock('../../convex/lib/rateLimit', () => ({
+  checkRateLimit: vi.fn(),
+}));
+
+import { startNewCycle } from '../../convex/game';
+import { getRoomState } from '../../convex/rooms';
+
+const startNewCycleHandler = (
+  startNewCycle as unknown as {
+    handler: (ctx: unknown, args: unknown) => Promise<void>;
+  }
+).handler;
+
+const getRoomStateHandler = (
+  getRoomState as unknown as {
+    handler: (
+      ctx: unknown,
+      args: unknown
+    ) => Promise<{
+      room: { status: 'LOBBY' | 'IN_PROGRESS' | 'COMPLETED' };
+    } | null>;
+  }
+).handler;
+
+function createStatefulCtx() {
+  const state = {
+    room: {
+      _id: 'room1',
+      code: 'TEST',
+      hostUserId: 'user1',
+      status: 'COMPLETED' as const,
+      currentGameId: 'game1',
+    },
+    games: [
+      {
+        _id: 'game1',
+        roomId: 'room1',
+        status: 'COMPLETED' as const,
+      },
+    ],
+    roomPlayers: [
+      {
+        _id: 'player1',
+        roomId: 'room1',
+        userId: 'user1',
+        displayName: 'Alice',
+        joinedAt: 1,
+      },
+    ],
+    users: new Map([
+      [
+        'user1',
+        {
+          _id: 'user1',
+          kind: 'HUMAN',
+        },
+      ],
+    ]),
+  };
+
+  const db = {
+    query(table: string) {
+      const filters = new Map<string, unknown>();
+      let direction: 'asc' | 'desc' = 'asc';
+      const queryBuilder = {
+        eq(field: string, value: unknown) {
+          filters.set(field, value);
+          return queryBuilder;
+        },
+      };
+      const builder = {
+        withIndex(
+          _indexName: string,
+          callback?: (q: typeof queryBuilder) => unknown
+        ) {
+          callback?.(queryBuilder);
+          return builder;
+        },
+        order(nextDirection: 'asc' | 'desc') {
+          direction = nextDirection;
+          return builder;
+        },
+        async first() {
+          if (table === 'rooms') {
+            return filters.get('code') === state.room.code ? state.room : null;
+          }
+
+          if (table === 'games') {
+            const matches = state.games.filter(
+              (game) =>
+                game.roomId === filters.get('roomId') &&
+                game.status === filters.get('status')
+            );
+            if (direction === 'desc') {
+              return matches.at(-1) ?? null;
+            }
+            return matches[0] ?? null;
+          }
+
+          return null;
+        },
+        async collect() {
+          if (table === 'roomPlayers') {
+            return state.roomPlayers.filter(
+              (player) => player.roomId === filters.get('roomId')
+            );
+          }
+
+          return [];
+        },
+      };
+      return builder;
+    },
+    patch: vi.fn(async (id: string, value: Record<string, unknown>) => {
+      if (id === state.room._id) {
+        state.room = { ...state.room, ...value };
+      }
+    }),
+    get: vi.fn(async (id: string) => state.users.get(id) ?? null),
+  };
+
+  return {
+    ctx: {
+      db,
+      auth: { getUserIdentity: vi.fn() },
+    },
+    state,
+  };
+}
+
+describe('room lifecycle', () => {
+  beforeEach(() => {
+    mockGetUser.mockReset();
+    mockCheckParticipation.mockReset();
+  });
+
+  it('returns LOBBY after startNewCycle resets a completed room', async () => {
+    const { ctx, state } = createStatefulCtx();
+    mockGetUser.mockResolvedValue({ _id: 'user1' });
+    mockCheckParticipation.mockResolvedValue(true);
+
+    await startNewCycleHandler(ctx, {
+      roomCode: 'TEST',
+      guestToken: 'token123',
+    });
+
+    const result = await getRoomStateHandler(ctx, {
+      code: 'TEST',
+      guestToken: 'token123',
+    });
+
+    expect(state.room.status).toBe('LOBBY');
+    expect(state.room.currentGameId).toBeUndefined();
+    expect(result?.room.status).toBe('LOBBY');
+  });
+});

--- a/tests/convex/rooms.test.ts
+++ b/tests/convex/rooms.test.ts
@@ -426,6 +426,8 @@ describe('rooms', () => {
         code: 'ABCD',
         status: 'COMPLETED',
       });
+      expect(mockGetActiveGame).toHaveBeenCalledWith(mockCtx, 'room1');
+      expect(mockDeriveRoomStatus).toHaveBeenCalledWith(mockCtx, 'room1', null);
     });
 
     it('returns null when non-participant and game in progress', async () => {

--- a/tests/convex/rooms.test.ts
+++ b/tests/convex/rooms.test.ts
@@ -40,10 +40,10 @@ vi.mock('../../convex/lib/rateLimit', () => ({
 const mockGetRoomByCode = vi.fn();
 const mockRequireRoomByCode = vi.fn();
 const mockGetActiveGame = vi.fn();
-const mockDeriveRoomStatus = vi.fn();
+const mockGetRoomActivity = vi.fn();
 vi.mock('../../convex/lib/room', () => ({
-  deriveRoomStatus: (...args: unknown[]) => mockDeriveRoomStatus(...args),
   getRoomByCode: (...args: unknown[]) => mockGetRoomByCode(...args),
+  getRoomActivity: (...args: unknown[]) => mockGetRoomActivity(...args),
   requireRoomByCode: (...args: unknown[]) => mockRequireRoomByCode(...args),
   getActiveGame: (...args: unknown[]) => mockGetActiveGame(...args),
 }));
@@ -64,8 +64,11 @@ describe('rooms', () => {
     mockGetRoomByCode.mockReset();
     mockRequireRoomByCode.mockReset();
     mockGetActiveGame.mockReset();
-    mockDeriveRoomStatus.mockReset();
-    mockDeriveRoomStatus.mockResolvedValue('LOBBY');
+    mockGetRoomActivity.mockReset();
+    mockGetRoomActivity.mockResolvedValue({
+      activeGame: null,
+      status: 'LOBBY',
+    });
   });
 
   describe('createRoom', () => {
@@ -353,7 +356,10 @@ describe('rooms', () => {
       mockGetUser.mockResolvedValue({ _id: 'user1' });
       mockGetRoomByCode.mockResolvedValue(room);
       mockCheckParticipation.mockResolvedValue(true);
-      mockDeriveRoomStatus.mockResolvedValue('IN_PROGRESS');
+      mockGetRoomActivity.mockResolvedValue({
+        activeGame: { _id: 'game1' },
+        status: 'IN_PROGRESS',
+      });
 
       // Act
       // @ts-expect-error - calling handler directly for test
@@ -410,9 +416,11 @@ describe('rooms', () => {
       mockGetUser.mockResolvedValue({ _id: 'user2' });
       mockGetRoomByCode.mockResolvedValue(room);
       mockCheckParticipation.mockResolvedValue(false);
-      mockGetActiveGame.mockResolvedValue(null);
       mockDb.collect.mockResolvedValue([{ userId: 'user1' }]);
-      mockDeriveRoomStatus.mockResolvedValue('COMPLETED');
+      mockGetRoomActivity.mockResolvedValue({
+        activeGame: null,
+        status: 'COMPLETED',
+      });
 
       // Act
       // @ts-expect-error - calling handler directly for test
@@ -426,8 +434,7 @@ describe('rooms', () => {
         code: 'ABCD',
         status: 'COMPLETED',
       });
-      expect(mockGetActiveGame).toHaveBeenCalledWith(mockCtx, 'room1');
-      expect(mockDeriveRoomStatus).toHaveBeenCalledWith(mockCtx, 'room1', null);
+      expect(mockGetRoomActivity).toHaveBeenCalledWith(mockCtx, room);
     });
 
     it('returns null when non-participant and game in progress', async () => {
@@ -441,7 +448,10 @@ describe('rooms', () => {
       mockGetUser.mockResolvedValue({ _id: 'user2' });
       mockGetRoomByCode.mockResolvedValue(room);
       mockCheckParticipation.mockResolvedValue(false);
-      mockGetActiveGame.mockResolvedValue({ _id: 'game1' });
+      mockGetRoomActivity.mockResolvedValue({
+        activeGame: { _id: 'game1' },
+        status: 'IN_PROGRESS',
+      });
 
       // Act
       // @ts-expect-error - calling handler directly for test
@@ -517,7 +527,10 @@ describe('rooms', () => {
       mockDb.collect.mockResolvedValue(players);
       mockGetUser.mockResolvedValue({ _id: 'user1' });
       mockCheckParticipation.mockResolvedValue(true);
-      mockDeriveRoomStatus.mockResolvedValue('IN_PROGRESS');
+      mockGetRoomActivity.mockResolvedValue({
+        activeGame: { _id: 'game1' },
+        status: 'IN_PROGRESS',
+      });
 
       // Act
       // @ts-expect-error - calling handler directly for test

--- a/tests/convex/rooms.test.ts
+++ b/tests/convex/rooms.test.ts
@@ -40,7 +40,9 @@ vi.mock('../../convex/lib/rateLimit', () => ({
 const mockGetRoomByCode = vi.fn();
 const mockRequireRoomByCode = vi.fn();
 const mockGetActiveGame = vi.fn();
+const mockDeriveRoomStatus = vi.fn();
 vi.mock('../../convex/lib/room', () => ({
+  deriveRoomStatus: (...args: unknown[]) => mockDeriveRoomStatus(...args),
   getRoomByCode: (...args: unknown[]) => mockGetRoomByCode(...args),
   requireRoomByCode: (...args: unknown[]) => mockRequireRoomByCode(...args),
   getActiveGame: (...args: unknown[]) => mockGetActiveGame(...args),
@@ -62,6 +64,8 @@ describe('rooms', () => {
     mockGetRoomByCode.mockReset();
     mockRequireRoomByCode.mockReset();
     mockGetActiveGame.mockReset();
+    mockDeriveRoomStatus.mockReset();
+    mockDeriveRoomStatus.mockResolvedValue('LOBBY');
   });
 
   describe('createRoom', () => {
@@ -349,6 +353,7 @@ describe('rooms', () => {
       mockGetUser.mockResolvedValue({ _id: 'user1' });
       mockGetRoomByCode.mockResolvedValue(room);
       mockCheckParticipation.mockResolvedValue(true);
+      mockDeriveRoomStatus.mockResolvedValue('IN_PROGRESS');
 
       // Act
       // @ts-expect-error - calling handler directly for test
@@ -358,7 +363,7 @@ describe('rooms', () => {
       });
 
       // Assert
-      expect(result).toEqual(room);
+      expect(result).toEqual({ ...room, status: 'IN_PROGRESS' });
       expect(mockGetRoomByCode).toHaveBeenCalledWith(mockCtx, 'ABCD');
     });
 
@@ -407,6 +412,7 @@ describe('rooms', () => {
       mockCheckParticipation.mockResolvedValue(false);
       mockGetActiveGame.mockResolvedValue(null);
       mockDb.collect.mockResolvedValue([{ userId: 'user1' }]);
+      mockDeriveRoomStatus.mockResolvedValue('COMPLETED');
 
       // Act
       // @ts-expect-error - calling handler directly for test
@@ -418,7 +424,7 @@ describe('rooms', () => {
       // Assert
       expect(result).toEqual({
         code: 'ABCD',
-        status: 'LOBBY',
+        status: 'COMPLETED',
       });
     });
 
@@ -509,6 +515,7 @@ describe('rooms', () => {
       mockDb.collect.mockResolvedValue(players);
       mockGetUser.mockResolvedValue({ _id: 'user1' });
       mockCheckParticipation.mockResolvedValue(true);
+      mockDeriveRoomStatus.mockResolvedValue('IN_PROGRESS');
 
       // Act
       // @ts-expect-error - calling handler directly for test
@@ -525,7 +532,11 @@ describe('rooms', () => {
         isBot: false,
         aiPersonaId: undefined,
       }));
-      expect(result).toEqual({ room, players: expectedPlayers, isHost: true });
+      expect(result).toEqual({
+        room: { ...room, status: 'IN_PROGRESS' },
+        players: expectedPlayers,
+        isHost: true,
+      });
     });
 
     it('returns isHost=false for non-host player', async () => {

--- a/tests/hooks/useShareLink.test.ts
+++ b/tests/hooks/useShareLink.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useShareLink } from '@/hooks/useShareLink';
+
+describe('useShareLink', () => {
+  let originalClipboard: Clipboard;
+  let originalShare: Navigator['share'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    originalClipboard = navigator.clipboard;
+    originalShare = navigator.share;
+
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    Object.defineProperty(navigator, 'share', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+    });
+
+    Object.defineProperty(navigator, 'share', {
+      value: originalShare,
+      configurable: true,
+    });
+  });
+
+  it('clears the previous success timeout when sharing twice', async () => {
+    const { result } = renderHook(() =>
+      useShareLink({
+        getShareData: () => ({ url: 'https://example.com/room/ABCD' }),
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleShare();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    await act(async () => {
+      await result.current.handleShare();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(result.current.copied).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current.copied).toBe(false);
+  });
+
+  it('surfaces an error when no share method is available', async () => {
+    const onError = vi.fn();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() =>
+      useShareLink({
+        getShareData: () => ({ url: 'https://example.com/room/ABCD' }),
+        onError,
+        failureMessage: 'Unable to share right now.',
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleShare();
+    });
+
+    expect(result.current.shareError).toBe('Unable to share right now.');
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect((onError.mock.calls[0] ?? [])[0]).toMatchObject({
+      message: 'Clipboard is unavailable',
+    });
+  });
+});

--- a/tests/hooks/useSharePoem.test.ts
+++ b/tests/hooks/useSharePoem.test.ts
@@ -17,10 +17,16 @@ vi.mock('@/lib/error', () => ({
     mockCaptureError(err, context),
 }));
 
+const mockTrackPoemShared = vi.fn();
+vi.mock('@/lib/analytics', () => ({
+  trackPoemShared: (props: unknown) => mockTrackPoemShared(props),
+}));
+
 describe('useSharePoem', () => {
   const testPoemId = 'poem123' as Id<'poems'>;
   let originalClipboard: Clipboard;
   let originalLocation: Location;
+  let originalShare: Navigator['share'];
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -29,12 +35,19 @@ describe('useSharePoem', () => {
     // Store originals
     originalClipboard = navigator.clipboard;
     originalLocation = window.location;
+    originalShare = navigator.share;
 
     // Mock clipboard
     Object.defineProperty(navigator, 'clipboard', {
       value: {
         writeText: vi.fn().mockResolvedValue(undefined),
       },
+      writable: true,
+      configurable: true,
+    });
+
+    Object.defineProperty(navigator, 'share', {
+      value: undefined,
       writable: true,
       configurable: true,
     });
@@ -58,6 +71,10 @@ describe('useSharePoem', () => {
     });
     Object.defineProperty(window, 'location', {
       value: originalLocation,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'share', {
+      value: originalShare,
       configurable: true,
     });
   });
@@ -116,6 +133,7 @@ describe('useSharePoem', () => {
     });
 
     expect(mockLogShare).toHaveBeenCalledWith({ poemId: testPoemId });
+    expect(mockTrackPoemShared).toHaveBeenCalledWith({ method: 'clipboard' });
   });
 
   it('handles logShare mutation failure gracefully', async () => {
@@ -147,6 +165,9 @@ describe('useSharePoem', () => {
       poemId: testPoemId,
     });
     expect(result.current.copied).toBe(false); // Copy failed, so copied stays false
+    expect(result.current.shareError).toBe(
+      'Failed to share poem. Please try again.'
+    );
   });
 
   it('does not log share when clipboard fails', async () => {
@@ -161,5 +182,66 @@ describe('useSharePoem', () => {
 
     // logShare should not be called since clipboard failed
     expect(mockLogShare).not.toHaveBeenCalled();
+  });
+
+  it('uses native share when available', async () => {
+    const nativeShare = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', {
+      value: nativeShare,
+      writable: true,
+      configurable: true,
+    });
+    const { result } = renderHook(() => useSharePoem(testPoemId));
+
+    await act(async () => {
+      await result.current.handleShare();
+    });
+
+    expect(nativeShare).toHaveBeenCalledWith({
+      title: 'Linejam poem',
+      text: 'Read this poem from our Linejam session.',
+      url: 'https://example.com/poem/poem123',
+    });
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(result.current.shared).toBe(true);
+    expect(mockTrackPoemShared).toHaveBeenCalledWith({
+      method: 'native-share',
+    });
+  });
+
+  it('falls back to clipboard when native share fails', async () => {
+    Object.defineProperty(navigator, 'share', {
+      value: vi.fn().mockRejectedValue(new Error('Share sheet unavailable')),
+      writable: true,
+      configurable: true,
+    });
+    const { result } = renderHook(() => useSharePoem(testPoemId));
+
+    await act(async () => {
+      await result.current.handleShare();
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'https://example.com/poem/poem123'
+    );
+    expect(result.current.copied).toBe(true);
+  });
+
+  it('does not surface an error when native share is cancelled', async () => {
+    const abortError = new DOMException('Cancelled', 'AbortError');
+    Object.defineProperty(navigator, 'share', {
+      value: vi.fn().mockRejectedValue(abortError),
+      writable: true,
+      configurable: true,
+    });
+    const { result } = renderHook(() => useSharePoem(testPoemId));
+
+    await act(async () => {
+      await result.current.handleShare();
+    });
+
+    expect(result.current.shareError).toBeNull();
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(mockCaptureError).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What changed

This PR hardens the room flow handoff surfaces so the in-room experience is self-sufficient:

- adds a room-scoped chrome for invite, help, theme, and archive access on `/room/[code]`
- centralizes share behavior behind a reusable share hook with native-share first and clipboard fallback
- upgrades poem sharing to surface explicit failure feedback instead of silently falling back
- makes room status come from derived game state in Convex instead of relying on stale room fields
- refactors the writing composer so round changes reset via keyed remounts and timer cleanup, not render-time state mutation
- adds targeted coverage for room chrome, sharing behavior, writing round transitions, and derived room status

## Why it changed

The top room-flow issue was that polished individual screens still depended on brittle handoffs:

- hosts had no first-class invite/share surface inside the room
- players lost help/theme/archive controls once they entered `/room/*`
- poem sharing was clipboard-only and hid failures
- the writing path relied on fragile client-side state transitions
- room routing and status depended on duplicated state sources

This PR closes that gap without changing gameplay rules.

## User impact

Players can now invite others from inside the room, keep access to help and theme controls during play, and get a more reliable share flow for finished poems. The room state path is also more stable, which reduces blank or inconsistent transitions between lobby, writing, and reveal.

## Root cause

The room journey had strong individual screens but weak state and handoff seams. Invite/share/help/navigation behavior lived outside the room experience, and status logic was split between mutable room fields and derived game state.

## Validation

- `pnpm test tests/hooks/useSharePoem.test.ts tests/components/RoomChrome.test.tsx tests/components/PoemDisplay.test.tsx tests/components/WritingScreen.test.tsx tests/convex/rooms.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- pre-push hook also passed `typecheck`, `build`, and the full `pnpm test` suite

## Notes

A pre-existing React test warning remains from `styled-jsx` usage in `components/WaitingScreen.tsx`; it is unrelated to this change set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent room chrome with invite/share, archive link, help, and theme controls; room invite sharing supports native share or clipboard and shows success/error states.
  * Loading UI now always displays the top chrome while room screens load.

* **Refactor**
  * Poem sharing UI consolidated to surface share status and errors; writing screen split to separate composer and wrapper for clearer submission/waiting flow.

* **Bug Fixes**
  * Stabilized share timers, fallback behavior, and round/loading transitions.

* **Tests**
  * Added/updated tests for sharing flows, room chrome, writing screen, and room lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->