### PR TITLE
fix: unblock hosted convex deployment flow

### DIFF
--- a/scripts/ci/bootstrap-convex-env.mjs
+++ b/scripts/ci/bootstrap-convex-env.mjs
@@ -274,10 +274,6 @@ export function buildHostedConvexDeployArgs(
   const target = resolveConvexEnvTarget(env);
   const args = ['exec', 'convex', 'deploy', '--cmd', buildCommand];
 
-  if (target.status === 'prod') {
-    args.push('--prod');
-  }
-
   if (target.status === 'preview') {
     const previewName = target.args[1];
     if (previewName) {

--- a/scripts/ci/bootstrap-convex-env.mjs
+++ b/scripts/ci/bootstrap-convex-env.mjs
@@ -9,6 +9,8 @@ import { fileURLToPath } from 'node:url';
  * @typedef {{ log: (...args: unknown[]) => void }} BootstrapLogger
  */
 
+const CONVEX_EXECUTABLE = ['pnpm', ['exec', 'convex']];
+
 /**
  * @param {EnvShape} [env]
  */
@@ -368,4 +370,3 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
     process.exit(1);
   });
 }
-const CONVEX_EXECUTABLE = ['pnpm', ['exec', 'convex']];

--- a/tests/scripts/bootstrap-convex-env.test.ts
+++ b/tests/scripts/bootstrap-convex-env.test.ts
@@ -286,26 +286,12 @@ describe('bootstrap-convex-env', () => {
       },
       {
         bin: 'pnpm',
-        args: [
-          'exec',
-          'convex',
-          'deploy',
-          '--cmd',
-          'pnpm run build:check',
-          '--prod',
-        ],
+        args: ['exec', 'convex', 'deploy', '--cmd', 'pnpm run build:check'],
       },
     ]);
     expect(calls.at(-1)).toEqual({
       bin: 'pnpm',
-      args: [
-        'exec',
-        'convex',
-        'deploy',
-        '--cmd',
-        'pnpm run build:check',
-        '--prod',
-      ],
+      args: ['exec', 'convex', 'deploy', '--cmd', 'pnpm run build:check'],
     });
   });
 
@@ -451,6 +437,58 @@ exit 0
       expect(readFileSync(logPath, 'utf8').trim().split('\n')).toEqual([
         'exec convex env --preview-name codex/canary-local-ci-agentic-qa set GUEST_TOKEN_SECRET guest-secret',
         'exec convex env --preview-name codex/canary-local-ci-agentic-qa set CLERK_JWT_ISSUER_DOMAIN https://solid-beetle-24.clerk.accounts.dev',
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('executes the CLI deploy path without passing an unsupported --prod flag', () => {
+    const tempDir = mkdtempSync(
+      join(tmpdir(), 'linejam-bootstrap-convex-deploy-')
+    );
+    const fakePnpm = join(tempDir, 'pnpm');
+    const logPath = join(tempDir, 'pnpm.log');
+
+    try {
+      writeFileSync(
+        fakePnpm,
+        `#!/bin/sh
+printf '%s\n' "$*" >> "${logPath}"
+exit 0
+`
+      );
+      chmodSync(fakePnpm, 0o755);
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          resolve(process.cwd(), 'scripts/ci/bootstrap-convex-env.mjs'),
+          '--deploy',
+        ],
+        {
+          env: {
+            ...process.env,
+            PATH: `${tempDir}:${process.env.PATH ?? ''}`,
+            CONVEX_DEPLOY_KEY: 'prod:team:project|secret',
+            VERCEL_ENV: 'production',
+            GUEST_TOKEN_SECRET: 'guest-secret',
+            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: clerkPublishableKey(
+              'live',
+              'clerk.linejam.app'
+            ),
+            CLERK_JWT_ISSUER_DOMAIN: 'https://clerk.linejam.app',
+          },
+          encoding: 'utf8',
+        }
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(readFileSync(logPath, 'utf8').trim().split('\n')).toEqual([
+        'exec convex env --prod set GUEST_TOKEN_SECRET guest-secret',
+        'exec convex env --prod set CLERK_JWT_ISSUER_DOMAIN https://clerk.linejam.app',
+        'exec convex deploy --cmd pnpm run build:check',
       ]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/tests/scripts/bootstrap-convex-env.test.ts
+++ b/tests/scripts/bootstrap-convex-env.test.ts
@@ -1,3 +1,14 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -396,5 +407,53 @@ describe('bootstrap-convex-env', () => {
         args: ['-lc', 'pnpm run build:check'],
       },
     ]);
+  });
+
+  it('executes the CLI bootstrap path without a temporal dead zone crash', () => {
+    const tempDir = mkdtempSync(
+      join(tmpdir(), 'linejam-bootstrap-convex-env-')
+    );
+    const fakePnpm = join(tempDir, 'pnpm');
+    const logPath = join(tempDir, 'pnpm.log');
+
+    try {
+      writeFileSync(
+        fakePnpm,
+        `#!/bin/sh
+printf '%s\n' "$*" >> "${logPath}"
+exit 0
+`
+      );
+      chmodSync(fakePnpm, 0o755);
+
+      const result = spawnSync(
+        process.execPath,
+        [resolve(process.cwd(), 'scripts/ci/bootstrap-convex-env.mjs')],
+        {
+          env: {
+            ...process.env,
+            PATH: `${tempDir}:${process.env.PATH ?? ''}`,
+            CONVEX_DEPLOY_KEY: 'preview:team:project|secret',
+            VERCEL_ENV: 'preview',
+            VERCEL_GIT_COMMIT_REF: 'codex/canary-local-ci-agentic-qa',
+            GUEST_TOKEN_SECRET: 'guest-secret',
+            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: clerkPublishableKey(
+              'test',
+              'solid-beetle-24.clerk.accounts.dev'
+            ),
+          },
+          encoding: 'utf8',
+        }
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(readFileSync(logPath, 'utf8').trim().split('\n')).toEqual([
+        'exec convex env --preview-name codex/canary-local-ci-agentic-qa set GUEST_TOKEN_SECRET guest-secret',
+        'exec convex env --preview-name codex/canary-local-ci-agentic-qa set CLERK_JWT_ISSUER_DOMAIN https://solid-beetle-24.clerk.accounts.dev',
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- fix the hosted Convex bootstrap script so direct Vercel execution no longer trips a temporal dead zone
- remove the unsupported \ flag from hosted Convex deploy invocations and cover the hosted CLI path with regression tests
- keep GitHub source in sync with the production hotfix that is already deployed

## Verification
- pnpm vitest run tests/scripts/bootstrap-convex-env.test.ts
- pnpm typecheck
- NEXT_PUBLIC_CANARY_ENDPOINT=https://canary-obs.fly.dev NEXT_PUBLIC_CANARY_API_KEY=<public canary write key> git push -u origin codex/fix-hosted-convex-deploy-regressions
- npx vercel deploy --prod --yes
- flyctl ssh console -a linejam-canary-responder -C "sh -lc 'cd /app && pnpm test:e2e:smoke'"
- curl -fsS https://www.linejam.app/api/health


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for the deployment bootstrap process to verify CLI execution and command sequencing.

* **Chores**
  * Streamlined internal deployment configuration handling by simplifying the CLI invocation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->