### PR TITLE
fix: simplify room chrome copy

### DIFF
--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -6,3 +6,4 @@
 {"date":"2026-04-08","pr":null,"correctness":9,"depth":9,"simplicity":9,"craft":9,"verdict":"ship","providers":["codex","internal-bench"]}
 {"date":"2026-04-08","pr":206,"correctness":9,"depth":9,"simplicity":9,"craft":9,"verdict":"ship","providers":["codex"]}
 {"date":"2026-04-09","pr":null,"correctness":9,"depth":9,"simplicity":8,"craft":9,"verdict":"ship","providers":["codex","internal-bench"]}
+{"date":"2026-04-09","pr":null,"correctness":9,"depth":9,"simplicity":8,"craft":9,"verdict":"ship","providers":["codex","internal-bench","thinktank"]}

--- a/components/Lobby.tsx
+++ b/components/Lobby.tsx
@@ -17,31 +17,8 @@ import { Bot, UserMinus } from 'lucide-react';
 import { trackGameStarted, trackAiPlayerAdded } from '../lib/analytics';
 
 /**
- * Information Architecture: The Split-View Strategy
- *
- * Strategic Design Decision (Ousterhout: Deep Module):
- * This component presents two conceptually distinct zones that reflect
- * the host's mental model during a gathering:
- *
- * 1. "Control Desk" (Static): Room identity + primary action
- *    - Room code (beacon)
- *    - Start button (action)
- *
- * 2. "Guest Registry" (Dynamic): Arrival tracking
- *    - Player list (grows)
- *    - Stamps mark arrivals
- *
- * Why this structure?
- * - Problem: Vertical stacking pushed critical action below fold
- * - Tactical fix: Add sticky positioning
- * - Strategic fix: Restructure information architecture
- *
- * Implementation:
- * - Desktop: Two-column grid (control desk sticky left, registry scrolls right)
- * - Mobile: Single column + sticky footer (native iOS/Android pattern)
- * - Button rendered twice (desktop inline, mobile sticky) - complexity hidden from parent
- *
- * This is a deep module: Simple interface (props), complex responsive layout inside.
+ * Lobby layout keeps actions separate from the live player list.
+ * Room identity and phase status live in RoomChrome above this component.
  */
 
 interface LobbyPlayer extends Doc<'roomPlayers'> {
@@ -173,7 +150,7 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
           >
             {canStart
               ? 'Start Linejam'
-              : `Need ${needsMore} more Poet${needsMore !== 1 ? 's' : ''} to Jam`}
+              : `Need ${needsMore} more player${needsMore === 1 ? '' : 's'}`}
           </Button>
           <Button
             onClick={handleCloseRoom}
@@ -181,7 +158,7 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
             className="w-full"
             variant="ghost"
           >
-            Close Room
+            Close room
           </Button>
         </div>
       );
@@ -195,7 +172,7 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
           className={`w-full h-16 text-lg opacity-50 cursor-not-allowed ${className || ''}`}
           variant="secondary"
         >
-          Waiting for Host...
+          Waiting for host
         </Button>
         <Button
           onClick={handleLeaveLobby}
@@ -203,7 +180,7 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
           className="w-full"
           variant="ghost"
         >
-          Leave Lobby
+          Leave room
         </Button>
       </div>
     );
