### PR TITLE
chore(convex): regenerate api.d.ts for sessionLifecycle module

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -29,6 +29,7 @@ import type * as lib_gameRules from "../lib/gameRules.js";
 import type * as lib_guestToken from "../lib/guestToken.js";
 import type * as lib_rateLimit from "../lib/rateLimit.js";
 import type * as lib_room from "../lib/room.js";
+import type * as lib_sessionLifecycle from "../lib/sessionLifecycle.js";
 import type * as lib_wordCount from "../lib/wordCount.js";
 import type * as migrations from "../migrations.js";
 import type * as poems from "../poems.js";
@@ -64,6 +65,7 @@ declare const fullApi: ApiFromModules<{
   "lib/guestToken": typeof lib_guestToken;
   "lib/rateLimit": typeof lib_rateLimit;
   "lib/room": typeof lib_room;
+  "lib/sessionLifecycle": typeof lib_sessionLifecycle;
   "lib/wordCount": typeof lib_wordCount;
   migrations: typeof migrations;
   poems: typeof poems;


### PR DESCRIPTION
## Summary

Artifact-sync commit. \`convex/lib/sessionLifecycle.ts\` landed in #213 but the matching auto-generated \`api.d.ts\` surface wasn't committed alongside it, so the module was missing from the typed API tree. Regenerated locally (via \`npx convex dev\`) to close the gap.

No behavioral change — the source module has been shipping since #213.

## Changes

- \`convex/_generated/api.d.ts\`: +2 lines (import + module entry for \`lib/sessionLifecycle\`).

## Test plan

- [x] \`pnpm ci:prepush\` green locally (full Dagger contract)
- [ ] Hosted \`merge-gate\` green