### PR TITLE
feat: redesign room chrome as sticky nav

### DIFF
--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -5,3 +5,4 @@
 {"date":"2026-04-08","pr":null,"correctness":9,"depth":9,"simplicity":8,"craft":9,"verdict":"ship","providers":["codex","internal-bench"]}
 {"date":"2026-04-08","pr":null,"correctness":9,"depth":9,"simplicity":9,"craft":9,"verdict":"ship","providers":["codex","internal-bench"]}
 {"date":"2026-04-08","pr":206,"correctness":9,"depth":9,"simplicity":9,"craft":9,"verdict":"ship","providers":["codex"]}
+{"date":"2026-04-09","pr":null,"correctness":9,"depth":9,"simplicity":8,"craft":9,"verdict":"ship","providers":["codex","internal-bench"]}

--- a/app/room/[code]/page.tsx
+++ b/app/room/[code]/page.tsx
@@ -4,6 +4,7 @@ import { use, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
+import type { Doc } from '@/convex/_generated/dataModel';
 import { AuthErrorState } from '@/components/AuthErrorState';
 import { Lobby } from '@/components/Lobby';
 import { RevealPhase } from '@/components/RevealPhase';
@@ -13,6 +14,7 @@ import { WritingScreen } from '@/components/WritingScreen';
 import { LoadingMessages, LoadingState } from '@/components/ui/LoadingState';
 import { useUser } from '@/lib/auth';
 import { captureError } from '@/lib/error';
+import { buildLobbyChromeCopy } from '@/lib/roomChromeCopy';
 
 function UnexpectedRoomState({
   code,
@@ -57,6 +59,53 @@ interface RoomPageProps {
   params: Promise<{ code: string }>;
 }
 
+interface RoomPageState {
+  room: Doc<'rooms'> & { status: Doc<'rooms'>['status'] };
+  players: Array<
+    Doc<'roomPlayers'> & {
+      stableId: string;
+      isBot?: boolean;
+      aiPersonaId?: string;
+    }
+  >;
+  isHost: boolean;
+}
+
+function ResolvedRoomPage({
+  code,
+  roomState,
+}: {
+  code: string;
+  roomState: RoomPageState;
+}) {
+  const { room, players, isHost } = roomState;
+
+  if (room.status === 'LOBBY') {
+    return (
+      <>
+        <RoomChrome
+          roomCode={code}
+          {...buildLobbyChromeCopy({
+            code,
+            playerCount: players.length,
+          })}
+        />
+        <Lobby room={room} players={players} isHost={isHost} />
+      </>
+    );
+  }
+
+  if (room.status === 'IN_PROGRESS') {
+    return <WritingScreen roomCode={code} showChrome />;
+  }
+
+  if (room.status === 'COMPLETED') {
+    return <RevealPhase roomCode={code} showChrome />;
+  }
+
+  return <UnexpectedRoomState code={code} status={String(room.status)} />;
+}
+
 export default function RoomPage({ params }: RoomPageProps) {
   const { code } = use(params);
   const { isLoading, guestToken, authError, retryAuth } = useUser();
@@ -90,24 +139,5 @@ export default function RoomPage({ params }: RoomPageProps) {
     );
   }
 
-  const { room, players, isHost } = roomState;
-
-  // Determine which screen to show
-  let content = null;
-  if (room.status === 'LOBBY') {
-    content = <Lobby room={room} players={players} isHost={isHost} />;
-  } else if (room.status === 'IN_PROGRESS') {
-    content = <WritingScreen roomCode={code} />;
-  } else if (room.status === 'COMPLETED') {
-    content = <RevealPhase roomCode={code} />;
-  } else {
-    content = <UnexpectedRoomState code={code} status={String(room.status)} />;
-  }
-
-  return (
-    <>
-      <RoomChrome roomCode={code} />
-      {content}
-    </>
-  );
+  return <ResolvedRoomPage code={code} roomState={roomState} />;
 }

--- a/backlog.d/007-establish-stagehand-agentic-qa-harness.md
+++ b/backlog.d/007-establish-stagehand-agentic-qa-harness.md
@@ -1,0 +1,122 @@
+# Establish Stagehand Agentic QA Harness
+
+Priority: high
+Status: ready
+Estimate: L
+
+## Goal
+
+Add a local-first agentic QA lane that runs named browser missions against Linejam, emits a stable artifact bundle, and grades the run with a separate critic so exploratory QA finds regressions that deterministic Playwright smoke does not.
+
+## Non-Goals
+
+- Replace Vitest, Playwright, or Dagger as the authoritative CI contract
+- Auto-fix bugs or auto-deploy code
+- Let an LLM critic block merges in the first release
+- Expand the responder into a full autonomous incident commander
+- Adopt a more autonomous browser stack than needed for a first-party app
+
+## Constraints / Invariants
+
+- Dagger plus deterministic Playwright remain the source of truth for pass/fail CI
+- The executor and critic must stay separate; no self-grading
+- Every run must start from a named mission and write a machine-readable artifact bundle
+- Missions must work against `local` first, then `preview`; production escalation is follow-on work
+- Authenticated missions must reuse the existing Clerk smoke posture and fail closed on live-key drift
+- Canary remains the primary incident sink; agentic QA augments Canary and Playwright instead of bypassing them
+
+## Authority Order
+
+tests > type system > code > docs > lore
+
+## Notes
+
+- Recommended stack: Stagehand for exploratory execution, Promptfoo for critic scoring, existing Playwright smoke for deterministic baseline
+- Keep `agent-browser` and Dogfood as operator tools, not the core harness contract
+- Defer Checkly or other hosted synthetics until the local and preview missions are stable
+
+## Product Direction
+
+### Approaches considered
+
+1. **Stagehand executor + Promptfoo critic layered on Playwright**  
+   Best fit. Preserves the current TypeScript/browser stack, keeps deterministic tests intact, and adds an exploratory lane with explicit artifacts and separate grading.
+
+2. **Playwright-only expansion**  
+   Low risk but misses the exploratory, fuzzy UX, and screenshot-driven QA goals that motivated this work.
+
+3. **More autonomous browser agents first (`browser-use`, `Skyvern`, similar)**  
+   Higher autonomy than needed for a first-party app. More operational drag and nondeterminism before we have a solid artifact and critic contract.
+
+### Recommendation
+
+Choose approach 1. Linejam already has a strong deterministic spine and a live Canary responder. The next missing module is an exploratory executor with stable evidence, not a new general-purpose browser platform.
+
+## Technical Direction
+
+### Recommended design
+
+- Add a `qa/agentic/` module that owns:
+  - mission definitions
+  - artifact manifest schema
+  - Stagehand runner
+  - Promptfoo critic adapter
+- Keep the execution surface thin:
+  - Stagehand runs a mission against a supplied base URL
+  - writes screenshots, trace links, transcript, console/network summaries, and a JSON manifest
+  - hands the manifest to a separate critic
+- Keep the critic deterministic where possible:
+  - deterministic assertions first: final URL, visible copy, absence of generic error UI, artifact presence
+  - model-graded rubric second: coherence, goal success, UX quality, unexpected friction
+- Keep CI posture advisory first:
+  - local/manual and preview runs produce reports
+  - critic failures do not gate merge until false-positive rate is understood
+
+### Repo Anchors
+
+- `playwright.smoke.config.ts`
+- `playwright.global.setup.ts`
+- `tests/e2e/prod-smoke.spec.ts`
+- `tests/e2e/support/clerk.ts`
+- `scripts/canary/trigger-smoke.mjs`
+- `scripts/canary/responder.mjs`
+- `scripts/canary/events.mjs`
+- `docs/testing.md`
+- `docs/ops/canary-responder.md`
+
+### Prior Art
+
+- `tests/e2e/prod-smoke.spec.ts` already captures the two highest-value smoke missions: guest multiplayer and signed-in join
+- `tests/e2e/support/clerk.ts` already encodes the live-vs-test Clerk safety posture
+- `scripts/canary/trigger-smoke.mjs` already owns smoke escalation, env filtering, and auth guardrails
+- `scripts/canary/responder.mjs` already gives us the thin incident loop shape we want to preserve
+
+## Oracle
+
+- [ ] `pnpm ci:dagger:all`
+- [ ] `pnpm qa:agentic:local --mission guest-host-signed-in-join`
+- [ ] `pnpm qa:agentic:local --mission signed-in-host-guest-join`
+- [ ] `pnpm qa:agentic:preview --mission guest-host-signed-in-join --base-url https://<preview-url>`
+- [ ] Each run writes `.qa/runs/<run-id>/manifest.json` plus screenshots and a critic summary
+- [ ] The critic marks an intentionally injected generic join error as fail and a healthy join mission as pass
+- [ ] `pnpm canary:responder` can be configured to attach the artifact bundle path or summary for follow-on investigation without replacing the existing deterministic smoke trigger
+
+## Implementation Sequence
+
+1. Add mission definitions and a versioned artifact manifest schema
+2. Add the Stagehand runner for local and preview missions, reusing existing Clerk smoke helpers where auth is required
+3. Add Promptfoo critic configs that grade artifact bundles against explicit rubrics and thresholds
+4. Add a Dagger advisory lane for agentic QA so local execution is first-class without becoming merge-gating
+5. Add responder handoff hooks so Canary incidents can attach agentic QA evidence after deterministic smoke, still behind an explicit flag
+
+## Risk + Rollout
+
+- Main risk: flaky or over-opinionated LLM grading creates noise
+  - Mitigation: keep critic advisory-only at first and require deterministic assertions in every mission
+- Main risk: exploratory harness drifts away from real auth and room-flow constraints
+  - Mitigation: reuse existing Playwright auth helpers and room missions instead of inventing a separate auth path
+- Rollout:
+  1. local only
+  2. preview/manual
+  3. scheduled preview
+  4. production post-deploy advisory

--- a/components/Lobby.tsx
+++ b/components/Lobby.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import { useMutation } from 'convex/react';
 import { api } from '../convex/_generated/api';
 import { useUser } from '../lib/auth';
-import { formatRoomCode } from '../lib/roomCode';
 import { errorToFeedback } from '../lib/errorFeedback';
 import { Alert } from './ui/Alert';
 import { Avatar } from './ui/Avatar';
@@ -217,11 +216,17 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
         <div className="grid md:grid-cols-[auto_1fr] gap-12 md:gap-24">
           {/* CONTROL DESK: Room Identity + Primary Action */}
           <div className="flex flex-col items-center md:items-start space-y-8 md:sticky md:top-12 md:self-start">
-            {/* Room Code - Breathing Beacon */}
-            <div className="text-center md:text-left">
-              <h1 className="text-7xl md:text-9xl font-[var(--font-display)] text-primary tracking-tighter animate-breathe">
-                {formatRoomCode(room.code)}
-              </h1>
+            <div className="max-w-md space-y-4 text-center md:text-left">
+              <p className="text-xs font-mono uppercase tracking-[0.32em] text-text-muted">
+                Control desk
+              </p>
+              <h2 className="text-4xl md:text-5xl font-[var(--font-display)] leading-none text-text-primary">
+                Let the room fill, then strike the first line.
+              </h2>
+              <p className="text-base leading-relaxed text-text-secondary">
+                Share the code from the room bar, add an AI poet if the circle
+                needs one, and start once everyone is in place.
+              </p>
             </div>
 
             {/* Add AI Player Button - Host only */}

--- a/components/RevealPhase.tsx
+++ b/components/RevealPhase.tsx
@@ -17,12 +17,18 @@ import { Avatar } from './ui/Avatar';
 import { BotBadge } from './ui/BotBadge';
 import { Id } from '../convex/_generated/dataModel';
 import { trackGameCompleted } from '../lib/analytics';
+import { RoomChrome } from './RoomChrome';
+import { buildRevealChromeCopy } from '../lib/roomChromeCopy';
 
 interface RevealPhaseProps {
   roomCode: string;
+  showChrome?: boolean;
 }
 
-export function RevealPhase({ roomCode }: RevealPhaseProps) {
+export function RevealPhase({
+  roomCode,
+  showChrome = false,
+}: RevealPhaseProps) {
   const { guestToken } = useUser();
   const [showingPoemId, setShowingPoemId] = useState<Id<'poems'> | null>(null);
   const [isRevealingId, setIsRevealingId] = useState<Id<'poems'> | null>(null);
@@ -120,6 +126,12 @@ export function RevealPhase({ roomCode }: RevealPhaseProps) {
   const displayingPoem = showingPoemId
     ? myPoems?.find((p) => p._id === showingPoemId)
     : null;
+  const chrome = showChrome ? (
+    <RoomChrome
+      roomCode={roomCode}
+      {...buildRevealChromeCopy({ allRevealed })}
+    />
+  ) : null;
 
   if (displayingPoem) {
     // Count unique poets for this poem
@@ -127,196 +139,189 @@ export function RevealPhase({ roomCode }: RevealPhaseProps) {
       .size;
 
     return (
-      <PoemDisplay
-        poemId={displayingPoem._id}
-        lines={displayingPoem.lines.map((l) => ({
-          text: l.text,
-          authorName: l.authorName,
-          authorStableId: l.authorStableId,
-          isBot: l.isBot,
-        }))}
-        onDone={() => setShowingPoemId(null)}
-        alreadyRevealed={displayingPoem.isRevealed}
-        allStableIds={allStableIds}
-        metadata={{
-          createdAt: displayingPoem.createdAt,
-          firstLine: displayingPoem.preview,
-          uniquePoets,
-        }}
-      />
+      <>
+        {chrome}
+        <PoemDisplay
+          poemId={displayingPoem._id}
+          lines={displayingPoem.lines.map((l) => ({
+            text: l.text,
+            authorName: l.authorName,
+            authorStableId: l.authorStableId,
+            isBot: l.isBot,
+          }))}
+          onDone={() => setShowingPoemId(null)}
+          alreadyRevealed={displayingPoem.isRevealed}
+          allStableIds={allStableIds}
+          metadata={{
+            createdAt: displayingPoem.createdAt,
+            firstLine: displayingPoem.preview,
+            uniquePoets,
+          }}
+        />
+      </>
     );
   }
 
   // Single-column editorial layout
   return (
-    <div className="min-h-screen bg-background flex flex-col">
-      <main className="flex-1 p-6 md:p-12 lg:p-24 max-w-3xl mx-auto w-full space-y-12">
-        {/* 1. HEADER - Context first */}
-        <header className="space-y-4">
-          <h1 className="text-3xl md:text-4xl font-[var(--font-display)] leading-[0.9]">
-            {allRevealed ? 'Session Complete' : 'Reading Phase'}
-          </h1>
-          <p className="text-lg text-text-secondary leading-relaxed">
-            {allRevealed
-              ? 'The cycle is finished. The poems are sealed.'
-              : 'One by one, unveil the hidden works. Read aloud with conviction.'}
-          </p>
-          <div className="border-t border-border" />
-        </header>
-
-        {/* 2. HERO - Your Assignment (primary action) */}
-        {myPoems && myPoems.length > 0 && (
-          <section className="space-y-6">
-            {/* Unrevealed poems - actionable cards */}
-            {myPoems
-              .filter((poem) => !poem.isRevealed)
-              .map((poem) => (
-                <div
-                  key={poem._id}
-                  className="p-6 border border-primary bg-surface shadow-lg space-y-4"
-                >
-                  <div>
-                    <div className="flex items-center gap-3 mb-2">
-                      <p className="text-xs font-mono uppercase tracking-widest text-primary">
-                        {poem.isForAi
-                          ? `Read for ${poem.aiPersonaName}`
-                          : 'Your Assignment'}
-                      </p>
-                      {poem.isForAi && <BotBadge />}
-                    </div>
-                    <p className="text-xl md:text-2xl font-[var(--font-display)] italic leading-relaxed">
-                      &ldquo;{poem.preview}...&rdquo;
-                    </p>
-                  </div>
-                  {error && <Alert variant="error">{error}</Alert>}
-                  <Button
-                    onClick={() => handleReveal(poem._id)}
-                    size="lg"
-                    className="w-full h-12"
-                    disabled={isRevealingId === poem._id}
+    <>
+      {chrome}
+      <div className="min-h-screen bg-background flex flex-col">
+        <main className="flex-1 max-w-3xl mx-auto w-full space-y-12 p-6 md:p-12 lg:px-24 lg:pb-24 lg:pt-16">
+          {/* 2. HERO - Your Assignment (primary action) */}
+          {myPoems && myPoems.length > 0 && (
+            <section className="space-y-6">
+              {/* Unrevealed poems - actionable cards */}
+              {myPoems
+                .filter((poem) => !poem.isRevealed)
+                .map((poem) => (
+                  <div
+                    key={poem._id}
+                    className="p-6 border border-primary bg-surface shadow-lg space-y-4"
                   >
-                    {isRevealingId === poem._id
-                      ? 'Unsealing...'
-                      : 'Reveal & Read'}
+                    <div>
+                      <div className="flex items-center gap-3 mb-2">
+                        <p className="text-xs font-mono uppercase tracking-widest text-primary">
+                          {poem.isForAi
+                            ? `Read for ${poem.aiPersonaName}`
+                            : 'Your Assignment'}
+                        </p>
+                        {poem.isForAi && <BotBadge />}
+                      </div>
+                      <p className="text-xl md:text-2xl font-[var(--font-display)] italic leading-relaxed">
+                        &ldquo;{poem.preview}...&rdquo;
+                      </p>
+                    </div>
+                    {error && <Alert variant="error">{error}</Alert>}
+                    <Button
+                      onClick={() => handleReveal(poem._id)}
+                      size="lg"
+                      className="w-full h-12"
+                      disabled={isRevealingId === poem._id}
+                    >
+                      {isRevealingId === poem._id
+                        ? 'Unsealing...'
+                        : 'Reveal & Read'}
+                    </Button>
+                  </div>
+                ))}
+
+              {/* Revealed poems - re-read buttons */}
+              {myPoems
+                .filter((poem) => poem.isRevealed)
+                .map((poem) => (
+                  <Button
+                    key={poem._id}
+                    onClick={() => setShowingPoemId(poem._id)}
+                    variant="outline"
+                    size="lg"
+                    className="w-full text-lg h-16 border-2"
+                  >
+                    <span className="flex items-center gap-3">
+                      {poem.isForAi ? (
+                        <>
+                          Re-Read {poem.aiPersonaName}&apos;s Poem
+                          <BotBadge showLabel={false} />
+                        </>
+                      ) : (
+                        'Re-Read My Poem'
+                      )}
+                    </span>
+                  </Button>
+                ))}
+            </section>
+          )}
+
+          {/* 3. STATUS - Poem Status list */}
+          <section className="space-y-4">
+            <Label className="block">Poem Status</Label>
+            <div className="border-t border-border-subtle">
+              {poems
+                .sort((a, b) => a.indexInRoom - b.indexInRoom)
+                .map((poem, i) => (
+                  <div
+                    key={poem._id}
+                    className="flex items-center justify-between py-3 border-b border-border-subtle"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="font-mono text-xs text-text-muted w-6">
+                        {(i + 1).toString().padStart(2, '0')}
+                      </span>
+                      <Avatar
+                        stableId={poem.readerStableId}
+                        displayName={poem.readerName}
+                        allStableIds={allStableIds}
+                        size="sm"
+                        outlined={!poem.isRevealed}
+                      />
+                      <span
+                        className={cn(
+                          'text-sm font-medium',
+                          poem.isRevealed && 'opacity-50'
+                        )}
+                      >
+                        {poem.readerName}
+                      </span>
+                    </div>
+                    {poem.isRevealed && (
+                      <span className="text-[10px] font-mono uppercase tracking-widest text-text-muted">
+                        READ
+                      </span>
+                    )}
+                  </div>
+                ))}
+            </div>
+          </section>
+
+          {/* 4. ACTIONS - Host controls */}
+          {allRevealed && (
+            <section className="space-y-4 pt-8 border-t border-border">
+              {error && <Alert variant="error">{error}</Alert>}
+
+              {/* Host controls */}
+              {isHost && (
+                <div className="grid grid-cols-2 gap-3">
+                  <Button
+                    onClick={handleStartNow}
+                    size="lg"
+                    className="h-14"
+                    disabled={isStartingNow}
+                  >
+                    {isStartingNow ? 'Starting...' : 'Start Next Round'}
+                  </Button>
+                  <Button
+                    onClick={handleStartNewCycle}
+                    variant="outline"
+                    size="lg"
+                    className="h-14"
+                  >
+                    Back to Lobby
                   </Button>
                 </div>
-              ))}
+              )}
 
-            {/* Revealed poems - re-read buttons */}
-            {myPoems
-              .filter((poem) => poem.isRevealed)
-              .map((poem) => (
-                <Button
-                  key={poem._id}
-                  onClick={() => setShowingPoemId(poem._id)}
-                  variant="outline"
-                  size="lg"
-                  className="w-full text-lg h-16 border-2"
-                >
-                  <span className="flex items-center gap-3">
-                    {poem.isForAi ? (
-                      <>
-                        Re-Read {poem.aiPersonaName}&apos;s Poem
-                        <BotBadge showLabel={false} />
-                      </>
-                    ) : (
-                      'Re-Read My Poem'
-                    )}
-                  </span>
+              {/* Non-host message */}
+              {!isHost && (
+                <p className="text-sm text-text-muted text-center">
+                  Waiting for host to start the next round...
+                </p>
+              )}
+
+              <Link href="/me/poems" className="block">
+                <Button variant="secondary" size="lg" className="w-full h-14">
+                  Archive
                 </Button>
-              ))}
-          </section>
-        )}
-
-        {/* 3. STATUS - Poem Status list */}
-        <section className="space-y-4">
-          <Label className="block">Poem Status</Label>
-          <div className="border-t border-border-subtle">
-            {poems
-              .sort((a, b) => a.indexInRoom - b.indexInRoom)
-              .map((poem, i) => (
-                <div
-                  key={poem._id}
-                  className="flex items-center justify-between py-3 border-b border-border-subtle"
-                >
-                  <div className="flex items-center gap-3">
-                    <span className="font-mono text-xs text-text-muted w-6">
-                      {(i + 1).toString().padStart(2, '0')}
-                    </span>
-                    <Avatar
-                      stableId={poem.readerStableId}
-                      displayName={poem.readerName}
-                      allStableIds={allStableIds}
-                      size="sm"
-                      outlined={!poem.isRevealed}
-                    />
-                    <span
-                      className={cn(
-                        'text-sm font-medium',
-                        poem.isRevealed && 'opacity-50'
-                      )}
-                    >
-                      {poem.readerName}
-                    </span>
-                  </div>
-                  {poem.isRevealed && (
-                    <span className="text-[10px] font-mono uppercase tracking-widest text-text-muted">
-                      READ
-                    </span>
-                  )}
-                </div>
-              ))}
-          </div>
-        </section>
-
-        {/* 4. ACTIONS - Host controls */}
-        {allRevealed && (
-          <section className="space-y-4 pt-8 border-t border-border">
-            {error && <Alert variant="error">{error}</Alert>}
-
-            {/* Host controls */}
-            {isHost && (
-              <div className="grid grid-cols-2 gap-3">
-                <Button
-                  onClick={handleStartNow}
-                  size="lg"
-                  className="h-14"
-                  disabled={isStartingNow}
-                >
-                  {isStartingNow ? 'Starting...' : 'Start Next Round'}
-                </Button>
-                <Button
-                  onClick={handleStartNewCycle}
-                  variant="outline"
-                  size="lg"
-                  className="h-14"
-                >
-                  Back to Lobby
-                </Button>
-              </div>
-            )}
-
-            {/* Non-host message */}
-            {!isHost && (
-              <p className="text-sm text-text-muted text-center">
-                Waiting for host to start the next round...
-              </p>
-            )}
-
-            <Link href="/me/poems" className="block">
-              <Button variant="secondary" size="lg" className="w-full h-14">
-                Archive
-              </Button>
-            </Link>
-            <Link
-              href="/"
-              className="block text-center text-sm font-mono uppercase tracking-widest text-text-muted hover:underline mt-6"
-            >
-              Exit Room
-            </Link>
-          </section>
-        )}
-      </main>
-    </div>
+              </Link>
+              <Link
+                href="/"
+                className="block text-center text-sm font-mono uppercase tracking-widest text-text-muted hover:underline mt-6"
+              >
+                Exit Room
+              </Link>
+            </section>
+          )}
+        </main>
+      </div>
+    </>
   );
 }

--- a/components/RoomChrome.tsx
+++ b/components/RoomChrome.tsx
@@ -9,23 +9,39 @@ import { Alert } from './ui/Alert';
 import { cn } from '@/lib/utils';
 import { useShareLink } from '@/hooks/useShareLink';
 import { trackRoomInviteShared } from '@/lib/analytics';
+import { formatRoomCode } from '@/lib/roomCode';
 
 interface RoomChromeProps {
   roomCode: string;
+  statusLabel: string;
+  title: string;
+  subtitle: string;
 }
 
-function chromeButtonClasses(emphasized = false) {
+function chromeButtonClasses({
+  emphasized = false,
+  iconOnly = false,
+}: {
+  emphasized?: boolean;
+  iconOnly?: boolean;
+} = {}) {
   return cn(
-    'inline-flex h-10 items-center justify-center rounded-full border px-3',
+    'inline-flex h-11 items-center justify-center rounded-full border',
     'transition-all duration-[var(--duration-normal)]',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2',
+    iconOnly ? 'w-11' : 'px-4',
     emphasized
       ? 'border-primary bg-primary text-text-inverse hover:bg-primary-hover'
       : 'border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-primary)] hover:border-[var(--color-primary)] hover:text-[var(--color-primary)]'
   );
 }
 
-export function RoomChrome({ roomCode }: RoomChromeProps) {
+export function RoomChrome({
+  roomCode,
+  statusLabel,
+  title,
+  subtitle,
+}: RoomChromeProps) {
   const [showThemes, setShowThemes] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -71,61 +87,90 @@ export function RoomChrome({ roomCode }: RoomChromeProps) {
     <>
       <HelpModal isOpen={showHelp} onClose={() => setShowHelp(false)} />
 
-      <div className="pointer-events-none fixed right-4 top-4 z-50 flex max-w-[calc(100vw-2rem)] flex-col items-end gap-2">
-        {shareError && (
-          <Alert
-            variant="error"
-            className="pointer-events-auto max-w-sm bg-[var(--color-surface)]/95 shadow-[var(--shadow-lg)] backdrop-blur"
-          >
-            {shareError}
-          </Alert>
-        )}
-
-        <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)]/92 p-2 shadow-[var(--shadow-lg)] backdrop-blur">
-          <button
-            type="button"
-            onClick={handleShare}
-            className={chromeButtonClasses(true)}
-            aria-label="Share room invite"
-          >
-            <Share2 className="mr-2 h-4 w-4" />
-            <span>{shared ? 'Shared!' : copied ? 'Copied!' : 'Invite'}</span>
-          </button>
-
-          <Link
-            href="/me/poems"
-            className={chromeButtonClasses()}
-            aria-label="View your poem archive"
-          >
-            <Archive className="h-4 w-4" />
-          </Link>
-
-          <button
-            type="button"
-            onClick={() => setShowHelp(true)}
-            className={chromeButtonClasses()}
-            aria-label="How to play"
-          >
-            <span className="text-lg font-medium">?</span>
-          </button>
-
-          <div className="relative" ref={dropdownRef}>
-            <button
-              type="button"
-              onClick={() => setShowThemes((current) => !current)}
-              className={chromeButtonClasses()}
-              aria-label="Choose theme"
-              aria-expanded={showThemes}
-              aria-haspopup="true"
+      <div className="sticky top-0 z-40 px-4 pt-4 md:px-6">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-3">
+          {shareError && (
+            <Alert
+              variant="error"
+              className="max-w-xl bg-[var(--color-surface)]/95 shadow-[var(--shadow-lg)] backdrop-blur"
             >
-              <Palette className="h-4 w-4" />
-            </button>
+              {shareError}
+            </Alert>
+          )}
 
-            {showThemes && (
-              <div className="absolute right-0 top-full mt-2 w-[320px] max-w-[calc(100vw-2rem)] rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-lg)]">
-                <ThemeSelector onClose={() => setShowThemes(false)} />
+          <div
+            data-testid="room-chrome"
+            className="grid gap-4 rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)]/92 px-4 py-4 shadow-[var(--shadow-lg)] backdrop-blur-xl md:grid-cols-[minmax(0,1fr)_auto] md:items-center md:px-6"
+          >
+            <div className="min-w-0 space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-full border border-[var(--color-border)] bg-[var(--color-background)]/72 px-3 py-1 text-[11px] font-mono uppercase tracking-[0.32em] text-[var(--color-text-muted)]">
+                  Room {formatRoomCode(roomCode)}
+                </span>
+                <span className="rounded-full border border-[var(--color-border-subtle)] px-3 py-1 text-[11px] font-mono uppercase tracking-[0.28em] text-[var(--color-text-secondary)]">
+                  {statusLabel}
+                </span>
               </div>
-            )}
+
+              <div className="space-y-1">
+                <h1 className="truncate text-2xl font-[var(--font-display)] leading-none text-[var(--color-text-primary)] md:text-3xl">
+                  {title}
+                </h1>
+                <p className="max-w-3xl text-sm leading-relaxed text-[var(--color-text-secondary)] md:text-base">
+                  {subtitle}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 md:justify-end">
+              <button
+                type="button"
+                onClick={handleShare}
+                className={chromeButtonClasses({ emphasized: true })}
+                aria-label="Share room invite"
+              >
+                <Share2 className="mr-2 h-4 w-4" />
+                <span>
+                  {shared ? 'Shared!' : copied ? 'Copied!' : 'Invite'}
+                </span>
+              </button>
+
+              <Link
+                href="/me/poems"
+                className={chromeButtonClasses({ iconOnly: true })}
+                aria-label="View your poem archive"
+              >
+                <Archive className="h-4 w-4" />
+              </Link>
+
+              <button
+                type="button"
+                onClick={() => setShowHelp(true)}
+                className={chromeButtonClasses({ iconOnly: true })}
+                aria-label="How to play"
+              >
+                <span className="text-lg font-medium">?</span>
+              </button>
+
+              <div className="relative" ref={dropdownRef}>
+                <button
+                  type="button"
+                  onClick={() => setShowThemes((current) => !current)}
+                  className={chromeButtonClasses({ iconOnly: true })}
+                  aria-label="Choose theme"
+                  aria-expanded={showThemes}
+                  aria-haspopup="true"
+                >
+                  <Palette className="h-4 w-4" />
+                </button>
+
+                {showThemes && (
+                  <div className="absolute right-0 top-full z-50 mt-3 w-[320px] max-w-[calc(100vw-2rem)] rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-lg)]">
+                    <ThemeSelector onClose={() => setShowThemes(false)} />
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/components/WaitingScreen.tsx
+++ b/components/WaitingScreen.tsx
@@ -8,16 +8,32 @@ import { BotBadge } from './ui/BotBadge';
 interface WaitingScreenProps {
   roomCode: string;
   guestToken?: string | null;
+  progressOverride?: {
+    round: number;
+    players: Array<{
+      submitted: boolean;
+      userId: string;
+      stableId: string;
+      displayName: string;
+      isBot?: boolean;
+    }>;
+  } | null;
 }
 
 export function WaitingScreen({
   roomCode,
   guestToken: propToken,
+  progressOverride,
 }: WaitingScreenProps) {
   // Use prop token if provided (from parent component), otherwise use hook token
   // This allows immediate query execution when transitioning from WritingScreen
   const { queryArgs } = useRoomQueryArgs(roomCode, propToken);
-  const progress = useQuery(api.game.getRoundProgress, queryArgs);
+  const queriedProgress = useQuery(
+    api.game.getRoundProgress,
+    progressOverride === undefined ? queryArgs : 'skip'
+  );
+  const progress =
+    progressOverride === undefined ? queriedProgress : progressOverride;
 
   // Loading state (query in flight or skipped)
   if (progress === undefined) {
@@ -49,23 +65,16 @@ export function WaitingScreen({
       {/* Floating vertical composition - massive breathing space */}
       <div
         className="w-full max-w-2xl flex flex-col items-center"
-        style={{ minHeight: '80vh' }}
+        style={{ minHeight: '72vh' }}
       >
-        {/* Top: Round indicator */}
-        <div className="flex-none mb-32 md:mb-40">
-          <div className="text-[var(--text-sm)] font-mono text-[var(--color-text-muted)] uppercase tracking-[0.4em] text-center">
-            Round {round + 1}
-          </div>
-        </div>
-
         {/* Center: Headline */}
-        <div className="flex-none mb-24 md:mb-32 text-center space-y-6">
+        <div className="flex-none mb-24 md:mb-28 text-center space-y-6">
           <h2 className="text-6xl md:text-8xl font-[var(--font-display)] leading-[1.05]">
             {allSubmitted ? 'Ready' : 'Others are writing...'}
           </h2>
           {!allSubmitted && (
             <p className="text-[var(--text-lg)] font-mono text-[var(--color-text-secondary)]">
-              {submittedCount} of {players.length} ready
+              Round {round + 1} · {submittedCount} of {players.length} ready
             </p>
           )}
         </div>

--- a/components/WritingScreen.tsx
+++ b/components/WritingScreen.tsx
@@ -9,13 +9,16 @@ import { captureError } from '@/lib/error';
 import { cn } from '@/lib/utils';
 import { countWords } from '@/lib/wordCount';
 import { Alert } from '@/components/ui/Alert';
+import { RoomChrome } from '@/components/RoomChrome';
 import { Button } from '@/components/ui/Button';
 import { LoadingMessages, LoadingState } from '@/components/ui/LoadingState';
 import { WordSlots } from '@/components/ui/WordSlots';
 import { WaitingScreen } from '@/components/WaitingScreen';
+import { buildInProgressChromeCopy } from '@/lib/roomChromeCopy';
 
 interface WritingScreenProps {
   roomCode: string;
+  showChrome?: boolean;
 }
 
 type RoomQueryArgs = ReturnType<typeof useRoomQueryArgs>['queryArgs'];
@@ -63,7 +66,6 @@ function WritingComposer({
   const [error, setError] = useState<string | null>(null);
   const [liveRegionMessage, setLiveRegionMessage] = useState('');
   const [hasFocus, setHasFocus] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const submitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const currentWordCount = countWords(text);
@@ -98,6 +100,10 @@ function WritingComposer({
     };
   }, []);
 
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+  }, [assignment.poemId, assignment.lineIndex]);
+
   if (showWaitingScreen) {
     return <WaitingScreen roomCode={roomCode} guestToken={guestToken} />;
   }
@@ -130,7 +136,7 @@ function WritingComposer({
   };
 
   return (
-    <div className="relative min-h-screen bg-background flex flex-col items-center pt-12 md:pt-24 p-6">
+    <div className="relative min-h-screen bg-background flex flex-col items-center px-6 pb-6 pt-8 md:px-8 md:pb-8 md:pt-12">
       {/* Screen reader live region for validation announcements */}
       <div
         className="sr-only"
@@ -142,14 +148,6 @@ function WritingComposer({
       </div>
 
       <div className="w-full max-w-3xl space-y-16">
-        {/* Status Row - Justified between (left: round, right: counter) */}
-        <div className="flex items-center justify-between mb-12">
-          <div className="text-xs font-mono uppercase tracking-widest text-text-muted">
-            Round {assignment.lineIndex + 1} / 9
-          </div>
-          <WordSlots current={currentWordCount} target={targetCount} />
-        </div>
-
         {/* The Memory - No container */}
         {assignment.previousLineText && (
           <div className="mb-16 animate-fade-in-up">
@@ -179,7 +177,6 @@ function WritingComposer({
           )}
 
           <textarea
-            ref={textareaRef}
             className={cn(
               'w-full min-h-[280px] md:min-h-[320px] lg:min-h-[360px] bg-transparent border-none outline-none resize-none',
               'text-3xl md:text-5xl lg:text-6xl font-[var(--font-display)] leading-tight',
@@ -195,13 +192,16 @@ function WritingComposer({
             }}
             onFocus={() => setHasFocus(true)}
             onBlur={() => setHasFocus(false)}
-            autoFocus
             spellCheck={false}
             aria-label={`Write your line for round ${assignment.lineIndex + 1}. Target: ${targetCount} ${targetCount === 1 ? 'word' : 'words'}.`}
             aria-required="true"
             aria-invalid={!isValid}
             aria-describedby="word-slots"
           />
+        </div>
+
+        <div className="flex justify-end">
+          <WordSlots current={currentWordCount} target={targetCount} />
         </div>
 
         {/* Error Display */}
@@ -236,9 +236,16 @@ function WritingComposer({
   );
 }
 
-export function WritingScreen({ roomCode }: WritingScreenProps) {
+export function WritingScreen({
+  roomCode,
+  showChrome = false,
+}: WritingScreenProps) {
   const { guestToken, shouldSkip, queryArgs } = useRoomQueryArgs(roomCode);
   const assignment = useQuery(api.game.getCurrentAssignment, queryArgs);
+  const roundProgress = useQuery(
+    api.game.getRoundProgress,
+    showChrome && assignment === null ? queryArgs : 'skip'
+  );
 
   if (shouldSkip || assignment === undefined) {
     return (
@@ -249,16 +256,38 @@ export function WritingScreen({ roomCode }: WritingScreenProps) {
   }
 
   if (assignment === null) {
-    return <WaitingScreen roomCode={roomCode} guestToken={guestToken} />;
+    return (
+      <>
+        {showChrome && (
+          <RoomChrome
+            roomCode={roomCode}
+            {...buildInProgressChromeCopy({ roundProgress })}
+          />
+        )}
+        <WaitingScreen
+          roomCode={roomCode}
+          guestToken={guestToken}
+          progressOverride={roundProgress}
+        />
+      </>
+    );
   }
 
   return (
-    <WritingComposer
-      key={`${assignment.poemId}:${assignment.lineIndex}`}
-      assignment={assignment}
-      guestToken={guestToken}
-      queryArgs={queryArgs}
-      roomCode={roomCode}
-    />
+    <>
+      {showChrome && (
+        <RoomChrome
+          roomCode={roomCode}
+          {...buildInProgressChromeCopy({ assignment })}
+        />
+      )}
+      <WritingComposer
+        key={`${assignment.poemId}:${assignment.lineIndex}`}
+        assignment={assignment}
+        guestToken={guestToken}
+        queryArgs={queryArgs}
+        roomCode={roomCode}
+      />
+    </>
   );
 }

--- a/lib/roomChromeCopy.ts
+++ b/lib/roomChromeCopy.ts
@@ -1,0 +1,93 @@
+import { WORD_COUNTS } from '@/convex/lib/gameRules';
+import { formatRoomCode } from '@/lib/roomCode';
+
+export interface RoomChromeCopy {
+  statusLabel: string;
+  title: string;
+  subtitle: string;
+}
+
+interface ChromeAssignment {
+  lineIndex: number;
+  targetWordCount: number;
+}
+
+interface ChromeRoundProgress {
+  round: number;
+  players: Array<{ submitted: boolean }>;
+}
+
+export function buildLobbyChromeCopy({
+  code,
+  playerCount,
+}: {
+  code: string;
+  playerCount: number;
+}): RoomChromeCopy {
+  const needsMore = Math.max(0, 2 - playerCount);
+
+  return {
+    statusLabel: 'Lobby',
+    title: 'Room open',
+    subtitle:
+      needsMore > 0
+        ? `Share ${formatRoomCode(code)} and gather ${needsMore} more poet${needsMore === 1 ? '' : 's'} before the first line.`
+        : `${playerCount} poets are here. Start when the room feels ready.`,
+  };
+}
+
+export function buildInProgressChromeCopy({
+  assignment,
+  roundProgress,
+}: {
+  assignment?: ChromeAssignment | null;
+  roundProgress?: ChromeRoundProgress | null;
+}): RoomChromeCopy {
+  const roundIndex = assignment?.lineIndex ?? roundProgress?.round ?? null;
+  const roundNumber = roundIndex === null ? null : roundIndex + 1;
+  const roundTitle = roundNumber
+    ? `Round ${roundNumber} / ${WORD_COUNTS.length}`
+    : 'Writing in progress';
+
+  if (assignment) {
+    const { targetWordCount } = assignment;
+
+    return {
+      statusLabel: 'In Progress',
+      title: roundTitle,
+      subtitle: `Write exactly ${targetWordCount} word${targetWordCount === 1 ? '' : 's'}. You can only see the line before yours.`,
+    };
+  }
+
+  if (roundProgress) {
+    const submittedCount = roundProgress.players.filter(
+      (player) => player.submitted
+    ).length;
+
+    return {
+      statusLabel: 'In Progress',
+      title: roundTitle,
+      subtitle: `${submittedCount} of ${roundProgress.players.length} poets are ready. Hold the cadence while the room catches up.`,
+    };
+  }
+
+  return {
+    statusLabel: 'In Progress',
+    title: 'Writing in progress',
+    subtitle: 'Keep the room steady while the next prompt resolves.',
+  };
+}
+
+export function buildRevealChromeCopy({
+  allRevealed,
+}: {
+  allRevealed: boolean;
+}): RoomChromeCopy {
+  return {
+    statusLabel: allRevealed ? 'Session Complete' : 'Reading Phase',
+    title: allRevealed ? 'The poems are unsealed' : 'Reveal each poem in turn',
+    subtitle: allRevealed
+      ? 'Return to the lobby, revisit the session, or head to the archive.'
+      : 'One reader at a time. Let the room hear the full poem before moving on.',
+  };
+}

--- a/tests/app/room-page.test.tsx
+++ b/tests/app/room-page.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import { getFunctionName } from 'convex/server';
 
 const mockReactUse = vi.fn();
 const mockUseClerkUser = vi.fn();
@@ -31,6 +32,38 @@ vi.mock('convex/react', () => ({
 
 vi.mock('@clerk/nextjs', () => ({
   useUser: () => mockUseClerkUser(),
+}));
+
+vi.mock('@/components/Lobby', () => ({
+  Lobby: () => <div>Lobby view</div>,
+}));
+
+vi.mock('@/components/WritingScreen', () => ({
+  WritingScreen: ({
+    roomCode,
+    showChrome,
+  }: {
+    roomCode: string;
+    showChrome?: boolean;
+  }) => (
+    <div>
+      Writing view {roomCode} {showChrome ? 'chrome on' : 'chrome off'}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/RevealPhase', () => ({
+  RevealPhase: ({
+    roomCode,
+    showChrome,
+  }: {
+    roomCode: string;
+    showChrome?: boolean;
+  }) => (
+    <div>
+      Reveal view {roomCode} {showChrome ? 'chrome on' : 'chrome off'}
+    </div>
+  ),
 }));
 
 import RoomPage from '@/app/room/[code]/page';
@@ -86,13 +119,23 @@ describe('RoomPage', () => {
   }
 
   it('renders an explicit recovery state when room status is unknown', async () => {
-    mockUseQuery.mockReturnValue({
-      room: {
-        code: 'ABCD',
-        status: 'BROKEN_STATE',
-      },
-      players: [],
-      isHost: false,
+    mockUseQuery.mockImplementation((query) => {
+      const functionName = getFunctionName(
+        query as Parameters<typeof getFunctionName>[0]
+      );
+
+      if (functionName === 'rooms:getRoomState') {
+        return {
+          room: {
+            code: 'ABCD',
+            status: 'BROKEN_STATE',
+          },
+          players: [],
+          isHost: false,
+        };
+      }
+
+      return null;
     });
 
     renderRoomPage();
@@ -109,7 +152,15 @@ describe('RoomPage', () => {
   });
 
   it('renders the shared auth recovery state when guest bootstrap fails', async () => {
-    mockUseQuery.mockReturnValue(undefined);
+    mockUseQuery.mockImplementation((query) => {
+      const functionName = getFunctionName(
+        query as Parameters<typeof getFunctionName>[0]
+      );
+      if (functionName === 'rooms:getRoomState') {
+        return undefined;
+      }
+      return null;
+    });
     mockFetch.mockRejectedValue(new Error('Network error'));
 
     renderRoomPage();
@@ -123,6 +174,110 @@ describe('RoomPage', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /try again/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the room chrome copy for the lobby state', async () => {
+    mockUseQuery.mockImplementation((query) => {
+      const functionName = getFunctionName(
+        query as Parameters<typeof getFunctionName>[0]
+      );
+
+      if (functionName === 'rooms:getRoomState') {
+        return {
+          room: {
+            _id: 'room_1',
+            _creationTime: Date.now(),
+            code: 'ABCD',
+            hostUserId: 'user_1',
+            createdAt: Date.now(),
+            status: 'LOBBY',
+          },
+          players: [
+            {
+              _id: 'player_1',
+              _creationTime: Date.now(),
+              roomId: 'room_1',
+              userId: 'user_1',
+              joinedAt: Date.now(),
+              stableId: 'stable-1',
+            },
+          ],
+          isHost: true,
+        };
+      }
+
+      return null;
+    });
+
+    renderRoomPage();
+
+    expect(await screen.findByText(/Room AB CD/i)).toBeInTheDocument();
+    expect(screen.getByText(/room open/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/share AB CD and gather 1 more poet/i)
+    ).toBeInTheDocument();
+  });
+
+  it('routes in-progress rooms through the writing phase with shared chrome enabled', async () => {
+    mockUseQuery.mockImplementation((query) => {
+      const functionName = getFunctionName(
+        query as Parameters<typeof getFunctionName>[0]
+      );
+
+      if (functionName === 'rooms:getRoomState') {
+        return {
+          room: {
+            _id: 'room_1',
+            _creationTime: Date.now(),
+            code: 'ABCD',
+            hostUserId: 'user_1',
+            createdAt: Date.now(),
+            status: 'IN_PROGRESS',
+          },
+          players: [],
+          isHost: true,
+        };
+      }
+
+      return null;
+    });
+
+    renderRoomPage();
+
+    expect(
+      await screen.findByText(/Writing view ABCD chrome on/i)
+    ).toBeInTheDocument();
+  });
+
+  it('routes completed rooms through the reveal phase with shared chrome enabled', async () => {
+    mockUseQuery.mockImplementation((query) => {
+      const functionName = getFunctionName(
+        query as Parameters<typeof getFunctionName>[0]
+      );
+
+      if (functionName === 'rooms:getRoomState') {
+        return {
+          room: {
+            _id: 'room_1',
+            _creationTime: Date.now(),
+            code: 'ABCD',
+            hostUserId: 'user_1',
+            createdAt: Date.now(),
+            status: 'COMPLETED',
+          },
+          players: [],
+          isHost: true,
+        };
+      }
+
+      return null;
+    });
+
+    renderRoomPage();
+
+    expect(
+      await screen.findByText(/Reveal view ABCD chrome on/i)
     ).toBeInTheDocument();
   });
 });

--- a/tests/components/Lobby.test.tsx
+++ b/tests/components/Lobby.test.tsx
@@ -107,12 +107,13 @@ describe('Lobby component', () => {
     global.fetch = originalFetch;
   });
 
-  it('displays room code correctly', () => {
+  it('renders the control-desk introduction', () => {
     // Arrange & Act
     render(<Lobby room={mockRoom} players={mockPlayers} isHost={true} />);
 
-    // Assert - Room code should be formatted (AB CD)
-    expect(screen.getByText('AB CD')).toBeInTheDocument();
+    expect(
+      screen.getByText(/let the room fill, then strike the first line/i)
+    ).toBeInTheDocument();
   });
 
   it('renders player list from room state', () => {

--- a/tests/components/RevealPhase.test.tsx
+++ b/tests/components/RevealPhase.test.tsx
@@ -257,7 +257,7 @@ describe('RevealPhase component', () => {
     });
   });
 
-  it('displays Session Complete when all revealed', () => {
+  it('shows completion actions when all poems are revealed', () => {
     // Arrange
     mockUseQuery.mockReturnValue(mockStateAllRevealed);
 
@@ -265,8 +265,10 @@ describe('RevealPhase component', () => {
     render(<RevealPhase roomCode="ABCD" />);
 
     // Assert
-    expect(screen.getByText(/Session/i)).toBeInTheDocument();
-    expect(screen.getByText(/Complete/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Start Next Round/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Archive/i })).toBeInTheDocument();
   });
 
   it('shows Back to Lobby button for host when all revealed', () => {

--- a/tests/components/RoomChrome.test.tsx
+++ b/tests/components/RoomChrome.test.tsx
@@ -83,8 +83,19 @@ describe('RoomChrome component', () => {
     });
   });
 
+  function renderRoomChrome() {
+    render(
+      <RoomChrome
+        roomCode="ABCD"
+        statusLabel="Lobby"
+        title="Room open"
+        subtitle="Share the code and gather the poets."
+      />
+    );
+  }
+
   it('renders room controls', () => {
-    render(<RoomChrome roomCode="ABCD" />);
+    renderRoomChrome();
 
     expect(
       screen.getByRole('button', { name: /Share room invite/i })
@@ -98,10 +109,12 @@ describe('RoomChrome component', () => {
     expect(
       screen.getByRole('button', { name: /Choose theme/i })
     ).toBeInTheDocument();
+    expect(screen.getByText('Room AB CD')).toBeInTheDocument();
+    expect(screen.getByText('Room open')).toBeInTheDocument();
   });
 
   it('copies a join link when native share is unavailable', async () => {
-    render(<RoomChrome roomCode="ABCD" />);
+    renderRoomChrome();
 
     await act(async () => {
       fireEvent.click(
@@ -128,7 +141,7 @@ describe('RoomChrome component', () => {
       writable: true,
       configurable: true,
     });
-    render(<RoomChrome roomCode="ABCD" />);
+    renderRoomChrome();
 
     await act(async () => {
       fireEvent.click(
@@ -150,7 +163,7 @@ describe('RoomChrome component', () => {
 
   it('opens help and theme surfaces', async () => {
     const user = userEvent.setup();
-    render(<RoomChrome roomCode="ABCD" />);
+    renderRoomChrome();
 
     await user.click(screen.getByRole('button', { name: /How to play/i }));
     expect(screen.getByText('Help modal')).toBeInTheDocument();
@@ -161,7 +174,7 @@ describe('RoomChrome component', () => {
 
   it('closes the theme chooser on outside click and escape', async () => {
     const user = userEvent.setup();
-    render(<RoomChrome roomCode="ABCD" />);
+    renderRoomChrome();
 
     await user.click(screen.getByRole('button', { name: /Choose theme/i }));
     expect(screen.getByText('Theme chooser')).toBeInTheDocument();
@@ -182,7 +195,7 @@ describe('RoomChrome component', () => {
 
   it('closes the theme chooser when the selector requests it', async () => {
     const user = userEvent.setup();
-    render(<RoomChrome roomCode="ABCD" />);
+    renderRoomChrome();
 
     await user.click(screen.getByRole('button', { name: /Choose theme/i }));
     expect(screen.getByText('Theme chooser')).toBeInTheDocument();

--- a/tests/components/WaitingScreen.test.tsx
+++ b/tests/components/WaitingScreen.test.tsx
@@ -143,7 +143,7 @@ describe('WaitingScreen component', () => {
     render(<WaitingScreen roomCode="ABCD" />);
 
     expect(screen.getByText('Others are writing...')).toBeInTheDocument();
-    expect(screen.getByText('1 of 2 ready')).toBeInTheDocument();
+    expect(screen.getByText(/Round 1 · 1 of 2 ready/i)).toBeInTheDocument();
   });
 
   it('shows "Ready" when all players have submitted', () => {
@@ -172,6 +172,37 @@ describe('WaitingScreen component', () => {
     expect(screen.getByText('Ready')).toBeInTheDocument();
     // Should not show "X of Y ready" when all submitted
     expect(screen.queryByText(/of.*ready/)).not.toBeInTheDocument();
+  });
+
+  it('uses progressOverride data and skips the round progress query', () => {
+    render(
+      <WaitingScreen
+        roomCode="ABCD"
+        progressOverride={{
+          round: 1,
+          players: [
+            {
+              userId: 'user_1',
+              stableId: 'stable_1',
+              displayName: 'Alice',
+              submitted: true,
+              isBot: false,
+            },
+            {
+              userId: 'user_2',
+              stableId: 'stable_2',
+              displayName: 'Bob',
+              submitted: false,
+              isBot: false,
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(expect.anything(), 'skip');
+    expect(screen.getByText('Others are writing...')).toBeInTheDocument();
+    expect(screen.getByText(/Round 2 · 1 of 2 ready/i)).toBeInTheDocument();
   });
 
   it('renders player avatars for each player', () => {

--- a/tests/components/WritingScreen.test.tsx
+++ b/tests/components/WritingScreen.test.tsx
@@ -102,12 +102,49 @@ describe('WritingScreen component', () => {
     global.fetch = originalFetch;
   });
 
-  it('displays round information correctly', () => {
+  it('keeps the word counter visible in the composer flow', () => {
     // Arrange & Act
     render(<WritingScreen roomCode="ABCD" />);
 
-    // Assert - Round 1 / 9 should be visible
-    expect(screen.getByText(/Round 1 \/ 9/)).toBeInTheDocument();
+    const wordSlots = document.getElementById('word-slots');
+    expect(wordSlots).toBeInTheDocument();
+  });
+
+  it('resets scroll when the active assignment changes', () => {
+    const scrollToSpy = vi
+      .spyOn(window, 'scrollTo')
+      .mockImplementation(() => undefined);
+    let activeAssignment: typeof mockAssignment | typeof mockAssignmentRound5 =
+      mockAssignment;
+
+    mockUseQuery.mockImplementation((query) => {
+      const functionName = getFunctionName(
+        query as Parameters<typeof getFunctionName>[0]
+      );
+      if (functionName === 'game:getRoundProgress') {
+        return mockRoundProgress;
+      }
+      return activeAssignment;
+    });
+
+    const { rerender } = render(<WritingScreen roomCode="ABCD" />);
+    expect(scrollToSpy).toHaveBeenCalledWith({
+      top: 0,
+      left: 0,
+      behavior: 'auto',
+    });
+
+    scrollToSpy.mockClear();
+    activeAssignment = mockAssignmentRound5;
+    rerender(<WritingScreen roomCode="ABCD" />);
+
+    expect(scrollToSpy).toHaveBeenCalledWith({
+      top: 0,
+      left: 0,
+      behavior: 'auto',
+    });
+
+    scrollToSpy.mockRestore();
   });
 
   it('shows textarea with correct aria label for word count', () => {
@@ -550,7 +587,10 @@ describe('WritingScreen component', () => {
       rerender(<WritingScreen roomCode="ABCD" />);
 
       await waitFor(() => {
-        expect(screen.getByText(/Round 2 \/ 9/)).toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toHaveAttribute(
+          'aria-label',
+          'Write your line for round 2. Target: 2 words.'
+        );
         expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe(
           ''
         );

--- a/tests/e2e/game-flow.spec.ts
+++ b/tests/e2e/game-flow.spec.ts
@@ -200,10 +200,10 @@ test.describe('Complete Game Flow', () => {
     // After round 9, both should see reveal phase
     await Promise.all([
       expect(
-        hostPage.getByRole('heading', { name: /Reading Phase/i })
+        hostPage.getByRole('heading', { name: /Reveal each poem in turn/i })
       ).toBeVisible({ timeout: 30000 }),
       expect(
-        guestPage.getByRole('heading', { name: /Reading Phase/i })
+        guestPage.getByRole('heading', { name: /Reveal each poem in turn/i })
       ).toBeVisible({ timeout: 30000 }),
     ]);
 
@@ -233,13 +233,13 @@ test.describe('Complete Game Flow', () => {
     await expect(guestPage.getByText('end')).toBeVisible();
     await guestPage.getByRole('button', { name: /Close|Done|Back/i }).click();
 
-    // After both reveal, should show "Session Complete"
+    // After both reveals, the completed reveal chrome should appear
     await Promise.all([
       expect(
-        hostPage.getByRole('heading', { name: /Session Complete/i })
+        hostPage.getByRole('heading', { name: /The poems are unsealed/i })
       ).toBeVisible({ timeout: 15000 }),
       expect(
-        guestPage.getByRole('heading', { name: /Session Complete/i })
+        guestPage.getByRole('heading', { name: /The poems are unsealed/i })
       ).toBeVisible({ timeout: 15000 }),
     ]);
   });

--- a/tests/e2e/room-chrome-layout.spec.ts
+++ b/tests/e2e/room-chrome-layout.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, BrowserContext, Page, devices } from '@playwright/test';
+
+test.describe.configure({ mode: 'serial' });
+
+const missingGuestTokenSecret = !process.env.GUEST_TOKEN_SECRET;
+test.skip(
+  missingGuestTokenSecret,
+  'Set GUEST_TOKEN_SECRET to the active Convex deployment secret to run room chrome layout E2E'
+);
+
+async function createRoom(page: Page, hostName: string) {
+  await page.goto('/host', { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('input#name', {
+    state: 'visible',
+    timeout: 30000,
+  });
+  await page.fill('input#name', hostName);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/room\/[A-Z]{4}$/, { timeout: 30000 });
+  const roomCode = page.url().match(/\/room\/([A-Z]{4})$/)?.[1] || '';
+  expect(roomCode).toMatch(/^[A-Z]{4}$/);
+  return roomCode;
+}
+
+async function joinRoom(page: Page, roomCode: string, playerName: string) {
+  await page.goto(`/join?code=${roomCode}`);
+  await page.waitForSelector('input#name', {
+    state: 'visible',
+    timeout: 30000,
+  });
+  await page.fill('input#name', playerName);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(`/room/${roomCode}`, { timeout: 30000 });
+}
+
+async function expectBelow(
+  upper: ReturnType<Page['getByTestId']>,
+  lower: ReturnType<Page['getByRole']> | ReturnType<Page['locator']>,
+  minimumGap = 8
+) {
+  const upperBox = await upper.boundingBox();
+  const lowerBox = await lower.boundingBox();
+
+  expect(upperBox).not.toBeNull();
+  expect(lowerBox).not.toBeNull();
+  expect(lowerBox!.y).toBeGreaterThan(
+    upperBox!.y + upperBox!.height + minimumGap
+  );
+}
+
+async function expectStickyAfterScroll(
+  page: Page,
+  chrome: ReturnType<Page['getByTestId']>
+) {
+  const beforeScroll = await chrome.boundingBox();
+  expect(beforeScroll).not.toBeNull();
+
+  await page.evaluate(async () => {
+    window.scrollTo({
+      top: document.documentElement.scrollHeight,
+      behavior: 'auto',
+    });
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+  });
+
+  const afterScroll = await chrome.boundingBox();
+  expect(afterScroll).not.toBeNull();
+  expect(Math.abs(afterScroll!.y - beforeScroll!.y)).toBeLessThan(4);
+}
+
+test('room chrome does not cover lobby or writing content on desktop and mobile', async ({
+  browser,
+}, testInfo) => {
+  let hostContext: BrowserContext | undefined;
+  let guestContext: BrowserContext | undefined;
+  let mobileContext: BrowserContext | undefined;
+
+  try {
+    hostContext = await browser.newContext();
+    guestContext = await browser.newContext();
+    mobileContext = await browser.newContext({
+      ...devices['iPhone 14'],
+    });
+
+    const hostPage = await hostContext.newPage();
+    const guestPage = await guestContext.newPage();
+    const mobilePage = await mobileContext.newPage();
+
+    const roomCode = await createRoom(hostPage, 'Layout Host');
+    await joinRoom(guestPage, roomCode, 'Layout Guest');
+    await joinRoom(mobilePage, roomCode, 'Pocket Guest');
+
+    const desktopChrome = hostPage.getByTestId('room-chrome');
+    const mobileChrome = mobilePage.getByTestId('room-chrome');
+
+    await expect(desktopChrome).toBeVisible();
+    await expect(mobileChrome).toBeVisible();
+
+    await expectBelow(
+      desktopChrome,
+      hostPage.getByRole('button', { name: /Start Linejam/i }).first()
+    );
+    await expectBelow(
+      mobileChrome,
+      mobilePage.getByRole('button', { name: /Waiting for Host/i }).first()
+    );
+
+    await hostPage.screenshot({
+      path: testInfo.outputPath('room-chrome-lobby-desktop.png'),
+      fullPage: true,
+    });
+    await mobilePage.screenshot({
+      path: testInfo.outputPath('room-chrome-lobby-mobile.png'),
+      fullPage: true,
+    });
+
+    await hostPage.getByRole('button', { name: /Start Linejam/i }).click();
+
+    await expect(hostPage.getByRole('textbox')).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(mobilePage.getByRole('textbox')).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expectBelow(desktopChrome, hostPage.getByRole('textbox'));
+    await expectBelow(mobileChrome, mobilePage.getByRole('textbox'));
+    await expectStickyAfterScroll(hostPage, desktopChrome);
+    await expectStickyAfterScroll(mobilePage, mobileChrome);
+
+    await hostPage.screenshot({
+      path: testInfo.outputPath('room-chrome-writing-desktop.png'),
+      fullPage: true,
+    });
+    await mobilePage.screenshot({
+      path: testInfo.outputPath('room-chrome-writing-mobile.png'),
+      fullPage: true,
+    });
+  } finally {
+    await hostContext?.close();
+    await guestContext?.close();
+    await mobileContext?.close();
+  }
+});

--- a/tests/lib/roomChromeCopy.test.ts
+++ b/tests/lib/roomChromeCopy.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { WORD_COUNTS } from '@/convex/lib/gameRules';
+import {
+  buildInProgressChromeCopy,
+  buildLobbyChromeCopy,
+  buildRevealChromeCopy,
+} from '@/lib/roomChromeCopy';
+
+describe('roomChromeCopy', () => {
+  it('builds lobby copy while the room still needs players', () => {
+    expect(buildLobbyChromeCopy({ code: 'ABCD', playerCount: 1 })).toEqual({
+      statusLabel: 'Lobby',
+      title: 'Room open',
+      subtitle: 'Share AB CD and gather 1 more poet before the first line.',
+    });
+  });
+
+  it('builds assignment-led in-progress copy using the shared round invariant', () => {
+    expect(
+      buildInProgressChromeCopy({
+        assignment: {
+          lineIndex: 4,
+          targetWordCount: 5,
+        },
+      })
+    ).toEqual({
+      statusLabel: 'In Progress',
+      title: `Round 5 / ${WORD_COUNTS.length}`,
+      subtitle:
+        'Write exactly 5 words. You can only see the line before yours.',
+    });
+  });
+
+  it('builds progress-led in-progress copy when the writer is waiting on the room', () => {
+    expect(
+      buildInProgressChromeCopy({
+        roundProgress: {
+          round: 2,
+          players: [
+            { submitted: true },
+            { submitted: false },
+            { submitted: true },
+          ],
+        },
+      })
+    ).toEqual({
+      statusLabel: 'In Progress',
+      title: `Round 3 / ${WORD_COUNTS.length}`,
+      subtitle:
+        '2 of 3 poets are ready. Hold the cadence while the room catches up.',
+    });
+  });
+
+  it('builds reveal copy for both active reading and completed sessions', () => {
+    expect(buildRevealChromeCopy({ allRevealed: false })).toEqual({
+      statusLabel: 'Reading Phase',
+      title: 'Reveal each poem in turn',
+      subtitle:
+        'One reader at a time. Let the room hear the full poem before moving on.',
+    });
+
+    expect(buildRevealChromeCopy({ allRevealed: true })).toEqual({
+      statusLabel: 'Session Complete',
+      title: 'The poems are unsealed',
+      subtitle:
+        'Return to the lobby, revisit the session, or head to the archive.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace the floating room controls with a full-width sticky room chrome
- move phase-specific chrome copy into shared helpers and render chrome across lobby, writing, waiting, and reveal flows
- add layout/browser regressions plus copy and waiting-override test coverage

## Verification
- ./scripts/ci/dagger-call.sh all
- pnpm vitest run tests/components/WaitingScreen.test.tsx
- pnpm exec playwright test tests/e2e/room-chrome-layout.spec.ts --project=chromium


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added sticky header with room status and session information across all game screens.
  * Auto-scroll to top when assignment changes during writing phase.

* **UI/UX Improvements**
  * Redesigned room chrome with centered status badges, titles, and action controls.
  * Consolidated round and player-ready status into subtitle text.
  * Updated lobby control desk with instructional text instead of room code display.
  * Improved layout spacing and alignment across writing and reveal phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->