@@ -212,24 +189,20 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
   return (
     <div className="min-h-screen bg-background p-6 md:p-12">
       <div className="w-full max-w-6xl mx-auto">
-        {/* Split-View Grid: Control Desk (left/sticky) + Guest Registry (right/scroll) */}
         <div className="grid md:grid-cols-[auto_1fr] gap-12 md:gap-24">
-          {/* CONTROL DESK: Room Identity + Primary Action */}
-          <div className="flex flex-col items-center md:items-start space-y-8 md:sticky md:top-12 md:self-start">
+          <div className="flex flex-col items-center md:items-start space-y-8 md:self-start">
             <div className="max-w-md space-y-4 text-center md:text-left">
               <p className="text-xs font-mono uppercase tracking-[0.32em] text-text-muted">
-                Control desk
+                Room actions
               </p>
-              <h2 className="text-4xl md:text-5xl font-[var(--font-display)] leading-none text-text-primary">
-                Let the room fill, then strike the first line.
+              <h2 className="text-2xl md:text-3xl font-[var(--font-display)] leading-tight text-text-primary">
+                Start when everyone is here.
               </h2>
               <p className="text-base leading-relaxed text-text-secondary">
-                Share the code from the room bar, add an AI poet if the circle
-                needs one, and start once everyone is in place.
+                Share the code from the top bar. Add an AI player if needed.
               </p>
             </div>
 
-            {/* Add AI Player Button - Host only */}
             {canAddAi && (
               <Button
                 onClick={handleAddAi}
@@ -239,11 +212,10 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
                 className="w-full"
               >
                 <Bot className="w-4 h-4 mr-2" />
-                {aiLoading ? 'Adding...' : 'Add AI Poet'}
+                {aiLoading ? 'Adding...' : 'Add AI player'}
               </Button>
             )}
 
-            {/* Desktop: Inline Button (visible above fold) */}
             <div className="hidden md:block w-full">
               {error && (
                 <Alert variant="error" className="mb-4">
@@ -254,9 +226,7 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
             </div>
           </div>
 
-          {/* GUEST REGISTRY: Dynamic Arrival Tracking */}
           <div className="relative">
-            {/* Player List - Scrollable */}
             <ul className="space-y-6 pb-24 md:pb-0">
               {players.map((player, i) => (
                 <StampAnimation key={player._id} delay={i * 150}>
@@ -295,7 +265,6 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
               ))}
             </ul>
 
-            {/* Mobile: Sticky Footer (native pattern) */}
             <div className="md:hidden fixed bottom-0 left-0 right-0 p-6 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[0_-8px_32px_rgba(0,0,0,0.1)] dark:shadow-[0_-8px_32px_rgba(0,0,0,0.4)]">
               {error && (
                 <Alert variant="error" className="mb-4">

--- a/components/RoomChrome.tsx
+++ b/components/RoomChrome.tsx
@@ -87,7 +87,7 @@ export function RoomChrome({
     <>
       <HelpModal isOpen={showHelp} onClose={() => setShowHelp(false)} />
 
-      <div className="sticky top-0 z-40 px-4 pt-4 md:px-6">
+      <div className="sticky top-0 z-40 px-4 pt-3 md:px-6">
         <div className="mx-auto flex w-full max-w-7xl flex-col gap-3">
           {shareError && (
             <Alert
@@ -100,9 +100,9 @@ export function RoomChrome({
 
           <div
             data-testid="room-chrome"
-            className="grid gap-4 rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)]/92 px-4 py-4 shadow-[var(--shadow-lg)] backdrop-blur-xl md:grid-cols-[minmax(0,1fr)_auto] md:items-center md:px-6"
+            className="grid gap-3 rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-surface)]/92 px-4 py-3 shadow-[var(--shadow-lg)] backdrop-blur-xl md:grid-cols-[minmax(0,1fr)_auto] md:items-center md:px-6"
           >
-            <div className="min-w-0 space-y-2">
+            <div className="min-w-0 space-y-1.5">
               <div className="flex flex-wrap items-center gap-2">
                 <span className="rounded-full border border-[var(--color-border)] bg-[var(--color-background)]/72 px-3 py-1 text-[11px] font-mono uppercase tracking-[0.32em] text-[var(--color-text-muted)]">
                   Room {formatRoomCode(roomCode)}
@@ -112,11 +112,11 @@ export function RoomChrome({
                 </span>
               </div>
 
-              <div className="space-y-1">
-                <h1 className="truncate text-2xl font-[var(--font-display)] leading-none text-[var(--color-text-primary)] md:text-3xl">
+              <div className="space-y-0.5">
+                <h1 className="truncate text-xl font-[var(--font-display)] font-medium leading-tight text-[var(--color-text-primary)] md:text-2xl">
                   {title}
                 </h1>
-                <p className="max-w-3xl text-sm leading-relaxed text-[var(--color-text-secondary)] md:text-base">
+                <p className="max-w-3xl text-sm leading-relaxed text-[var(--color-text-secondary)]">
                   {subtitle}
                 </p>
               </div>

--- a/lib/roomChromeCopy.ts
+++ b/lib/roomChromeCopy.ts
@@ -28,11 +28,14 @@ export function buildLobbyChromeCopy({
 
   return {
     statusLabel: 'Lobby',
-    title: 'Room open',
+    title:
+      needsMore > 0
+        ? `Need ${needsMore} more player${needsMore === 1 ? '' : 's'}`
+        : `${playerCount} players ready`,
     subtitle:
       needsMore > 0
-        ? `Share ${formatRoomCode(code)} and gather ${needsMore} more poet${needsMore === 1 ? '' : 's'} before the first line.`
-        : `${playerCount} poets are here. Start when the room feels ready.`,
+        ? `Share ${formatRoomCode(code)} to start.`
+        : 'Start when you are ready.',
   };
 }
 
@@ -46,16 +49,16 @@ export function buildInProgressChromeCopy({
   const roundIndex = assignment?.lineIndex ?? roundProgress?.round ?? null;
   const roundNumber = roundIndex === null ? null : roundIndex + 1;
   const roundTitle = roundNumber
-    ? `Round ${roundNumber} / ${WORD_COUNTS.length}`
-    : 'Writing in progress';
+    ? `Round ${roundNumber} of ${WORD_COUNTS.length}`
+    : 'Writing';
 
   if (assignment) {
     const { targetWordCount } = assignment;
 
     return {
-      statusLabel: 'In Progress',
+      statusLabel: 'Writing',
       title: roundTitle,
-      subtitle: `Write exactly ${targetWordCount} word${targetWordCount === 1 ? '' : 's'}. You can only see the line before yours.`,
+      subtitle: `Write exactly ${targetWordCount} word${targetWordCount === 1 ? '' : 's'}. You only see the previous line.`,
     };
   }
 
@@ -65,16 +68,16 @@ export function buildInProgressChromeCopy({
     ).length;
 
     return {
-      statusLabel: 'In Progress',
+      statusLabel: 'Waiting',
       title: roundTitle,
-      subtitle: `${submittedCount} of ${roundProgress.players.length} poets are ready. Hold the cadence while the room catches up.`,
+      subtitle: `${submittedCount} of ${roundProgress.players.length} ready.`,
     };
   }
 
   return {
-    statusLabel: 'In Progress',
-    title: 'Writing in progress',
-    subtitle: 'Keep the room steady while the next prompt resolves.',
+    statusLabel: 'Writing',
+    title: 'Writing',
+    subtitle: 'Loading the next step.',
   };
 }
 
@@ -84,10 +87,10 @@ export function buildRevealChromeCopy({
   allRevealed: boolean;
 }): RoomChromeCopy {
   return {
-    statusLabel: allRevealed ? 'Session Complete' : 'Reading Phase',
-    title: allRevealed ? 'The poems are unsealed' : 'Reveal each poem in turn',
+    statusLabel: allRevealed ? 'Done' : 'Reveal',
+    title: allRevealed ? 'All poems revealed' : 'Reveal poems',
     subtitle: allRevealed
-      ? 'Return to the lobby, revisit the session, or head to the archive.'
-      : 'One reader at a time. Let the room hear the full poem before moving on.',
+      ? 'Start again, open the archive, or leave the room.'
+      : 'Read one poem at a time.',
   };
 }

--- a/tests/app/room-page.test.tsx
+++ b/tests/app/room-page.test.tsx
@@ -213,10 +213,8 @@ describe('RoomPage', () => {
     renderRoomPage();
 
     expect(await screen.findByText(/Room AB CD/i)).toBeInTheDocument();
-    expect(screen.getByText(/room open/i)).toBeInTheDocument();
-    expect(
-      screen.getByText(/share AB CD and gather 1 more poet/i)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/need 1 more player/i)).toBeInTheDocument();
+    expect(screen.getByText(/share AB CD to start/i)).toBeInTheDocument();
   });
 
   it('routes in-progress rooms through the writing phase with shared chrome enabled', async () => {

--- a/tests/components/Lobby.test.tsx
+++ b/tests/components/Lobby.test.tsx
@@ -112,7 +112,7 @@ describe('Lobby component', () => {
     render(<Lobby room={mockRoom} players={mockPlayers} isHost={true} />);
 
     expect(
-      screen.getByText(/let the room fill, then strike the first line/i)
+      screen.getByText(/start when everyone is here/i)
     ).toBeInTheDocument();
   });
 
@@ -135,10 +135,10 @@ describe('Lobby component', () => {
     // Assert - Button should be disabled and show "need more" message
     // Component renders button twice (desktop + mobile), get first one
     const startButtons = screen.getAllByRole('button', {
-      name: /Need .* Poet.*to Jam/i,
+      name: /Need .* player/i,
     });
     expect(startButtons[0]).toBeDisabled();
-    expect(startButtons[0]).toHaveTextContent('Need 1 more Poet to Jam');
+    expect(startButtons[0]).toHaveTextContent('Need 1 more player');
   });
 
   it('Start Game button enabled with ≥2 players', () => {
@@ -200,27 +200,27 @@ describe('Lobby component', () => {
     });
   });
 
-  it('shows "Waiting for Host" button when not host', () => {
+  it('shows "Waiting for host" button when not host', () => {
     // Arrange & Act
     render(<Lobby room={mockRoom} players={mockPlayers} isHost={false} />);
 
     // Assert - Non-host sees waiting message
     // Component renders button twice (desktop + mobile), get first one
     const waitingButtons = screen.getAllByRole('button', {
-      name: /Waiting for Host/i,
+      name: /Waiting for host/i,
     });
     expect(waitingButtons[0]).toBeDisabled();
     expect(waitingButtons[0]).toHaveClass('opacity-50', 'cursor-not-allowed');
   });
 
-  it('Close Room button calls mutation and navigates to home (host)', async () => {
+  it('Close room button calls mutation and navigates to home (host)', async () => {
     // Arrange
     const user = userEvent.setup();
     render(<Lobby room={mockRoom} players={mockPlayers} isHost={true} />);
 
     // Component renders button twice (desktop + mobile), get first one
     const closeButtons = screen.getAllByRole('button', {
-      name: /Close Room/i,
+      name: /Close room/i,
     });
 
     // Act
@@ -236,14 +236,14 @@ describe('Lobby component', () => {
     });
   });
 
-  it('Leave Lobby button calls mutation and navigates to home (guest)', async () => {
+  it('Leave room button calls mutation and navigates to home (guest)', async () => {
     // Arrange
     const user = userEvent.setup();
     render(<Lobby room={mockRoom} players={mockPlayers} isHost={false} />);
 
     // Component renders button twice (desktop + mobile), get first one
     const leaveButtons = screen.getAllByRole('button', {
-      name: /Leave Lobby/i,
+      name: /Leave room/i,
     });
 
     // Act

--- a/tests/components/RoomChrome.test.tsx
+++ b/tests/components/RoomChrome.test.tsx
@@ -88,8 +88,8 @@ describe('RoomChrome component', () => {
       <RoomChrome
         roomCode="ABCD"
         statusLabel="Lobby"
-        title="Room open"
-        subtitle="Share the code and gather the poets."
+        title="Need 1 more player"
+        subtitle="Share the code to start."
       />
     );
   }
@@ -110,7 +110,7 @@ describe('RoomChrome component', () => {
       screen.getByRole('button', { name: /Choose theme/i })
     ).toBeInTheDocument();
     expect(screen.getByText('Room AB CD')).toBeInTheDocument();
-    expect(screen.getByText('Room open')).toBeInTheDocument();
+    expect(screen.getByText('Need 1 more player')).toBeInTheDocument();
   });
 
   it('copies a join link when native share is unavailable', async () => {

--- a/tests/e2e/errors.spec.ts
+++ b/tests/e2e/errors.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, BrowserContext, Page } from '@playwright/test';
+import { WORD_COUNTS } from '@/convex/lib/gameRules';
 
 /**
  * E2E Test: Error Scenarios and Validation
@@ -94,7 +95,9 @@ test.describe('Word Count Validation', () => {
 
     // Host starts game
     await hostPage.click('button:has-text("Start Linejam")');
-    await expect(hostPage.getByText(/Round 1 \/ 9/)).toBeVisible({
+    await expect(
+      hostPage.getByText(new RegExp(`Round 1 of ${WORD_COUNTS.length}`))
+    ).toBeVisible({
       timeout: 15000,
     });
   });

--- a/tests/e2e/game-flow.spec.ts
+++ b/tests/e2e/game-flow.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, BrowserContext, Page } from '@playwright/test';
+import { WORD_COUNTS } from '@/convex/lib/gameRules';
 
 /**
  * E2E Test: Complete Game Flow
@@ -74,7 +75,7 @@ test.describe('Complete Game Flow', () => {
     // Verify we're in the lobby
     await expect(hostPage.getByText('Host Player')).toBeVisible();
     await expect(
-      hostPage.getByRole('button', { name: /Need.*Poet.*to Jam/i })
+      hostPage.getByRole('button', { name: /Need.*player/i })
     ).toBeVisible();
   });
 
@@ -105,9 +106,9 @@ test.describe('Complete Game Flow', () => {
       hostPage.getByRole('button', { name: /Start Linejam/i })
     ).toBeEnabled();
 
-    // Guest sees "Waiting for Host" button
+    // Guest sees "Waiting for host" button
     await expect(
-      guestPage.getByRole('button', { name: /Waiting for Host/i })
+      guestPage.getByRole('button', { name: /Waiting for host/i })
     ).toBeVisible();
   });
 
@@ -115,11 +116,15 @@ test.describe('Complete Game Flow', () => {
     // Host clicks Start Linejam
     await hostPage.click('button:has-text("Start Linejam")');
 
-    // Both players should see Round 1 / 9
-    await expect(hostPage.getByText(/Round 1 \/ 9/)).toBeVisible({
+    // Both players should see the first round
+    await expect(
+      hostPage.getByText(new RegExp(`Round 1 of ${WORD_COUNTS.length}`))
+    ).toBeVisible({
       timeout: 15000,
     });
-    await expect(guestPage.getByText(/Round 1 \/ 9/)).toBeVisible({
+    await expect(
+      guestPage.getByText(new RegExp(`Round 1 of ${WORD_COUNTS.length}`))
+    ).toBeVisible({
       timeout: 15000,
     });
 
@@ -187,10 +192,14 @@ test.describe('Complete Game Flow', () => {
       // Wait for next round or reveal
       if (round < lines.length - 1) {
         await Promise.all([
-          expect(hostPage.getByText(`Round ${round + 2} / 9`)).toBeVisible({
+          expect(
+            hostPage.getByText(`Round ${round + 2} of ${WORD_COUNTS.length}`)
+          ).toBeVisible({
             timeout: 15000,
           }),
-          expect(guestPage.getByText(`Round ${round + 2} / 9`)).toBeVisible({
+          expect(
+            guestPage.getByText(`Round ${round + 2} of ${WORD_COUNTS.length}`)
+          ).toBeVisible({
             timeout: 15000,
           }),
         ]);
@@ -200,10 +209,10 @@ test.describe('Complete Game Flow', () => {
     // After round 9, both should see reveal phase
     await Promise.all([
       expect(
-        hostPage.getByRole('heading', { name: /Reveal each poem in turn/i })
+        hostPage.getByRole('heading', { name: /Reveal poems/i })
       ).toBeVisible({ timeout: 30000 }),
       expect(
-        guestPage.getByRole('heading', { name: /Reveal each poem in turn/i })
+        guestPage.getByRole('heading', { name: /Reveal poems/i })
       ).toBeVisible({ timeout: 30000 }),
     ]);
 
@@ -236,10 +245,10 @@ test.describe('Complete Game Flow', () => {
     // After both reveals, the completed reveal chrome should appear
     await Promise.all([
       expect(
-        hostPage.getByRole('heading', { name: /The poems are unsealed/i })
+        hostPage.getByRole('heading', { name: /All poems revealed/i })
       ).toBeVisible({ timeout: 15000 }),
       expect(
-        guestPage.getByRole('heading', { name: /The poems are unsealed/i })
+        guestPage.getByRole('heading', { name: /All poems revealed/i })
       ).toBeVisible({ timeout: 15000 }),
     ]);
   });

--- a/tests/e2e/prod-smoke.spec.ts
+++ b/tests/e2e/prod-smoke.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Browser, Page } from '@playwright/test';
+import { WORD_COUNTS } from '@/convex/lib/gameRules';
 import {
   ensureClerkAuthState,
   hasClerkBrowserAuth,
@@ -61,10 +62,14 @@ test.describe('Deployment Smoke', () => {
       ).toBeEnabled();
       await hostPage.click('button:has-text("Start Linejam")');
 
-      await expect(hostPage.getByText(/Round 1 \/ 9/)).toBeVisible({
+      await expect(
+        hostPage.getByText(new RegExp(`Round 1 of ${WORD_COUNTS.length}`))
+      ).toBeVisible({
         timeout: 15000,
       });
-      await expect(guestPage.getByText(/Round 1 \/ 9/)).toBeVisible({
+      await expect(
+        guestPage.getByText(new RegExp(`Round 1 of ${WORD_COUNTS.length}`))
+      ).toBeVisible({
         timeout: 15000,
       });
 

--- a/tests/e2e/room-chrome-layout.spec.ts
+++ b/tests/e2e/room-chrome-layout.spec.ts
@@ -104,7 +104,7 @@ test('room chrome does not cover lobby or writing content on desktop and mobile'
     );
     await expectBelow(
       mobileChrome,
-      mobilePage.getByRole('button', { name: /Waiting for Host/i }).first()
+      mobilePage.getByRole('button', { name: /Waiting for host/i }).first()
     );
 
     await hostPage.screenshot({

--- a/tests/lib/roomChromeCopy.test.ts
+++ b/tests/lib/roomChromeCopy.test.ts
@@ -10,8 +10,16 @@ describe('roomChromeCopy', () => {
   it('builds lobby copy while the room still needs players', () => {
     expect(buildLobbyChromeCopy({ code: 'ABCD', playerCount: 1 })).toEqual({
       statusLabel: 'Lobby',
-      title: 'Room open',
-      subtitle: 'Share AB CD and gather 1 more poet before the first line.',
+      title: 'Need 1 more player',
+      subtitle: 'Share AB CD to start.',
+    });
+  });
+
+  it('builds lobby copy when enough players are ready', () => {
+    expect(buildLobbyChromeCopy({ code: 'ABCD', playerCount: 3 })).toEqual({
+      statusLabel: 'Lobby',
+      title: '3 players ready',
+      subtitle: 'Start when you are ready.',
     });
   });
 
@@ -24,10 +32,9 @@ describe('roomChromeCopy', () => {
         },
       })
     ).toEqual({
-      statusLabel: 'In Progress',
-      title: `Round 5 / ${WORD_COUNTS.length}`,
-      subtitle:
-        'Write exactly 5 words. You can only see the line before yours.',
+      statusLabel: 'Writing',
+      title: `Round 5 of ${WORD_COUNTS.length}`,
+      subtitle: 'Write exactly 5 words. You only see the previous line.',
     });
   });
 
@@ -44,26 +51,23 @@ describe('roomChromeCopy', () => {
         },
       })
     ).toEqual({
-      statusLabel: 'In Progress',
-      title: `Round 3 / ${WORD_COUNTS.length}`,
-      subtitle:
-        '2 of 3 poets are ready. Hold the cadence while the room catches up.',
+      statusLabel: 'Waiting',
+      title: `Round 3 of ${WORD_COUNTS.length}`,
+      subtitle: '2 of 3 ready.',
     });
   });
 
   it('builds reveal copy for both active reading and completed sessions', () => {
     expect(buildRevealChromeCopy({ allRevealed: false })).toEqual({
-      statusLabel: 'Reading Phase',
-      title: 'Reveal each poem in turn',
-      subtitle:
-        'One reader at a time. Let the room hear the full poem before moving on.',
+      statusLabel: 'Reveal',
+      title: 'Reveal poems',
+      subtitle: 'Read one poem at a time.',
     });
 
     expect(buildRevealChromeCopy({ allRevealed: true })).toEqual({
-      statusLabel: 'Session Complete',
-      title: 'The poems are unsealed',
-      subtitle:
-        'Return to the lobby, revisit the session, or head to the archive.',
+      statusLabel: 'Done',
+      title: 'All poems revealed',
+      subtitle: 'Start again, open the archive, or leave the room.',
     });
   });
 });


### PR DESCRIPTION
## Summary
- make the shared room chrome copy shorter and less dominant
- simplify the lobby action panel and remove the overlapping sticky layer under the top chrome
- align unit and e2e coverage with the new direct copy and stable round-count expectations

## Verification
- ./scripts/ci/dagger-call.sh all
- pre-push Dagger gate on git push
- pnpm vitest run tests/components/Lobby.test.tsx tests/lib/roomChromeCopy.test.ts tests/components/RoomChrome.test.tsx tests/app/room-page.test.tsx tests/components/WaitingScreen.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Updates**
  * Replaced "Poet" terminology with "player" throughout the interface
  * Refined button labels and messaging for improved clarity
  * Adjusted layout spacing and typography for better visual hierarchy
  * Updated round display format (from "Round X / N" to "Round X of N")
  * Simplified reveal phase instructions and status messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->