### PR TITLE
fix(ci): stop Dependabot from double-stamping commit scopes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,9 +30,12 @@ updates:
     labels:
       - 'dependencies'
       - 'npm'
+    # Dependabot appends the scope automatically when `include: scope` is set,
+    # so `prefix` must NOT already contain parens — otherwise commit subjects
+    # land as `chore(deps)(deps): ...` and trip Conventional Commits validation.
     commit-message:
-      prefix: 'chore(deps)'
-      prefix-development: 'chore(deps-dev)'
+      prefix: 'chore'
+      prefix-development: 'chore'
       include: 'scope'
     groups:
       # Low-risk production bumps — batch review.
@@ -116,7 +119,7 @@ updates:
       - 'npm'
       - 'dagger'
     commit-message:
-      prefix: 'chore(deps)'
+      prefix: 'chore'
       include: 'scope'
     groups:
       dagger-all:
@@ -142,8 +145,11 @@ updates:
     labels:
       - 'dependencies'
       - 'github-actions'
+    # github-actions bumps are workflow/CI changes, but routing them through
+    # `chore(deps)` keeps semantic-release's changelog consistent (all bumps
+    # classify the same way). Override the include:scope to "ci" if needed.
     commit-message:
-      prefix: 'chore(ci)'
+      prefix: 'chore'
       include: 'scope'
     groups:
       gha-all:


### PR DESCRIPTION
## Summary

Three commits landed to master in the previous round with doubled Conventional Commits scopes — `chore(deps)(deps):`, `chore(deps-dev)(deps-dev):`, and `chore(ci)(deps):` (see #229, #230, #231).

**Root cause:** when `include: scope` is set, Dependabot appends `(deps)` / `(deps-dev)` to whatever `prefix` already says. My config's `prefix: 'chore(deps)'` already had parens, so the scope landed twice.

## Changes

- `.github/dependabot.yml`: prefix is just `chore` in every ecosystem block. Scope is provided by `include: scope`.
- Added an explanatory comment above the first `commit-message` block so the trap is documented for future edits.

## Why this matters

- Doubled scopes trip Conventional Commits parsing and risk blocking semantic-release on the next version bump.
- The three already-merged commits stay as-is — rewriting master is off the table — but all future Dependabot commits will land clean.

## Test plan

- [x] `pnpm ci:prepush` green locally (full Dagger contract)
- [ ] Hosted `merge-gate` green
- [ ] Verify next Dependabot PR title uses single-scope form (`chore(deps): ...`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized Dependabot commit message prefixes from feature-specific labels to a uniform `chore` prefix for improved consistency in dependency and workflow tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->