### PR TITLE
chore: split dependabot majors into per-package PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,49 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     open-pull-requests-limit: 10
+    # Grouping strategy:
+    #   - minor + patch bumps group into a single PR (low-risk, mechanical).
+    #   - Major bumps open one PR per package so each gets its own behavioral
+    #     diff, reachability analysis, and migration notes. See
+    #     .claude/skills/deps/SKILL.md for the process.
     groups:
       minor-and-patch:
         update-types:
-          - "minor"
-          - "patch"
-      major:
+          - 'minor'
+          - 'patch'
+    # Load-bearing deps that need deliberate human migration instead of a
+    # dependabot PR. Surface their majors via `pnpm outdated` / osv-scanner
+    # and shape a dedicated PR.
+    ignore:
+      - dependency-name: 'next'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'convex'
         update-types:
-          - "major"
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+      - dependency-name: 'convex-test'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+      - dependency-name: '@clerk/nextjs'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@clerk/backend'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'tailwindcss'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@playwright/test'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'


### PR DESCRIPTION
## Summary

- Drop the `major` grouping from `.github/dependabot.yml` so each major bump opens its own PR — per `.claude/skills/deps/SKILL.md` (one `fix(deps):` PR per advisory cluster, one `feat(deps):` PR per major migration).
- Add `ignore` entries for load-bearing deps (Next, React, Convex, Clerk, Tailwind, TypeScript, ESLint, Playwright) so dependabot stops opening bulk-major PRs against them. Their majors still surface via `pnpm outdated` and osv-scanner; the migration lands as a deliberate PR with behavioral diff + reachability analysis.
- Convex and Playwright also ignore **minor** bumps: Convex has mid-semver breaking changes, and Playwright bumps must be paired with `Dockerfile.responder` + `fly.responder.toml` image pins to keep local Dagger and the Fly responder in sync.

## Background

- #207 (8 grouped majors: TS 6, ESLint 10, Clerk 7, lucide-react 1, marked 18, @vercel/analytics 2, @vercel/speed-insights 2, @vitejs/plugin-react 6) — closed as unreviewable; format-check + Vercel both red on the new toolchain, 11 days stale.
- #217 (23 minor+patches) — silent Convex 1.31→1.35 and Playwright 1.58→1.59 hiding inside the bulk bump. Closed for rebase after #218 landed the advisory overrides; wanted Convex/Playwright split out when it regenerates.
- #216 — superseded by #218 directly.

This PR is the structural fix so the same anti-pattern doesn't recur.

## Test plan

- [ ] `pnpm ci:prepush` green locally (Dagger ran on pre-push: 150s, all-no-e2e + e2e ok)
- [ ] `yamllint .github/dependabot.yml` (line-length + doc-start are warnings only; no errors)
- [ ] Next dependabot run opens separate PRs for any pending majors (validation will come on next scheduled run, Monday)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency management by better organizing update strategies. Minor and patch updates are now grouped together for more efficient handling, while major version updates for critical dependencies are handled with additional scrutiny to ensure stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->