### PR TITLE
feat: add agentic QA harness

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -237,6 +237,21 @@ Do not invent names.
 - Write a new Dagger lane from scratch — that is a design decision; file
   it as a backlog item under `backlog.d/NNN-*.md` with Goal + Oracle.
 
+## Verification Scope
+
+**A green lane only proves the commands that actually ran.**
+
+When a diff adds or materially changes a runtime entrypoint in
+`scripts/**`, `dagger/**`, `package.json` scripts, smoke/canary runners,
+responders, migrations, or other operator-facing executables:
+
+- name the exact command that exercised the path
+- or say explicitly that the runtime path is unverified
+
+Fixture-only tests, helper-unit coverage, and adjacent lanes do **not**
+count as exercising the new entrypoint unless they invoke that exact path.
+Do not report such a change as "fully tested" without that evidence.
+
 ## Anti-patterns (linejam-specific)
 
 - **Running `pnpm vitest` or `pnpm next build` directly when a Dagger
@@ -266,6 +281,10 @@ Do not invent names.
 - **Declaring green while Dagger is still running.** Wait for the exit
   code. The `<LaneName> DONE` marker in stdout is not the final word —
   only the process exit is.
+- **Claiming a new runner or lane was tested when only helper fixtures
+  ran.** Example: `pnpm qa:agentic:critic:fixtures` proves critic
+  fixtures; it does not prove `scripts/qa/agentic-runner.mjs` executed.
+  Name the exact runtime command or mark the path unverified.
 - **Adding a new pre-commit hook instead of a Dagger lane.** Pre-commit
   is intentionally fast (gitleaks + eslint --fix + prettier --write).
   Anything heavier belongs in `pnpm ci:prepush`.

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -176,6 +176,14 @@ Red Dagger never ships. Pushing on red requires `--no-verify`, which is
 forbidden. If a lane is flaky, the fix is the lane or the test, not a
 bypass.
 
+For newly introduced or materially changed runtime entrypoints in
+`scripts/**`, `dagger/**`, `package.json` scripts, smoke/canary runners,
+responders, migrations, or other operator-facing executables, the green
+gate is necessary but not sufficient. The marshal must list the exact
+runtime command that was exercised. If the new entrypoint was not run,
+the review must label it an **unverified runtime path** and the PR stays
+draft.
+
 ## Review Focus By File Type
 
 Tailor reviewer prompts based on which of these surfaces the diff touches.
@@ -321,6 +329,24 @@ routes/components via Playwright (`pnpm test:e2e` or
 **Skip:** pure Convex refactors with no schema changes, config-only,
 test-only, `dagger/**` internals, `scripts/**` with no user-facing
 surface, `docs/**`.
+
+## Executable Path Verification
+
+**Trigger:** the diff adds or materially changes an entrypoint in
+`scripts/**`, `dagger/**`, `package.json` scripts, smoke/canary runners,
+responders, migrations, or other operator-facing executables.
+
+**Rule:** the marshal or a reviewer must either:
+
+- run the exact entrypoint once
+- or cite an artifact-producing lane that invokes that exact path
+
+Helper tests, fixture-only critics, and adjacent lanes do not count.
+
+**Verdict:** if the new entrypoint was not exercised, this is a blocking
+finding for "ready to ship". The PR may exist for review, but it stays
+draft until the runtime path is exercised or the diff is reframed as
+scaffolding only.
 
 ## Plausible-but-Wrong Patterns (linejam flavor)
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,9 @@ next-env.d.ts
 /test-results/
 /playwright-report/
 /playwright/.cache/
+.qa/
 .canary/
+.claims/
 .evidence/
 .worktrees
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,13 @@ Hosted workflows:
 
 Local Dagger is authoritative. Hosted CI is secondary confirmation.
 
+Adjacent green evidence is not runtime proof. For any newly added or
+materially changed executable path in `scripts/`, `dagger/`, package
+scripts, smoke/canary responders, migrations, or other operator-facing
+entrypoints, name the exact command or artifact that exercised it, or mark
+the path unverified. Do not call a path "tested" or a PR "ready" on helper
+coverage or neighboring lanes alone.
+
 ## Known-Debt Map
 
 | Debt                                               | Pointer                                                                                      | Tracker                                                   |

--- a/backlog.d/_done/007-establish-stagehand-agentic-qa-harness.md
+++ b/backlog.d/_done/007-establish-stagehand-agentic-qa-harness.md
@@ -1,7 +1,7 @@
 # Establish Stagehand Agentic QA Harness
 
 Priority: high
-Status: ready
+Status: done
 Estimate: L
 
 ## Goal
@@ -120,3 +120,19 @@ Choose approach 1. Linejam already has a strong deterministic spine and a live C
   2. preview/manual
   3. scheduled preview
   4. production post-deploy advisory
+
+## What Was Built
+
+- Added `qa/agentic/` mission, manifest, deterministic critic, and Promptfoo advisory config for the first two room-flow missions.
+- Added `scripts/qa/agentic-runner.mjs` to run local/preview missions with Playwright contexts, Clerk auth guardrails, Stagehand page actions, screenshots, manifest output, and separate critic artifacts.
+- Added `LINEJAM_SMOKE_RUNNER=agentic` so Canary follow-up can produce agentic QA evidence without changing the default deterministic smoke path.
+- Added `pnpm ci:dagger:agentic-qa` and `pnpm ci:dagger:agentic-qa-preview` as explicit non-gating Dagger advisory lanes.
+
+## Verification
+
+- `pnpm test --run tests/scripts/agentic-qa.test.ts tests/scripts/canary-trigger-smoke.test.ts tests/scripts/canary-store.test.ts tests/scripts/dagger-call.test.ts`
+- `pnpm qa:agentic:critic:fixtures`
+- `pnpm typecheck`
+- `pnpm format:check`
+- `pnpm lint`
+- `pnpm ci:dagger:agentic-qa`

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -445,6 +445,90 @@ export class Ci {
   }
 
   @func()
+  async agenticQa(
+    source: Directory,
+    nextPublicConvexUrl?: string,
+    nextPublicClerkPublishableKey?: string,
+    clerkSecretKey?: Secret,
+    clerkJwtIssuerDomain?: string,
+    playwrightClerkTestEmail?: string,
+    guestTokenSecret?: Secret,
+    canaryEndpoint?: string,
+    canaryApiKey?: Secret,
+    nextPublicCanaryEndpoint?: string,
+    nextPublicCanaryApiKey?: string
+  ): Promise<string> {
+    return baseContainer(
+      source,
+      {
+        nextPublicConvexUrl,
+        nextPublicClerkPublishableKey,
+        clerkSecretKey,
+        clerkJwtIssuerDomain,
+        playwrightClerkTestEmail,
+        guestTokenSecret,
+        canaryEndpoint,
+        canaryApiKey,
+        nextPublicCanaryEndpoint,
+        nextPublicCanaryApiKey,
+      },
+      PLAYWRIGHT_IMAGE,
+      'linejam-pnpm-playwright'
+    )
+      .withExec(['pnpm', 'qa:agentic:critic:fixtures'])
+      .stdout();
+  }
+
+  @func()
+  async agenticQaPreview(
+    source: Directory,
+    baseUrl: string,
+    mission?: string,
+    nextPublicConvexUrl?: string,
+    nextPublicClerkPublishableKey?: string,
+    clerkSecretKey?: Secret,
+    clerkJwtIssuerDomain?: string,
+    playwrightClerkTestEmail?: string,
+    guestTokenSecret?: Secret,
+    canaryEndpoint?: string,
+    canaryApiKey?: Secret,
+    nextPublicCanaryEndpoint?: string,
+    nextPublicCanaryApiKey?: string
+  ): Promise<string> {
+    return withOptionalEnv(
+      withOptionalEnv(
+        withOptionalEnv(
+          baseContainer(
+            source,
+            {
+              nextPublicConvexUrl,
+              nextPublicClerkPublishableKey,
+              clerkSecretKey,
+              clerkJwtIssuerDomain,
+              playwrightClerkTestEmail,
+              guestTokenSecret,
+              canaryEndpoint,
+              canaryApiKey,
+              nextPublicCanaryEndpoint,
+              nextPublicCanaryApiKey,
+            },
+            PLAYWRIGHT_IMAGE,
+            'linejam-pnpm-playwright'
+          ),
+          'PLAYWRIGHT_BASE_URL',
+          baseUrl
+        ),
+        'LINEJAM_AGENTIC_MISSION',
+        mission
+      ),
+      'LINEJAM_AGENTIC_MODE',
+      'deterministic'
+    )
+      .withExec(['pnpm', 'qa:agentic:preview'])
+      .stdout();
+  }
+
+  @func()
   async allNoE2e(
     source: Directory,
     nextPublicConvexUrl?: string,

--- a/docs/ops/canary-responder.md
+++ b/docs/ops/canary-responder.md
@@ -25,7 +25,11 @@ Optional:
 - `CANARY_SMOKE_MAX_IN_FLIGHT` defaults to `2`
 - `CANARY_SMOKE_MAX_PENDING` defaults to `20`
 - `CANARY_SMOKE_TIMEOUT_MS` defaults to `600000`
-- `LINEJAM_SMOKE_RUNNER=dagger|playwright` defaults to `dagger`; use `playwright` for hosted responders so the worker can execute the smoke suite without embedding Dagger
+- `LINEJAM_SMOKE_RUNNER=dagger|playwright|agentic` defaults to `dagger`; use `playwright` for hosted responders so the worker can execute the smoke suite without embedding Dagger, or `agentic` when Canary should attach an agentic QA artifact bundle
+- `LINEJAM_AGENTIC_MISSION` selects the agentic mission when `LINEJAM_SMOKE_RUNNER=agentic`
+- `LINEJAM_AGENTIC_OUT_DIR` can pin the artifact directory; otherwise Canary agentic runs write under `.canary/agentic/<delivery-id>`
+- `LINEJAM_AGENTIC_MODE=deterministic` skips Stagehand actions for harness debugging only
+- `LINEJAM_STAGEHAND_MODEL` selects the Stagehand model
 - `LINEJAM_CANARY_CONTEXT_TIMEOUT_MS` defaults to `5000`
 - `LINEJAM_CANARY_RETENTION_DAYS` defaults to `14`
 - `LINEJAM_CANARY_PRUNE_INTERVAL_MS` defaults to `3600000`
@@ -80,10 +84,21 @@ For the shared automation event set, the responder triggers:
 ```bash
 pnpm ci:dagger:smoke   # local authoritative contract
 pnpm test:e2e:smoke    # hosted responders with LINEJAM_SMOKE_RUNNER=playwright
+pnpm qa:agentic:preview # artifact bundle with LINEJAM_SMOKE_RUNNER=agentic
 ```
 
 This uses `PLAYWRIGHT_BASE_URL` plus the dedicated `playwright.smoke.config.ts` configuration. When `CLERK_SECRET_KEY` and `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` are set, the smoke suite also exercises a signed-in Clerk join path; `PLAYWRIGHT_CLERK_TEST_EMAIL` only overrides the default smoke user, and live Clerk tenants should point it at a precreated account. Set `PLAYWRIGHT_REQUIRE_AUTH_SMOKE=1` anywhere auth coverage is mandatory, including preview and production smoke jobs.
 
 Local operators should keep the authoritative Dagger contract by leaving `LINEJAM_SMOKE_RUNNER=dagger`. Hosted responders should switch to `LINEJAM_SMOKE_RUNNER=playwright`; the same smoke suite runs directly with Playwright and avoids trying to embed Dagger inside the webhook worker. Hosted smoke still enforces the URL allowlist, rejects `pk_test_...` and `sk_test_...` keys against `https://www.linejam.app`, requires complete Clerk auth env when auth smoke is enabled, and validates the Clerk `convex` JWT template before it launches the browser. The committed Fly deployment files are [`Dockerfile.responder`](../../Dockerfile.responder) and [`fly.responder.toml`](../../fly.responder.toml).
+
+Use `LINEJAM_SMOKE_RUNNER=agentic` when the follow-up should produce the
+agentic QA bundle instead of only deterministic smoke output. This mode still
+receives `PLAYWRIGHT_BASE_URL` from the responder, writes `manifest.json`,
+screenshots, `critic-result.json`, and `critic-summary.md`, and returns non-zero
+when the separate critic finds generic error UI, missing required screenshots,
+failed checks, or runtime browser errors. Unless `LINEJAM_AGENTIC_OUT_DIR` is
+set explicitly, artifacts land under `.canary/agentic/<delivery-id>` and are
+pruned with the responder retention window. Keep this mode advisory until its
+false-positive rate is known.
 
 Canary itself treats generic signed webhooks as the stable product contract, so the responder should stay thin: verify, fetch context, store evidence, trigger the smoke harness, then hand off to follow-on agents.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,6 +14,10 @@ pnpm test:e2e:smoke # Remote preview/prod smoke
 pnpm test:e2e:evidence # Run the tagged evidence capture spec
 pnpm test:e2e:ui   # Playwright UI mode
 pnpm evidence:guest-flow # Package screenshots, video, GIF, and summary
+pnpm qa:agentic:local --mission guest-host-signed-in-join
+pnpm qa:agentic:preview --mission signed-in-host-guest-join --base-url https://<preview-url>
+pnpm ci:dagger:agentic-qa # Advisory critic fixtures; not part of ci:prepush
+pnpm ci:dagger:agentic-qa-preview # Advisory preview run when PLAYWRIGHT_BASE_URL is set
 ```
 
 ## Test Structure
@@ -218,6 +222,51 @@ pnpm evidence:guest-flow
 - `pnpm test:e2e` excludes the `@evidence` suite so merge-gating stays deterministic.
 - `pnpm evidence:guest-flow` runs the canonical guest flow, then writes screenshots, `guest-flow.webm`, `guest-flow.gif`, `qa-summary.md`, and `manifest.json`.
 - When local Convex/Clerk wiring is unavailable, point the evidence run at a deployed target with `LINEJAM_BASE_URL=https://www.linejam.app`.
+
+### Agentic QA
+
+The advisory agentic lane runs named browser missions and writes a stable
+artifact bundle for follow-on critique. It does not replace `pnpm ci:prepush`
+and is not merge-gating yet.
+
+```bash
+pnpm qa:agentic:local --mission guest-host-signed-in-join
+pnpm qa:agentic:local --mission signed-in-host-guest-join
+pnpm qa:agentic:preview --mission guest-host-signed-in-join --base-url https://<preview-url>
+pnpm qa:agentic:critic:fixtures
+```
+
+Artifacts land in `.qa/runs/<run-id>/` by default:
+
+- `manifest.json` with mission metadata, checks, observations, runtime errors, screenshots, and transcript
+- `critic-result.json` with the deterministic separate-critic verdict
+- `critic-summary.md` for human review
+- mission screenshots referenced by `manifest.json`
+
+`guest-host-signed-in-join` and `signed-in-host-guest-join` both require Clerk
+browser auth: set `CLERK_SECRET_KEY` plus either
+`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` or `CLERK_PUBLISHABLE_KEY`. Live Clerk
+tenants still fail closed on smoke-user auto-provisioning; set
+`PLAYWRIGHT_CLERK_TEST_EMAIL` to a precreated live smoke account.
+
+Stagehand drives page actions by default. Set `OPENAI_API_KEY` or another
+Stagehand-supported provider key before running the browser mission, and use
+`LINEJAM_STAGEHAND_MODEL` to override the default model. For harness debugging
+only, `LINEJAM_AGENTIC_MODE=deterministic` skips Stagehand actions while keeping
+the same manifest and critic contract.
+
+Promptfoo is advisory on top of the deterministic critic:
+
+```bash
+pnpm qa:agentic:promptfoo --var manifest="$(cat .qa/runs/<run-id>/manifest.json)"
+```
+
+The default Dagger advisory lane only runs `pnpm qa:agentic:critic:fixtures`.
+`pnpm ci:dagger:agentic-qa-preview` is the explicit preview lane; it preserves
+the smoke URL allowlist guardrails and sets
+`LINEJAM_AGENTIC_MODE=deterministic` inside Dagger so the lane is runnable
+without LLM provider secrets. Use `pnpm qa:agentic:preview` directly when you
+want Stagehand-backed actions.
 
 ## Coverage
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,14 @@
     "test:e2e:smoke": "playwright test --config=playwright.smoke.config.ts",
     "test:e2e:evidence": "playwright test tests/e2e/guest-flow.evidence.spec.ts --project=chromium --workers=1 --retries=0 --reporter=line",
     "test:e2e:ui": "playwright test --ui --grep-invert @evidence",
+    "qa:agentic:local": "node scripts/qa/agentic-runner.mjs --target local",
+    "qa:agentic:preview": "node scripts/qa/agentic-runner.mjs --target preview",
+    "qa:agentic:critic:fixtures": "node scripts/qa/agentic-critic-fixtures.mjs",
+    "qa:agentic:promptfoo": "pnpm dlx promptfoo@0.121.7 eval -c qa/agentic/promptfoo.config.yaml",
     "ci:dagger:all": "./scripts/ci/dagger-call.sh all",
     "ci:dagger:all-no-e2e": "./scripts/ci/dagger-call.sh all-no-e2e",
+    "ci:dagger:agentic-qa": "./scripts/ci/dagger-call.sh agentic-qa",
+    "ci:dagger:agentic-qa-preview": "./scripts/ci/dagger-call.sh agentic-qa-preview",
     "ci:dagger:audit": "./scripts/ci/dagger-call.sh audit",
     "ci:dagger:build-check": "./scripts/ci/dagger-call.sh build-check",
     "ci:dagger:e2e": "./scripts/ci/dagger-call.sh e2e",
@@ -65,6 +71,7 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@browserbasehq/stagehand": "3.2.1",
     "@clerk/backend": "^3.2.13",
     "@clerk/testing": "^2.0.17",
     "@commitlint/cli": "^20.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0
     devDependencies:
+      '@browserbasehq/stagehand':
+        specifier: 3.2.1
+        version: 3.2.1(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(deepmerge@4.3.1)(zod@4.3.6)
       '@clerk/backend':
         specifier: ^3.2.13
         version: 3.2.13(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -140,7 +143,7 @@ importers:
         version: 16.2.4(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       happy-dom:
         specifier: ^20.9.0
-        version: 20.9.0
+        version: 20.9.0(bufferutil@4.1.0)
       lefthook:
         specifier: ^2.1.6
         version: 2.1.6
@@ -161,7 +164,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
+        version: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0(bufferutil@4.1.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
 
 packages:
 
@@ -180,9 +183,123 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
+  '@ai-sdk/amazon-bedrock@3.0.97':
+    resolution: {integrity: sha512-EUkR9ovQQY9dHVo67bchi9Qa+05FlSee6hTNZ6X1Rz1SJQKIIR2jt9rN7glRTvrYd+70zU7Xl993RKE3JtqT9w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/anthropic@2.0.77':
+    resolution: {integrity: sha512-8n7ApEzFOxqVvT3HyqLrEQlgUx/2nUmPFLTGY3fNKwUA8KVNU3Ovd2C66Qh1Y93Iq5NkHsOWuLiTyAZpRKQhgw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/azure@2.0.105':
+    resolution: {integrity: sha512-pdYOtsFNJvNARbNxHORBIS6gwvU6yHdmgB3ZAzGdt89TiVtWiO1/quJeJ7Y3KUVLbjdpbVsTAWlL/J70XQxV5A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/cerebras@1.0.41':
+    resolution: {integrity: sha512-UeBaOMXOcfkzHZE8TfbWRe9OMDkwB1NpHe837A+mRGWFabgdpJFTDnNrqCQVc3kGdDVhYBiDFh0lOEd8QRwJHQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/deepseek@1.0.37':
+    resolution: {integrity: sha512-GXSsA1wz0r9LdtEa7uxSB3ynaLHzKP7WmExrl5v5QgNVCmjmv/P4RhEMa1T6JFVdqG2sK1Nud/VWJ38LlnxkGg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@2.0.82':
+    resolution: {integrity: sha512-vtoCSEBGPcxzChI3eqe9C9AJSlc/WUZp92tzpOqVd4B6Tnu4583S+qR7TknB0tPta15TEoOIkK0ENW6D/DgRJQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google-vertex@3.0.132':
+    resolution: {integrity: sha512-IZfAutGNrHPk7VsziwtBVsNBnXTS2y5qZpI1tT9MdN+O6z0UFv6LVBDIpAFAZcQOec9M22j+5uc4ukB6BfC/0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google@2.0.70':
+    resolution: {integrity: sha512-NDMTvMo6vnPHDTA94FBOh3YMv0lxWDohYmFSGYhg0IimHMcOcC1ZV7E2KMLjzHOz5S7uasTITW7V3X5T+ozInQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/groq@2.0.38':
+    resolution: {integrity: sha512-qw6OB9RTYy1JO1//FK/bE4o12sl6s6uff7+C2L0AlskRbqOw0oWNh1FjeQU9bqHdObL5P6/UU1Cnq0FcQ7OT3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/mistral@2.0.31':
+    resolution: {integrity: sha512-ii+06f4Vzt3OH7/FNCj/QVms65VaZxqfat9GvMZ03ZdxlhO8yWzw83j3OqgdQ8pRL5qkABNepf06YUwfeNz6XQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@1.0.36':
+    resolution: {integrity: sha512-ePJ1nj1Wv2QcG9m8zA3zT20WBInFqEfwV17KT0JBeRyQucmiJBwIhzLkOq95O0sBwUutJJJrQNG8pEYxGf6w3w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@2.0.103':
+    resolution: {integrity: sha512-FDwY060LV/D5th+LeaxpSKcot5eXjzNzHguDf0NU1K+v7rxYZFWbldQPZarNo/IpD/WJE9RojgrFAcZ1e8KyvQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/perplexity@2.0.28':
+    resolution: {integrity: sha512-6KUdU+ccJEX+Y9xx8wKjEXIrELZINZg6NiZf2w9ZCcd96hC+8hkcq9TC4g3PDbtoA51ITfYXqwOer7UOx1nrZg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@3.0.23':
+    resolution: {integrity: sha512-60GYsRj5wIJQRcq5YwYJq4KhwLeStceXEJiZdecP1miiH+6FMmrnc7lZDOJoQ6m9lrudEb+uI4LEwddLz5+rPQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@2.0.1':
+    resolution: {integrity: sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/togetherai@1.0.39':
+    resolution: {integrity: sha512-RUKl8FD8WVnEHV//HnsNcV9r6lQGdfjYF2ypMON3eZZja2cGKdk/qrJnX9KBApkPjVmm2AiB1YBgkuVDWv8WTg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/xai@2.0.68':
+    resolution: {integrity: sha512-LqjizlypsbFcjVS/0BqGCPgvz4V5MaWCk+H7Tj7bZFQ1Ca8hby2Q0wGJ6u1ypR4Z8rRLHmfyrZ0mAEm/vd/d/A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/sdk@0.39.0':
+    resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -278,6 +395,19 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@browserbasehq/sdk@2.10.0':
+    resolution: {integrity: sha512-pOL4yW8P8AI2+N5y6zEP6XXKqIXtYyKunr1JXppqQDOyKLxxvZEDqQCHJXWUzqgx3R1tGWpn7m9AjXN7MeYInA==}
+
+  '@browserbasehq/stagehand@3.2.1':
+    resolution: {integrity: sha512-h7KAAaNK7JUMw97w7sj0CBsBVtjLXyEorbUoYmCwLYYWrL2IUd9WFS7gRFspCp0ww2hpVPJEKMxHumwFCPEC8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      deepmerge: ^4.3.1
+      zod: ^3.25.76 || ^4.2.0
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
   '@clerk/backend@2.33.2':
     resolution: {integrity: sha512-5nNPTdSLCTt7yVvMdd5CoEYZXVQhA9i0C50PxmAOjApYDIEfASedP9KXRb+YARiDrOSHQg0qFJhWUnujaG3hpw==}
@@ -794,6 +924,21 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@google/genai@1.50.1':
+    resolution: {integrity: sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -970,6 +1115,26 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@langchain/core@0.3.80':
+    resolution: {integrity: sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==}
+    engines: {node: '>=18'}
+
+  '@langchain/openai@0.4.9':
+    resolution: {integrity: sha512-NAsaionRHNdqaMjVLPkFCyjUDze+OqRHghA1Cn4fPoAafz+FXcl9c7LlEl9Xo0FH6/8yiCl7Rw2t780C/SBVxQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.3.39 <0.4.0'
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -1095,6 +1260,10 @@ packages:
     resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
@@ -1163,6 +1332,9 @@ packages:
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
     engines: {node: '>=18'}
@@ -1215,6 +1387,11 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@puppeteer/browsers@2.3.0':
+    resolution: {integrity: sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -1416,6 +1593,42 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@smithy/eventstream-codec@4.2.14':
+    resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -1545,6 +1758,9 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -1582,6 +1798,12 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
@@ -1596,14 +1818,23 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@8.59.0':
     resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
@@ -1788,6 +2019,10 @@ packages:
       vue-router:
         optional: true
 
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
   '@vercel/speed-insights@2.0.0':
     resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
     peerDependencies:
@@ -1858,6 +2093,14 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -1877,6 +2120,10 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
@@ -1884,6 +2131,20 @@ packages:
   aggregate-error@5.0.0:
     resolution: {integrity: sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==}
     engines: {node: '>=18'}
+
+  ai@5.0.179:
+    resolution: {integrity: sha512-tuq/r2FH/pBuY3jo0yHF3UglDV73WONGLhW80DuwgO6w0ftPIqRsAm5p9cE3Bu4LfEuCkMXpiUG/pQRzqKRRaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -1977,6 +2238,10 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
@@ -1984,9 +2249,19 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  aws4fetch@1.0.20:
+    resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
 
   axe-core@4.11.3:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
@@ -1996,17 +2271,80 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  b4a@1.8.0:
+    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.0:
+    resolution: {integrity: sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.0:
+    resolution: {integrity: sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.2:
+    resolution: {integrity: sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   baseline-browser-mapping@2.10.20:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  basic-ftp@5.3.0:
+    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
+    engines: {node: '>=10.0.0'}
+
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
 
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
@@ -2024,8 +2362,25 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2046,6 +2401,10 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
 
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
@@ -2069,6 +2428,16 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  chrome-launcher@1.2.1:
+    resolution: {integrity: sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+
+  chromium-bidi@0.6.3:
+    resolution: {integrity: sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==}
+    peerDependencies:
+      devtools-protocol: '*'
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
@@ -2121,6 +2490,13 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -2129,6 +2505,17 @@ packages:
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
+  console-table-printer@2.15.0:
+    resolution: {integrity: sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
 
   conventional-changelog-angular@8.1.0:
     resolution: {integrity: sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==}
@@ -2189,11 +2576,23 @@ packages:
       react:
         optional: true
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig-typescript-loader@6.3.0:
     resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
@@ -2245,6 +2644,14 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -2256,6 +2663,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -2274,12 +2684,20 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -2289,6 +2707,18 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -2296,6 +2726,12 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devtools-protocol@0.0.1312386:
+    resolution: {integrity: sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==}
+
+  devtools-protocol@0.0.1464554:
+    resolution: {integrity: sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -2329,6 +2765,12 @@ packages:
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.341:
     resolution: {integrity: sha512-1sZTssferjgDgaqRTc0ieP+ozzpOy7LQTPTtEW3yQFn4+ORdIAZWV5BthXPyHF7YqLvFJCUPhNhdAJQYlYUgiw==}
 
@@ -2343,6 +2785,13 @@ packages:
 
   emojilib@2.4.0:
     resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -2420,6 +2869,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -2431,6 +2883,11 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
 
   eslint-config-next@16.2.4:
     resolution: {integrity: sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg==}
@@ -2536,6 +2993,11 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -2555,6 +3017,28 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -2571,11 +3055,35 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@8.4.0:
+    resolution: {integrity: sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
+  fast-copy@4.0.3:
+    resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -2587,6 +3095,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
@@ -2596,6 +3107,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2604,6 +3118,13 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
+  fetch-cookie@3.2.0:
+    resolution: {integrity: sha512-n61pQIxP25C6DRhcJxn7BDzgHP/+S56Urowb5WFxtcRMpU6drqXD90xjyAsVQYsNSNNVbaCcYY1DuHsdkZLuiA==}
 
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
@@ -2623,6 +3144,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
@@ -2650,6 +3175,29 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   from2@2.3.0:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
@@ -2682,6 +3230,14 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -2706,6 +3262,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -2728,6 +3288,10 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
 
   git-log-parser@1.2.1:
     resolution: {integrity: sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==}
@@ -2763,6 +3327,14 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2814,6 +3386,9 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
@@ -2822,6 +3397,10 @@ packages:
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+    engines: {node: '>=16.9.0'}
 
   hook-std@4.0.0:
     resolution: {integrity: sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==}
@@ -2840,6 +3419,10 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -2860,6 +3443,16 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2918,6 +3511,14 @@ packages:
     resolution: {integrity: sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==}
     engines: {node: '>=12'}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -2955,6 +3556,11 @@ packages:
   is-date-object@1.1.0:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2999,6 +3605,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -3052,6 +3661,10 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
@@ -3089,9 +3702,19 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
+
+  js-tiktoken@1.0.21:
+    resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -3108,6 +3731,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -3122,6 +3748,12 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -3142,8 +3774,31 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  langsmith@0.3.87:
+    resolution: {integrity: sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==}
+    peerDependencies:
+      '@opentelemetry/api': '*'
+      '@opentelemetry/exporter-trace-otlp-proto': '*'
+      '@opentelemetry/sdk-trace-base': '*'
+      openai: '*'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-proto':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      openai:
+        optional: true
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -3209,6 +3864,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lighthouse-logger@2.0.2:
+    resolution: {integrity: sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -3354,6 +4012,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
   lucide-react@1.8.0:
     resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
     peerDependencies:
@@ -3388,9 +4050,16 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  marky@1.3.0:
+    resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
 
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -3398,6 +4067,10 @@ packages:
 
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
   merge-stream@2.0.0:
@@ -3410,6 +4083,22 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@4.1.0:
     resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
@@ -3435,11 +4124,18 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -3457,11 +4153,19 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   nerf-dart@1.0.0:
     resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
+
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
 
   next@16.2.4:
     resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
@@ -3487,6 +4191,11 @@ packages:
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
@@ -3494,6 +4203,23 @@ packages:
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
@@ -3637,6 +4363,23 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  ollama-ai-provider-v2@1.5.5:
+    resolution: {integrity: sha512-1YwTFdPjhPNHny/DrOHO+s8oVGGIE5Jib61/KnnjPRNWQhVVimrJJdaAX3e6nNRRDXrY5zbb9cfm2+yVvgsrqw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^4.0.16
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
@@ -3644,6 +4387,18 @@ packages:
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
+
+  openai@4.104.0:
+    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3664,6 +4419,10 @@ packages:
   p-filter@4.1.0:
     resolution: {integrity: sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==}
     engines: {node: '>=18'}
+
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
 
   p-is-promise@3.0.0:
     resolution: {integrity: sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==}
@@ -3689,6 +4448,10 @@ packages:
     resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
     engines: {node: '>=18'}
 
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
   p-reduce@2.1.0:
     resolution: {integrity: sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==}
     engines: {node: '>=8'}
@@ -3697,6 +4460,14 @@ packages:
     resolution: {integrity: sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==}
     engines: {node: '>=12'}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+
   p-timeout@6.1.4:
     resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
     engines: {node: '>=14.16'}
@@ -3704,6 +4475,14 @@ packages:
   p-try@1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
     engines: {node: '>=4'}
+
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -3734,6 +4513,15 @@ packages:
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  patchright-core@1.59.4:
+    resolution: {integrity: sha512-7/vyX0XK0cpGKlcnUD+Rhjv5o9rrmZQl4v/NI+EUBed+VaU5EORpkOF0Gdi+fP698fLhY0tXwacKBUqKE38jQA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
     engines: {node: '>=4'}
@@ -3757,6 +4545,9 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   path-type@3.0.0:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
     engines: {node: '>=4'}
@@ -3767,6 +4558,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3783,6 +4577,27 @@ packages:
   pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
+
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    hasBin: true
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
@@ -3836,6 +4651,13 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3846,15 +4668,48 @@ packages:
     resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  puppeteer-core@22.15.0:
+    resolution: {integrity: sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==}
+    engines: {node: '>=18'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
 
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -3901,6 +4756,10 @@ packages:
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -3951,6 +4810,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -3959,6 +4822,10 @@ packages:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3982,8 +4849,18 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semantic-release@25.0.3:
     resolution: {integrity: sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==}
@@ -4012,8 +4889,19 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -4026,6 +4914,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -4081,9 +4972,27 @@ packages:
     resolution: {integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==}
     engines: {node: '>=6'}
 
+  simple-wcswidth@1.1.2:
+    resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
+
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4114,6 +5023,10 @@ packages:
   split2@1.0.0:
     resolution: {integrity: sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==}
 
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -4122,6 +5035,10 @@ packages:
 
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -4135,6 +5052,9 @@ packages:
 
   stream-combiner2@1.1.1:
     resolution: {integrity: sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==}
+
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -4210,6 +5130,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -4262,6 +5186,15 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
+  tar-stream@3.1.8:
+    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
   temp-dir@3.0.0:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
     engines: {node: '>=14.16'}
@@ -4275,6 +5208,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -4282,8 +5218,14 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   time-span@5.1.0:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
@@ -4308,9 +5250,27 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   traverse@0.6.8:
     resolution: {integrity: sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==}
@@ -4352,6 +5312,10 @@ packages:
     resolution: {integrity: sha512-xygQcmneDyzsEuKZrFbRMne5HDqMs++aFzefrJTgEIKjQ3rekM+RPfFCVq2Gp1VIDqddoYeppCj4Pcb+RZW0GQ==}
     engines: {node: '>=20'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -4389,6 +5353,12 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  unbzip2-stream@1.4.3:
+    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
@@ -4419,6 +5389,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -4435,6 +5409,9 @@ packages:
     resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  urlpattern-polyfill@10.0.0:
+    resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
+
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -4443,8 +5420,20 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
@@ -4527,15 +5516,29 @@ packages:
       jsdom:
         optional: true
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
   web-vitals@5.2.0:
     resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
   web-worker@1.2.0:
     resolution: {integrity: sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -4586,6 +5589,9 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -4633,6 +5639,9 @@ packages:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -4641,11 +5650,22 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -4670,7 +5690,169 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@ai-sdk/amazon-bedrock@3.0.97(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/anthropic': 2.0.77(zod@4.3.6)
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/util-utf8': 4.2.2
+      aws4fetch: 1.0.20
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/anthropic@2.0.77(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/azure@2.0.105(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/openai': 2.0.103(zod@4.3.6)
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/cerebras@1.0.41(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/openai-compatible': 1.0.36(zod@4.3.6)
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/deepseek@1.0.37(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/gateway@2.0.82(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      '@vercel/oidc': 3.1.0
+      zod: 4.3.6
+
+  '@ai-sdk/google-vertex@3.0.132(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/anthropic': 2.0.77(zod@4.3.6)
+      '@ai-sdk/google': 2.0.70(zod@4.3.6)
+      '@ai-sdk/openai-compatible': 1.0.36(zod@4.3.6)
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      google-auth-library: 10.6.2
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@ai-sdk/google@2.0.70(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/groq@2.0.38(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/mistral@2.0.31(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/openai-compatible@1.0.36(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/openai@2.0.103(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/perplexity@2.0.28(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/provider-utils@3.0.23(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.3.6
+
+  '@ai-sdk/provider@2.0.1':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/togetherai@1.0.39(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/openai-compatible': 1.0.36(zod@4.3.6)
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/xai@2.0.68(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/openai-compatible': 1.0.36(zod@4.3.6)
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      zod: 4.3.6
+    optional: true
+
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.39.0':
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    optional: true
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -4789,6 +5971,73 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@browserbasehq/sdk@2.10.0':
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@browserbasehq/stagehand@3.2.1(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(deepmerge@4.3.1)(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@anthropic-ai/sdk': 0.39.0
+      '@browserbasehq/sdk': 2.10.0
+      '@google/genai': 1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0)
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6)))(ws@8.20.0(bufferutil@4.1.0))
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      ai: 5.0.179(zod@4.3.6)
+      deepmerge: 4.3.1
+      devtools-protocol: 0.0.1464554
+      fetch-cookie: 3.2.0
+      openai: 4.104.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6)
+      pino: 9.14.0
+      pino-pretty: 13.1.3
+      uuid: 11.1.0
+      ws: 8.20.0(bufferutil@4.1.0)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    optionalDependencies:
+      '@ai-sdk/amazon-bedrock': 3.0.97(zod@4.3.6)
+      '@ai-sdk/anthropic': 2.0.77(zod@4.3.6)
+      '@ai-sdk/azure': 2.0.105(zod@4.3.6)
+      '@ai-sdk/cerebras': 1.0.41(zod@4.3.6)
+      '@ai-sdk/deepseek': 1.0.37(zod@4.3.6)
+      '@ai-sdk/google': 2.0.70(zod@4.3.6)
+      '@ai-sdk/google-vertex': 3.0.132(zod@4.3.6)
+      '@ai-sdk/groq': 2.0.38(zod@4.3.6)
+      '@ai-sdk/mistral': 2.0.31(zod@4.3.6)
+      '@ai-sdk/openai': 2.0.103(zod@4.3.6)
+      '@ai-sdk/perplexity': 2.0.28(zod@4.3.6)
+      '@ai-sdk/togetherai': 1.0.39(zod@4.3.6)
+      '@ai-sdk/xai': 2.0.68(zod@4.3.6)
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6))
+      bufferutil: 4.1.0
+      chrome-launcher: 1.2.1
+      ollama-ai-provider-v2: 1.5.5(zod@4.3.6)
+      patchright-core: 1.59.4
+      playwright: 1.58.2
+      playwright-core: 1.58.2
+      puppeteer-core: 22.15.0(bufferutil@4.1.0)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - bare-abort-controller
+      - bare-buffer
+      - encoding
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  '@cfworker/json-schema@4.1.1': {}
 
   '@clerk/backend@2.33.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -5219,6 +6468,23 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(bufferutil@4.1.0)':
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.5.5
+      ws: 8.20.0(bufferutil@4.1.0)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@hono/node-server@1.19.14(hono@4.12.14)':
+    dependencies:
+      hono: 4.12.14
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -5357,6 +6623,61 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6))':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.3.87(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6))
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6)))(ws@8.20.0(bufferutil@4.1.0))':
+    dependencies:
+      '@langchain/core': 0.3.80(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6))
+      js-tiktoken: 1.0.21
+      openai: 4.104.0(ws@8.20.0(bufferutil@4.1.0))(zod@3.25.76)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - encoding
+      - ws
+
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.14)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.0(express@5.2.1)
+      hono: 4.12.14
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -5471,6 +6792,8 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@opentelemetry/api@1.9.1': {}
 
   '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.1)':
@@ -5543,6 +6866,8 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
 
+  '@pinojs/redact@0.4.0': {}
+
   '@playwright/test@1.58.2':
     dependencies:
       playwright: 1.58.2
@@ -5585,6 +6910,23 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@puppeteer/browsers@2.3.0':
+    dependencies:
+      debug: 4.4.3
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.7.4
+      tar-fs: 3.1.2
+      unbzip2-stream: 1.4.3
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+    optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
@@ -5787,6 +7129,58 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@smithy/eventstream-codec@4.2.14':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -5900,6 +7294,9 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    optional: true
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -5945,6 +7342,15 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 25.6.0
+      form-data: 4.0.5
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
@@ -5959,14 +7365,23 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/retry@0.12.0': {}
+
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/uuid@10.0.0': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 25.6.0
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 25.6.0
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -6123,6 +7538,8 @@ snapshots:
       next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
+  '@vercel/oidc@3.1.0': {}
+
   '@vercel/speed-insights@2.0.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     optionalDependencies:
       next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -6152,7 +7569,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
+      vitest: 4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0(bufferutil@4.1.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -6195,6 +7612,15 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -6207,6 +7633,10 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+
   aggregate-error@3.1.0:
     dependencies:
       clean-stack: 2.2.0
@@ -6216,6 +7646,18 @@ snapshots:
     dependencies:
       clean-stack: 5.3.0
       indent-string: 5.0.0
+
+  ai@5.0.179(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 2.0.82(zod@4.3.6)
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv@6.14.0:
     dependencies:
@@ -6336,6 +7778,11 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   ast-v8-to-istanbul@1.0.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -6344,19 +7791,88 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  asynckit@0.4.0: {}
+
+  atomic-sleep@1.0.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  aws4fetch@1.0.20:
+    optional: true
 
   axe-core@4.11.3: {}
 
   axobject-query@4.1.0: {}
 
+  b4a@1.8.0:
+    optional: true
+
   balanced-match@4.0.4: {}
+
+  bare-events@2.8.2:
+    optional: true
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.13.0(bare-events@2.8.2)
+      bare-url: 2.4.2
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  bare-os@3.9.0:
+    optional: true
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.9.0
+    optional: true
+
+  bare-stream@2.13.0(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - react-native-b4a
+    optional: true
+
+  bare-url@2.4.2:
+    dependencies:
+      bare-path: 3.0.0
+    optional: true
+
+  base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.20: {}
 
+  basic-ftp@5.3.0:
+    optional: true
+
   before-after-hook@4.0.0: {}
+
+  bignumber.js@9.3.1: {}
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   bottleneck@2.19.5: {}
 
@@ -6376,8 +7892,26 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer-crc32@0.2.13:
+    optional: true
+
+  buffer-equal-constant-time@1.0.1: {}
+
   buffer-from@1.1.2:
     optional: true
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    optional: true
+
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
+  bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -6405,6 +7939,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase@6.3.0: {}
+
   caniuse-lite@1.0.30001788: {}
 
   chai@6.2.2: {}
@@ -6423,6 +7959,24 @@ snapshots:
   chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
+
+  chrome-launcher@1.2.1:
+    dependencies:
+      '@types/node': 25.6.0
+      escape-string-regexp: 4.0.0
+      is-wsl: 2.2.0
+      lighthouse-logger: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  chromium-bidi@0.6.3(devtools-protocol@0.0.1312386):
+    dependencies:
+      devtools-protocol: 0.0.1312386
+      mitt: 3.0.1
+      urlpattern-polyfill: 10.0.0
+      zod: 3.23.8
+    optional: true
 
   cjs-module-lexer@2.2.0: {}
 
@@ -6481,6 +8035,12 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@2.0.20: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@2.20.3:
     optional: true
 
@@ -6493,6 +8053,14 @@ snapshots:
     dependencies:
       ini: 1.3.8
       proto-list: 1.2.4
+
+  console-table-printer@2.15.0:
+    dependencies:
+      simple-wcswidth: 1.1.2
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
 
   conventional-changelog-angular@8.1.0:
     dependencies:
@@ -6540,9 +8108,18 @@ snapshots:
       '@clerk/clerk-react': 5.61.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   core-js@3.49.0: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig-typescript-loader@6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
@@ -6595,6 +8172,11 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
+  data-uri-to-buffer@6.0.2:
+    optional: true
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -6613,6 +8195,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dateformat@4.6.3: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -6621,9 +8205,13 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
+
+  deepmerge@4.3.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -6637,9 +8225,25 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+    optional: true
+
+  delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  devtools-protocol@0.0.1312386:
+    optional: true
+
+  devtools-protocol@0.0.1464554: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -6673,6 +8277,12 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.341: {}
 
   emoji-regex@10.6.0: {}
@@ -6682,6 +8292,12 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   emojilib@2.4.0: {}
+
+  encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -6923,11 +8539,22 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+    optional: true
 
   eslint-config-next@16.2.4(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -7122,6 +8749,9 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
+  esprima@4.0.1:
+    optional: true
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -7137,6 +8767,25 @@ snapshots:
       '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
+
+  etag@1.8.1: {}
+
+  event-target-shim@5.0.1: {}
+
+  eventemitter3@4.0.7: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+    optional: true
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
 
   execa@5.1.1:
     dependencies:
@@ -7179,9 +8828,65 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  express-rate-limit@8.4.0(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  extend@3.0.2: {}
+
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   fast-content-type-parse@3.0.0: {}
 
+  fast-copy@4.0.3: {}
+
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2:
+    optional: true
 
   fast-glob@3.3.1:
     dependencies:
@@ -7195,6 +8900,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-safe-stringify@2.1.1: {}
+
   fast-sha256@1.3.0: {}
 
   fast-uri@3.1.0: {}
@@ -7203,9 +8910,24 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+    optional: true
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  fetch-cookie@3.2.0:
+    dependencies:
+      set-cookie-parser: 2.7.2
+      tough-cookie: 6.0.1
 
   fflate@0.4.8: {}
 
@@ -7224,6 +8946,17 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up-simple@1.0.1: {}
 
@@ -7251,6 +8984,29 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data-encoder@1.7.2: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   from2@2.3.0:
     dependencies:
@@ -7284,6 +9040,22 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
@@ -7310,6 +9082,11 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+    optional: true
+
   get-stream@6.0.1: {}
 
   get-stream@7.0.1: {}
@@ -7330,6 +9107,15 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.0
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   git-log-parser@1.2.1:
     dependencies:
@@ -7371,6 +9157,19 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.10: {}
@@ -7386,14 +9185,14 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
-  happy-dom@20.9.0:
+  happy-dom@20.9.0(bufferutil@4.1.0):
     dependencies:
       '@types/node': 25.6.0
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.20.0
+      ws: 8.20.0(bufferutil@4.1.0)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7422,6 +9221,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  help-me@5.0.0: {}
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -7429,6 +9230,8 @@ snapshots:
       hermes-estree: 0.25.1
 
   highlight.js@10.7.3: {}
+
+  hono@4.12.14: {}
 
   hook-std@4.0.0: {}
 
@@ -7443,6 +9246,14 @@ snapshots:
       lru-cache: 11.2.4
 
   html-escaper@2.0.2: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -7463,6 +9274,17 @@ snapshots:
   human-signals@5.0.0: {}
 
   human-signals@8.0.1: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1:
+    optional: true
 
   ignore@5.3.2: {}
 
@@ -7514,6 +9336,10 @@ snapshots:
       from2: 2.3.0
       p-is-promise: 3.0.0
 
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -7560,6 +9386,9 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-docker@2.2.1:
+    optional: true
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -7594,6 +9423,8 @@ snapshots:
   is-obj@2.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -7642,6 +9473,11 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
+    optional: true
+
   isarray@1.0.0: {}
 
   isarray@2.0.5: {}
@@ -7682,7 +9518,15 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.2: {}
+
+  joycon@3.1.1: {}
+
   js-cookie@3.0.5: {}
+
+  js-tiktoken@1.0.21:
+    dependencies:
+      base64-js: 1.5.1
 
   js-tokens@10.0.0: {}
 
@@ -7694,6 +9538,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-parse-better-errors@1.0.2: {}
@@ -7703,6 +9551,10 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
+  json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -7725,9 +9577,33 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.1.2
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.1.2
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  langsmith@0.3.87(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1))(openai@4.104.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6)):
+    dependencies:
+      '@types/uuid': 10.0.0
+      chalk: 4.1.2
+      console-table-printer: 2.15.0
+      p-queue: 6.6.2
+      semver: 7.7.4
+      uuid: 10.0.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
+      openai: 4.104.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6)
 
   language-subtag-registry@0.3.23: {}
 
@@ -7782,6 +9658,14 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lighthouse-logger@2.0.2:
+    dependencies:
+      debug: 4.4.3
+      marky: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -7892,6 +9776,9 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru-cache@7.18.3:
+    optional: true
+
   lucide-react@1.8.0(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -7931,11 +9818,18 @@ snapshots:
 
   marked@15.0.12: {}
 
+  marky@1.3.0:
+    optional: true
+
   math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
 
   memorystream@0.3.1: {}
 
   meow@13.2.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -7945,6 +9839,18 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 4.0.4
+
+  mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@4.1.0: {}
 
@@ -7960,9 +9866,14 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  mitt@3.0.1:
+    optional: true
+
   module-details-from-path@1.0.4: {}
 
   ms@2.1.3: {}
+
+  mustache@4.2.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -7976,9 +9887,14 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   neo-async@2.6.2: {}
 
   nerf-dart@1.0.0: {}
+
+  netmask@2.1.1:
+    optional: true
 
   next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -8008,6 +9924,8 @@ snapshots:
 
   nice-try@1.0.5: {}
 
+  node-domexception@1.0.0: {}
+
   node-emoji@2.2.0:
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -8021,6 +9939,19 @@ snapshots:
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-releases@2.0.37: {}
 
@@ -8116,6 +10047,23 @@ snapshots:
 
   obug@2.1.1: {}
 
+  ollama-ai-provider-v2@1.5.5(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.3.6)
+      zod: 4.3.6
+    optional: true
+
+  on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
@@ -8123,6 +10071,36 @@ snapshots:
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
+
+  openai@4.104.0(ws@8.20.0(bufferutil@4.1.0))(zod@3.25.76):
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 8.20.0(bufferutil@4.1.0)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - encoding
+
+  openai@4.104.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6):
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 8.20.0(bufferutil@4.1.0)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - encoding
 
   optionator@0.9.4:
     dependencies:
@@ -8149,6 +10127,8 @@ snapshots:
     dependencies:
       p-map: 7.0.4
 
+  p-finally@1.0.0: {}
+
   p-is-promise@3.0.0: {}
 
   p-limit@1.3.0:
@@ -8169,13 +10149,47 @@ snapshots:
 
   p-map@7.0.4: {}
 
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
   p-reduce@2.1.0: {}
 
   p-reduce@3.0.0: {}
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
+
   p-timeout@6.1.4: {}
 
   p-try@1.0.0: {}
+
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
+    optional: true
 
   parent-module@1.0.1:
     dependencies:
@@ -8209,6 +10223,11 @@ snapshots:
 
   parse5@6.0.1: {}
 
+  parseurl@1.3.3: {}
+
+  patchright-core@1.59.4:
+    optional: true
+
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
@@ -8221,6 +10240,8 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-to-regexp@8.4.2: {}
+
   path-type@3.0.0:
     dependencies:
       pify: 3.0.0
@@ -8229,6 +10250,9 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pend@1.2.0:
+    optional: true
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -8236,6 +10260,48 @@ snapshots:
   pidtree@0.3.1: {}
 
   pify@3.0.0: {}
+
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.3
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.4
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 5.0.3
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.1.0
+
+  pkce-challenge@5.0.1: {}
 
   pkg-conf@2.1.0:
     dependencies:
@@ -8298,6 +10364,11 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  process-warning@5.0.0: {}
+
+  progress@2.0.3:
+    optional: true
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -8321,11 +10392,69 @@ snapshots:
       '@types/node': 25.6.0
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  proxy-from-env@1.1.0:
+    optional: true
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
+
+  puppeteer-core@22.15.0(bufferutil@4.1.0):
+    dependencies:
+      '@puppeteer/browsers': 2.3.0
+      chromium-bidi: 0.6.3(devtools-protocol@0.0.1312386)
+      debug: 4.4.3
+      devtools-protocol: 0.0.1312386
+      ws: 8.20.0(bufferutil@4.1.0)
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+    optional: true
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
 
   query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -8391,6 +10520,8 @@ snapshots:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
+  real-require@0.2.0: {}
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -8453,6 +10584,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   rollup@4.59.0:
@@ -8485,6 +10618,16 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.59.0
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
 
   run-parallel@1.2.0:
     dependencies:
@@ -8519,7 +10662,13 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safe-stable-stringify@2.5.0: {}
+
+  safer-buffer@2.1.2: {}
+
   scheduler@0.27.0: {}
+
+  secure-json-parse@4.1.0: {}
 
   semantic-release@25.0.3(typescript@5.9.3):
     dependencies:
@@ -8565,7 +10714,34 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   server-only@0.0.1: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -8588,6 +10764,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -8675,9 +10853,33 @@ snapshots:
       figures: 2.0.0
       pkg-conf: 2.1.0
 
+  simple-wcswidth@1.1.2: {}
+
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
+
+  smart-buffer@4.2.0:
+    optional: true
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.1.0
+      smart-buffer: 4.2.0
+    optional: true
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
 
   source-map-js@1.2.1: {}
 
@@ -8709,6 +10911,8 @@ snapshots:
     dependencies:
       through2: 2.0.5
 
+  split2@4.2.0: {}
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -8717,6 +10921,8 @@ snapshots:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -8731,6 +10937,16 @@ snapshots:
     dependencies:
       duplexer2: 0.1.4
       readable-stream: 2.3.8
+
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
 
   string-width@4.2.3:
     dependencies:
@@ -8829,6 +11045,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-json-comments@5.0.3: {}
+
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.5):
     dependencies:
       client-only: 0.0.1
@@ -8871,6 +11089,39 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.1.8
+    optionalDependencies:
+      bare-fs: 4.7.1
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+    optional: true
+
+  tar-stream@3.1.8:
+    dependencies:
+      b4a: 1.8.0
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+    optional: true
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
   temp-dir@3.0.0: {}
 
   tempy@3.1.1:
@@ -8888,6 +11139,13 @@ snapshots:
       source-map-support: 0.5.21
     optional: true
 
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.0
+    transitivePeerDependencies:
+      - react-native-b4a
+    optional: true
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -8896,10 +11154,17 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
+
   through2@2.0.5:
     dependencies:
       readable-stream: 2.3.8
       xtend: 4.0.2
+
+  through@2.3.8:
+    optional: true
 
   time-span@5.1.0:
     dependencies:
@@ -8921,9 +11186,23 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toidentifier@1.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
+  tr46@0.0.3: {}
 
   traverse@0.6.8: {}
 
@@ -8955,6 +11234,12 @@ snapshots:
   type-fest@5.4.1:
     dependencies:
       tagged-tag: 1.0.0
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -9012,6 +11297,14 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  unbzip2-stream@1.4.3:
+    dependencies:
+      buffer: 5.7.1
+      through: 2.3.8
+    optional: true
+
+  undici-types@5.26.5: {}
+
   undici-types@7.19.2: {}
 
   undici@7.24.0: {}
@@ -9029,6 +11322,8 @@ snapshots:
   universal-user-agent@7.0.3: {}
 
   universalify@2.0.1: {}
+
+  unpipe@1.0.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -9066,16 +11361,25 @@ snapshots:
 
   url-join@5.0.0: {}
 
+  urlpattern-polyfill@10.0.0:
+    optional: true
+
   use-sync-external-store@1.6.0(react@19.2.5):
     dependencies:
       react: 19.2.5
 
   util-deprecate@1.0.2: {}
 
+  uuid@10.0.0: {}
+
+  uuid@11.1.0: {}
+
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vary@1.1.2: {}
 
   vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1):
     dependencies:
@@ -9092,7 +11396,7 @@ snapshots:
       lightningcss: 1.32.0
       terser: 5.46.1
 
-  vitest@4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)):
+  vitest@4.1.5(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0(bufferutil@4.1.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
@@ -9119,15 +11423,26 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.6.0
       '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
-      happy-dom: 20.9.0
+      happy-dom: 20.9.0(bufferutil@4.1.0)
     transitivePeerDependencies:
       - msw
+
+  web-streams-polyfill@3.3.3: {}
+
+  web-streams-polyfill@4.0.0-beta.3: {}
 
   web-vitals@5.2.0: {}
 
   web-worker@1.2.0: {}
 
+  webidl-conversions@3.0.1: {}
+
   whatwg-mimetype@3.0.0: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -9209,7 +11524,11 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.2
 
-  ws@8.20.0: {}
+  wrappy@1.0.2: {}
+
+  ws@8.20.0(bufferutil@4.1.0):
+    optionalDependencies:
+      bufferutil: 4.1.0
 
   xtend@4.0.2: {}
 
@@ -9252,12 +11571,31 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 22.0.0
 
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+    optional: true
+
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
 
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@3.23.8:
+    optional: true
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}

--- a/qa/agentic/critic.mjs
+++ b/qa/agentic/critic.mjs
@@ -1,0 +1,74 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { validateAgenticManifest } from './manifest.mjs';
+
+export function scoreAgenticManifest(manifest, mission) {
+  const validation = validateAgenticManifest(manifest, mission);
+  const blockingReasons = [...validation.errors];
+  const completedChecks = Array.isArray(manifest?.checks)
+    ? manifest.checks.filter((check) => check.status === 'PASS').length
+    : 0;
+  const totalChecks = Array.isArray(manifest?.checks)
+    ? manifest.checks.length
+    : 0;
+  const score =
+    blockingReasons.length === 0
+      ? 1
+      : Math.max(0, Math.min(0.75, completedChecks / Math.max(totalChecks, 1)));
+
+  return {
+    verdict: blockingReasons.length === 0 ? 'pass' : 'fail',
+    score,
+    blockingReasons,
+    summary:
+      blockingReasons.length === 0
+        ? `Mission ${manifest.mission.id} passed deterministic QA checks.`
+        : `Mission ${manifest?.mission?.id ?? 'unknown'} failed: ${blockingReasons.join('; ')}`,
+  };
+}
+
+export async function writeAgenticCriticArtifacts({
+  manifest,
+  mission,
+  outDir,
+}) {
+  const result = scoreAgenticManifest(manifest, mission);
+  const resultPath = path.join(outDir, 'critic-result.json');
+  const summaryPath = path.join(outDir, 'critic-summary.md');
+
+  await fs.writeFile(
+    resultPath,
+    `${JSON.stringify(result, null, 2)}\n`,
+    'utf8'
+  );
+  await fs.writeFile(
+    summaryPath,
+    renderCriticSummary(result, manifest),
+    'utf8'
+  );
+
+  return {
+    ...result,
+    resultPath,
+    summaryPath,
+  };
+}
+
+function renderCriticSummary(result, manifest) {
+  const lines = [
+    '# Linejam Agentic QA Critic',
+    '',
+    `- Mission: ${manifest?.mission?.id ?? 'unknown'}`,
+    `- Verdict: ${result.verdict}`,
+    `- Score: ${result.score.toFixed(2)}`,
+    '',
+    '## Blocking Reasons',
+    ...(result.blockingReasons.length === 0
+      ? ['- None']
+      : result.blockingReasons.map((reason) => `- ${reason}`)),
+    '',
+  ];
+
+  return `${lines.join('\n')}\n`;
+}

--- a/qa/agentic/manifest.mjs
+++ b/qa/agentic/manifest.mjs
@@ -1,0 +1,124 @@
+export const AGENTIC_MANIFEST_VERSION = 1;
+export const GENERIC_ERROR_PATTERNS = Object.freeze([
+  /unexpected error occurred/i,
+  /something went wrong/i,
+  /application error/i,
+  /generic join error/i,
+]);
+
+export function createAgenticManifest({
+  baseUrl,
+  mission,
+  runId,
+  startedAt = new Date().toISOString(),
+  target,
+}) {
+  return {
+    version: AGENTIC_MANIFEST_VERSION,
+    runId,
+    target,
+    baseUrl,
+    mission: {
+      id: mission.id,
+      title: mission.title,
+      goal: mission.goal,
+    },
+    startedAt,
+    finishedAt: null,
+    status: 'RUNNING',
+    checks: [],
+    observations: [],
+    runtimeErrors: [],
+    screenshots: [],
+    transcript: [],
+  };
+}
+
+export function detectGenericErrors(values) {
+  return values
+    .map((value) => String(value ?? ''))
+    .flatMap((value) =>
+      GENERIC_ERROR_PATTERNS.filter((pattern) => pattern.test(value)).map(
+        (pattern) => ({
+          pattern: pattern.source,
+          excerpt: excerpt(value),
+        })
+      )
+    );
+}
+
+export function validateAgenticManifest(manifest, mission) {
+  const errors = [];
+
+  if (!manifest || typeof manifest !== 'object') {
+    return { ok: false, errors: ['manifest must be an object'] };
+  }
+
+  if (manifest.version !== AGENTIC_MANIFEST_VERSION) {
+    errors.push(`manifest version must be ${AGENTIC_MANIFEST_VERSION}`);
+  }
+
+  if (!manifest.runId) errors.push('runId is required');
+  if (!manifest.baseUrl) errors.push('baseUrl is required');
+  if (!manifest.mission?.id) errors.push('mission.id is required');
+  if (!['RUNNING', 'PASS', 'FAIL'].includes(manifest.status)) {
+    errors.push('status must be RUNNING, PASS, or FAIL');
+  }
+
+  const requiredScreenshots = mission?.requiredScreenshots ?? [];
+  const screenshotLabels = new Set(
+    Array.isArray(manifest.screenshots)
+      ? manifest.screenshots.map((screenshot) => screenshot.label)
+      : []
+  );
+
+  for (const label of requiredScreenshots) {
+    if (!screenshotLabels.has(label)) {
+      errors.push(`missing required screenshot: ${label}`);
+    }
+  }
+
+  const checkFailures = Array.isArray(manifest.checks)
+    ? manifest.checks.filter((check) => check.status === 'FAIL')
+    : [];
+  for (const check of checkFailures) {
+    errors.push(`check failed: ${check.name}`);
+  }
+
+  const observationText = Array.isArray(manifest.observations)
+    ? manifest.observations.map((observation) => observation.text)
+    : [];
+  const genericErrors = detectGenericErrors(observationText);
+  for (const genericError of genericErrors) {
+    errors.push(`generic error UI detected: ${genericError.excerpt}`);
+  }
+
+  if (
+    Array.isArray(manifest.runtimeErrors) &&
+    manifest.runtimeErrors.length > 0
+  ) {
+    errors.push(`runtime errors captured: ${manifest.runtimeErrors.length}`);
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+  };
+}
+
+export function markAgenticManifestFinished(
+  manifest,
+  status,
+  now = new Date()
+) {
+  manifest.status = status;
+  manifest.finishedAt = now.toISOString();
+  return manifest;
+}
+
+function excerpt(value) {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  return normalized.length <= 160
+    ? normalized
+    : `${normalized.slice(0, 157)}...`;
+}

--- a/qa/agentic/missions.mjs
+++ b/qa/agentic/missions.mjs
@@ -1,0 +1,113 @@
+export const DEFAULT_AGENTIC_MISSION = 'guest-host-signed-in-join';
+export const DEFAULT_LOCAL_BASE_URL = 'http://localhost:3000';
+
+export const AGENTIC_MISSIONS = Object.freeze([
+  {
+    id: 'guest-host-signed-in-join',
+    title: 'Guest host, signed-in joiner',
+    requiresAuth: true,
+    actors: ['guest-host', 'signed-in-joiner'],
+    requiredScreenshots: ['host-lobby', 'signed-in-joined'],
+    goal: 'A guest host creates a room and a signed-in Clerk user joins it without generic error UI.',
+  },
+  {
+    id: 'signed-in-host-guest-join',
+    title: 'Signed-in host, guest joiner',
+    requiresAuth: true,
+    actors: ['signed-in-host', 'guest-joiner'],
+    requiredScreenshots: ['host-lobby', 'guest-joined'],
+    goal: 'A signed-in Clerk host creates a room and a guest user joins it without generic error UI.',
+  },
+]);
+
+export function listAgenticMissions() {
+  return AGENTIC_MISSIONS.map((mission) => ({ ...mission }));
+}
+
+export function resolveAgenticMission(
+  missionId = process.env.LINEJAM_AGENTIC_MISSION || DEFAULT_AGENTIC_MISSION
+) {
+  const mission = AGENTIC_MISSIONS.find(
+    (candidate) => candidate.id === missionId
+  );
+
+  if (!mission) {
+    throw new Error(
+      `Unknown agentic QA mission: ${missionId}. Expected one of ${AGENTIC_MISSIONS.map(
+        (candidate) => candidate.id
+      ).join(', ')}.`
+    );
+  }
+
+  return mission;
+}
+
+export function normalizeAgenticTarget(value = 'local') {
+  const target = String(value).trim().toLowerCase();
+
+  if (target === 'local' || target === 'preview') {
+    return target;
+  }
+
+  throw new Error(
+    `Unknown agentic QA target: ${value}. Expected local or preview.`
+  );
+}
+
+export function resolveAgenticBaseUrl({
+  baseUrl = process.env.PLAYWRIGHT_BASE_URL || process.env.LINEJAM_BASE_URL,
+  target = 'local',
+} = {}) {
+  const resolvedTarget = normalizeAgenticTarget(target);
+  const trimmedBaseUrl = typeof baseUrl === 'string' ? baseUrl.trim() : '';
+
+  if (trimmedBaseUrl) {
+    return trimTrailingSlash(trimmedBaseUrl);
+  }
+
+  if (resolvedTarget === 'local') {
+    return DEFAULT_LOCAL_BASE_URL;
+  }
+
+  throw new Error(
+    'PLAYWRIGHT_BASE_URL or --base-url is required for preview agentic QA runs.'
+  );
+}
+
+export function assertAgenticMissionEnvironment(mission, env = process.env) {
+  if (!mission.requiresAuth) {
+    return;
+  }
+
+  const missing = [];
+  if (!env.CLERK_SECRET_KEY?.trim()) {
+    missing.push('CLERK_SECRET_KEY');
+  }
+  if (
+    !env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.trim() &&
+    !env.CLERK_PUBLISHABLE_KEY?.trim()
+  ) {
+    missing.push('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY or CLERK_PUBLISHABLE_KEY');
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `${mission.id} requires authenticated Clerk coverage. Set ${missing.join(
+        ', '
+      )} before running this mission.`
+    );
+  }
+}
+
+export function createAgenticRunId({
+  missionId,
+  now = new Date(),
+  target = 'local',
+}) {
+  const stamp = now.toISOString().replace(/[:.]/g, '-');
+  return `${stamp}-${target}-${missionId}`;
+}
+
+function trimTrailingSlash(value) {
+  return value.replace(/\/+$/, '');
+}

--- a/qa/agentic/modelEnv.mjs
+++ b/qa/agentic/modelEnv.mjs
@@ -1,0 +1,71 @@
+export const DEFAULT_STAGEHAND_MODEL = 'gpt-4.1-mini';
+
+export const STAGEHAND_PROVIDER_ENV_KEYS = Object.freeze([
+  'ANTHROPIC_API_KEY',
+  'CEREBRAS_API_KEY',
+  'GOOGLE_API_KEY',
+  'GOOGLE_GENERATIVE_AI_API_KEY',
+  'GROQ_API_KEY',
+  'OPENAI_API_KEY',
+]);
+
+export const AGENTIC_SMOKE_ENV_KEYS = Object.freeze([
+  ...STAGEHAND_PROVIDER_ENV_KEYS,
+  'LINEJAM_AGENTIC_HEADFUL',
+  'LINEJAM_AGENTIC_MISSION',
+  'LINEJAM_AGENTIC_MODE',
+  'LINEJAM_AGENTIC_OUT_DIR',
+  'LINEJAM_STAGEHAND_MODEL',
+]);
+
+export function resolveStagehandModel(env = process.env) {
+  return env.LINEJAM_STAGEHAND_MODEL?.trim() || DEFAULT_STAGEHAND_MODEL;
+}
+
+export function requiredStagehandProviderEnvKeys(model) {
+  const normalized = String(model).trim().toLowerCase();
+
+  if (
+    normalized.startsWith('gpt-') ||
+    normalized.startsWith('o1') ||
+    normalized.startsWith('o3') ||
+    normalized.startsWith('o4') ||
+    normalized.startsWith('openai/')
+  ) {
+    return ['OPENAI_API_KEY'];
+  }
+
+  if (normalized.startsWith('claude') || normalized.startsWith('anthropic/')) {
+    return ['ANTHROPIC_API_KEY'];
+  }
+
+  if (normalized.startsWith('gemini') || normalized.startsWith('google/')) {
+    return ['GOOGLE_API_KEY', 'GOOGLE_GENERATIVE_AI_API_KEY'];
+  }
+
+  if (normalized.startsWith('groq') || normalized.includes('groq-')) {
+    return ['GROQ_API_KEY'];
+  }
+
+  if (normalized.startsWith('cerebras') || normalized.includes('cerebras-')) {
+    return ['CEREBRAS_API_KEY'];
+  }
+
+  return STAGEHAND_PROVIDER_ENV_KEYS;
+}
+
+export function assertStagehandModelEnvironment({
+  env = process.env,
+  model = resolveStagehandModel(env),
+} = {}) {
+  const requiredKeys = requiredStagehandProviderEnvKeys(model);
+  if (requiredKeys.some((key) => env[key]?.trim())) {
+    return;
+  }
+
+  throw new Error(
+    `Stagehand model ${model} requires ${requiredKeys.join(
+      ' or '
+    )}. Set LINEJAM_AGENTIC_MODE=deterministic only for harness debugging.`
+  );
+}

--- a/qa/agentic/modelEnv.mjs
+++ b/qa/agentic/modelEnv.mjs
@@ -1,4 +1,4 @@
-export const DEFAULT_STAGEHAND_MODEL = 'gpt-4.1-mini';
+export const DEFAULT_STAGEHAND_MODEL = 'openai/gpt-4.1-mini';
 
 export const STAGEHAND_PROVIDER_ENV_KEYS = Object.freeze([
   'ANTHROPIC_API_KEY',

--- a/qa/agentic/promptfoo.config.yaml
+++ b/qa/agentic/promptfoo.config.yaml
@@ -1,0 +1,23 @@
+description: Linejam agentic QA critic advisory rubric
+prompts:
+  - |
+    You are the separate Linejam QA critic. Grade this agentic browser mission
+    artifact bundle as JSON with keys verdict, score, and blockingReasons.
+
+    Pass only when the mission reached the intended room state, contains no
+    generic error UI, includes required screenshots, and has no captured runtime
+    browser errors.
+
+    Manifest:
+    {{manifest}}
+providers:
+  - openai:gpt-4.1-mini
+tests:
+  - vars:
+      manifest: '{{manifest}}'
+    assert:
+      - type: javascript
+        value: |
+          const normalized = String(output).toLowerCase();
+          return normalized.includes('verdict') &&
+            (normalized.includes('pass') || normalized.includes('fail'));

--- a/scripts/canary/store.mjs
+++ b/scripts/canary/store.mjs
@@ -3,6 +3,7 @@ import {
   mkdir,
   readFile,
   readdir,
+  rm,
   stat,
   unlink,
   writeFile,
@@ -10,8 +11,11 @@ import {
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
-const ROOT_DIR = path.resolve(process.env.LINEJAM_CANARY_STORE_DIR || '.canary');
+const ROOT_DIR = path.resolve(
+  process.env.LINEJAM_CANARY_STORE_DIR || '.canary'
+);
 const PRUNABLE_SUBDIRECTORIES = [
+  'agentic',
   'contexts',
   'deliveries',
   'fingerprints',
@@ -21,6 +25,14 @@ const PRUNABLE_SUBDIRECTORIES = [
 
 function sanitizeSegment(value) {
   return value.replace(/[^a-zA-Z0-9._-]/g, '-');
+}
+
+export function agenticArtifactDir(
+  deliveryId,
+  storeDir = process.env.LINEJAM_CANARY_STORE_DIR || '.canary'
+) {
+  const normalizedDeliveryId = sanitizeSegment(String(deliveryId || 'manual'));
+  return path.join(storeDir, 'agentic', normalizedDeliveryId);
 }
 
 async function ensureSubdirectory(name) {
@@ -95,7 +107,8 @@ export async function listPendingSmokeDeliveries() {
           ? payload.service
           : 'unknown',
       sequence:
-        typeof payload.sequence === 'number' && Number.isFinite(payload.sequence)
+        typeof payload.sequence === 'number' &&
+        Number.isFinite(payload.sequence)
           ? payload.sequence
           : 0,
       deliveryRecord: payload,
@@ -189,12 +202,17 @@ export async function pruneExpiredArtifacts({
         continue;
       }
 
-      if (!metadata.isFile() || metadata.mtimeMs >= cutoffTimestamp) {
+      if (metadata.mtimeMs >= cutoffTimestamp) {
         continue;
       }
 
-      await unlink(file);
-      deletedFiles.push(file);
+      if (metadata.isDirectory()) {
+        await rm(file, { recursive: true, force: true });
+        deletedFiles.push(file);
+      } else if (metadata.isFile()) {
+        await unlink(file);
+        deletedFiles.push(file);
+      }
     }
   }
 

--- a/scripts/canary/trigger-smoke.mjs
+++ b/scripts/canary/trigger-smoke.mjs
@@ -2,7 +2,9 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { isCanaryAutomationEvent } from './events.mjs';
 import { getSmokeClerkKeyError } from './smoke-auth.mjs';
+import { agenticArtifactDir } from './store.mjs';
 import { ensureClerkConvexTemplate } from '../ci/ensure-clerk-convex-template.mjs';
+import { AGENTIC_SMOKE_ENV_KEYS } from '../../qa/agentic/modelEnv.mjs';
 
 const DEFAULT_SMOKE_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_SMOKE_KILL_GRACE_MS = 5_000;
@@ -13,6 +15,7 @@ const SMOKE_ENV_KEYS = [
   'CANARY_ENDPOINT',
   'CI',
   'CLERK_JWT_ISSUER_DOMAIN',
+  'CLERK_PUBLISHABLE_KEY',
   'CLERK_SECRET_KEY',
   'FORCE_COLOR',
   'GUEST_TOKEN_SECRET',
@@ -36,6 +39,7 @@ const SMOKE_ENV_KEYS = [
   'TMPDIR',
 ];
 const SMOKE_RUNNER_COMMANDS = Object.freeze({
+  agentic: ['pnpm', ['qa:agentic:preview']],
   dagger: ['pnpm', ['ci:dagger:smoke']],
   playwright: ['pnpm', ['test:e2e:smoke']],
 });
@@ -87,16 +91,24 @@ function resolveSmokeCommand(runner) {
   return SMOKE_RUNNER_COMMANDS[runner];
 }
 
-function buildSmokeEnv(baseUrl) {
+function buildSmokeEnv(baseUrl, runner, deliveryId) {
   const nextEnv = {
     PLAYWRIGHT_BASE_URL: baseUrl,
   };
+  const envKeys =
+    runner === 'agentic'
+      ? [...SMOKE_ENV_KEYS, ...AGENTIC_SMOKE_ENV_KEYS]
+      : SMOKE_ENV_KEYS;
 
-  for (const key of SMOKE_ENV_KEYS) {
+  for (const key of envKeys) {
     const value = process.env[key];
     if (value) {
       nextEnv[key] = value;
     }
+  }
+
+  if (runner === 'agentic' && !nextEnv.LINEJAM_AGENTIC_OUT_DIR) {
+    nextEnv.LINEJAM_AGENTIC_OUT_DIR = agenticArtifactDir(deliveryId);
   }
 
   return nextEnv;
@@ -270,7 +282,7 @@ export async function runSmoke({
 
     const child = spawnProcess(smokeCommand, smokeArgs, {
       cwd: REPO_ROOT,
-      env: buildSmokeEnv(baseUrl),
+      env: buildSmokeEnv(baseUrl, resolvedRunner, deliveryId),
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 

--- a/scripts/ci/dagger-call.sh
+++ b/scripts/ci/dagger-call.sh
@@ -9,6 +9,8 @@ CONVEX_DEV_URL=""
 CONVEX_PROD_URL=""
 
 case "$FUNCTION_NAME" in
+  agentic-qa) FUNCTION_NAME="agentic-qa" ;;
+  agentic-qa-preview) FUNCTION_NAME="agentic-qa-preview" ;;
   all-no-e2e) FUNCTION_NAME="all-no-e-2-e" ;;
   e2e) FUNCTION_NAME="e-2-e" ;;
 esac
@@ -35,7 +37,7 @@ create_source_snapshot() {
 	local snapshot_dir
 	snapshot_dir="$(mktemp -d "${TMPDIR:-/tmp}/linejam-dagger-src.XXXXXX")"
 
-	git ls-files --cached --others --exclude-standard -z | \
+	git -c core.fsmonitor=false ls-files --cached --others --exclude-standard -z | \
 		while IFS= read -r -d '' path; do
 			[[ -e "$path" ]] || continue
 			printf '%s\0' "$path"
@@ -502,8 +504,11 @@ if function_requires_canary_browser_config; then
 	ensure_canary_browser_config
 fi
 
-if [[ "$FUNCTION_NAME" == "smoke" ]]; then
+if [[ "$FUNCTION_NAME" == "smoke" || "$FUNCTION_NAME" == "agentic-qa-preview" ]]; then
 	validate_smoke_base_url
+fi
+
+if [[ "$FUNCTION_NAME" == "smoke" ]]; then
 	validate_smoke_auth_configuration
 fi
 
@@ -544,7 +549,7 @@ append_app_env() {
 }
 
 case "$FUNCTION_NAME" in
-  all|all-no-e-2-e|base|build-check|e-2-e|format-check|lint|smoke|typecheck|unit-test)
+  agentic-qa|agentic-qa-preview|all|all-no-e-2-e|base|build-check|e-2-e|format-check|lint|smoke|typecheck|unit-test)
     append_app_env
     ;;
 esac
@@ -558,8 +563,15 @@ if [[ "$FUNCTION_NAME" == "smoke" ]]; then
 	append_arg "--playwright-require-auth-smoke" "${PLAYWRIGHT_REQUIRE_AUTH_SMOKE:-}"
 fi
 
+if [[ "$FUNCTION_NAME" == "agentic-qa-preview" ]]; then
+	append_arg "--base-url" "${PLAYWRIGHT_BASE_URL:-}"
+	append_arg "--mission" "${LINEJAM_AGENTIC_MISSION:-}"
+fi
+
 dagger_success_marker() {
 	case "$FUNCTION_NAME" in
+		agentic-qa) printf '%s' 'Ci.agenticQa DONE' ;;
+		agentic-qa-preview) printf '%s' 'Ci.agenticQaPreview DONE' ;;
 		all) printf '%s' 'Ci.all DONE' ;;
 		all-no-e-2-e) printf '%s' 'Ci.allNoE2e DONE' ;;
 		build-check) printf '%s' 'Ci.buildCheck DONE' ;;

--- a/scripts/qa/agentic-critic-fixtures.mjs
+++ b/scripts/qa/agentic-critic-fixtures.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+import {
+  DEFAULT_AGENTIC_MISSION,
+  resolveAgenticMission,
+} from '../../qa/agentic/missions.mjs';
+import { scoreAgenticManifest } from '../../qa/agentic/critic.mjs';
+
+const mission = resolveAgenticMission(DEFAULT_AGENTIC_MISSION);
+const healthyManifest = {
+  version: 1,
+  runId: 'fixture-pass',
+  target: 'local',
+  baseUrl: 'http://localhost:3000',
+  mission,
+  startedAt: '2026-04-23T00:00:00.000Z',
+  finishedAt: '2026-04-23T00:00:01.000Z',
+  status: 'PASS',
+  checks: [{ name: 'join completed', status: 'PASS' }],
+  observations: [{ actor: 'host', label: 'lobby', text: 'Canary Clerk User' }],
+  runtimeErrors: [],
+  screenshots: mission.requiredScreenshots.map((label) => ({
+    label,
+    file: `${label}.png`,
+  })),
+  transcript: [],
+};
+const genericJoinErrorManifest = {
+  ...healthyManifest,
+  runId: 'fixture-fail',
+  observations: [
+    {
+      actor: 'joiner',
+      label: 'join error',
+      text: 'An unexpected error occurred while joining the room.',
+    },
+  ],
+};
+
+const healthyResult = scoreAgenticManifest(healthyManifest, mission);
+const genericErrorResult = scoreAgenticManifest(
+  genericJoinErrorManifest,
+  mission
+);
+
+if (healthyResult.verdict !== 'pass') {
+  throw new Error(`Healthy fixture should pass: ${healthyResult.summary}`);
+}
+
+if (genericErrorResult.verdict !== 'fail') {
+  throw new Error('Generic join error fixture should fail.');
+}
+
+process.stdout.write(
+  `${JSON.stringify(
+    {
+      healthy: healthyResult.verdict,
+      genericJoinError: genericErrorResult.verdict,
+    },
+    null,
+    2
+  )}\n`
+);

--- a/scripts/qa/agentic-runner.mjs
+++ b/scripts/qa/agentic-runner.mjs
@@ -1,0 +1,508 @@
+#!/usr/bin/env node
+
+import { createClerkClient } from '@clerk/backend';
+import { clerk } from '@clerk/testing/playwright';
+import { chromium, expect } from '@playwright/test';
+import { Stagehand } from '@browserbasehq/stagehand';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+import {
+  assertAgenticMissionEnvironment,
+  createAgenticRunId,
+  normalizeAgenticTarget,
+  resolveAgenticBaseUrl,
+  resolveAgenticMission,
+} from '../../qa/agentic/missions.mjs';
+import {
+  assertStagehandModelEnvironment,
+  DEFAULT_STAGEHAND_MODEL,
+  resolveStagehandModel,
+} from '../../qa/agentic/modelEnv.mjs';
+import {
+  createAgenticManifest,
+  markAgenticManifestFinished,
+} from '../../qa/agentic/manifest.mjs';
+import { writeAgenticCriticArtifacts } from '../../qa/agentic/critic.mjs';
+
+const DEFAULT_CLERK_TEST_EMAIL = 'linejam-e2e+clerk_test@example.com';
+
+function parseArgs(argv) {
+  const args = {
+    baseUrl: undefined,
+    missionId: process.env.LINEJAM_AGENTIC_MISSION,
+    outDir: process.env.LINEJAM_AGENTIC_OUT_DIR,
+    target: 'local',
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--base-url' && argv[i + 1]) {
+      args.baseUrl = argv[i + 1];
+      i += 1;
+    } else if (arg === '--mission' && argv[i + 1]) {
+      args.missionId = argv[i + 1];
+      i += 1;
+    } else if (arg === '--out-dir' && argv[i + 1]) {
+      args.outDir = argv[i + 1];
+      i += 1;
+    } else if (arg === '--target' && argv[i + 1]) {
+      args.target = argv[i + 1];
+      i += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node scripts/qa/agentic-runner.mjs [options]
+
+Options:
+  --target local|preview       Run posture. Local defaults to http://localhost:3000.
+  --mission <id>              Mission id. Defaults to LINEJAM_AGENTIC_MISSION.
+  --base-url <url>            Target URL. Required for preview runs.
+  --out-dir <path>            Artifact directory. Defaults to .qa/runs/<run-id>.
+
+Environment:
+  LINEJAM_AGENTIC_MODE=deterministic skips Stagehand actions for harness debugging.
+  LINEJAM_STAGEHAND_MODEL selects the Stagehand model, default ${DEFAULT_STAGEHAND_MODEL}.
+`);
+}
+
+function shouldUseStagehand() {
+  return process.env.LINEJAM_AGENTIC_MODE !== 'deterministic';
+}
+
+function requireStagehandModelEnv() {
+  if (!shouldUseStagehand()) {
+    return;
+  }
+
+  assertStagehandModelEnvironment();
+}
+
+async function createStagehand() {
+  if (!shouldUseStagehand()) {
+    return null;
+  }
+
+  const stagehand = new Stagehand({
+    env: 'LOCAL',
+    model: resolveStagehandModel(),
+    disablePino: true,
+    verbose: 0,
+    localBrowserLaunchOptions: {
+      headless: process.env.LINEJAM_AGENTIC_HEADFUL !== '1',
+    },
+  });
+
+  await stagehand.init();
+  return stagehand;
+}
+
+async function perform({
+  actor,
+  fallback,
+  instruction,
+  manifest,
+  page,
+  stagehand,
+}) {
+  if (stagehand) {
+    const result = await stagehand.act(instruction, {
+      page,
+      timeout: 30_000,
+      serverCache: true,
+    });
+
+    manifest.transcript.push({
+      actor,
+      instruction,
+      mode: 'stagehand',
+      result: result.message,
+      success: result.success,
+    });
+
+    if (!result.success) {
+      throw new Error(
+        `Stagehand action failed for ${actor}: ${result.message}`
+      );
+    }
+
+    return;
+  }
+
+  await fallback();
+  manifest.transcript.push({
+    actor,
+    instruction,
+    mode: 'deterministic',
+    result: 'ok',
+    success: true,
+  });
+}
+
+async function runCheck(manifest, name, fn) {
+  try {
+    await fn();
+    manifest.checks.push({ name, status: 'PASS' });
+  } catch (error) {
+    manifest.checks.push({
+      name,
+      status: 'FAIL',
+      detail: errorMessage(error),
+    });
+    throw error;
+  }
+}
+
+async function createContextPage(browser, baseUrl) {
+  const context = await browser.newContext({ baseURL: baseUrl });
+  const page = await context.newPage();
+  return { context, page };
+}
+
+async function ensureClerkAuthState(page) {
+  const secretKey = process.env.CLERK_SECRET_KEY?.trim();
+  if (!secretKey) {
+    throw new Error('CLERK_SECRET_KEY is required for signed-in agentic QA.');
+  }
+  process.env.CLERK_PUBLISHABLE_KEY ??=
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+  const emailAddress =
+    process.env.PLAYWRIGHT_CLERK_TEST_EMAIL?.trim() || DEFAULT_CLERK_TEST_EMAIL;
+
+  await ensureClerkSmokeUser(secretKey, emailAddress);
+  await page.goto('/');
+  await clerk.signIn({ page, emailAddress });
+  await clerk.loaded({ page });
+  await page.waitForFunction(
+    () => Boolean(window.Clerk?.loaded && window.Clerk?.session?.id),
+    { timeout: 30_000 }
+  );
+  await page.waitForFunction(
+    async () => {
+      if (!window.Clerk?.loaded || !window.Clerk.session) {
+        return false;
+      }
+
+      try {
+        return Boolean(
+          await window.Clerk.session.getToken({ template: 'convex' })
+        );
+      } catch {
+        return false;
+      }
+    },
+    { timeout: 30_000 }
+  );
+}
+
+async function ensureClerkSmokeUser(secretKey, emailAddress) {
+  const client = createClerkClient({ secretKey });
+  const existing = await client.users.getUserList({
+    emailAddress: [emailAddress],
+  });
+  if (existing.data[0]) return;
+
+  if (secretKey.startsWith('sk_live_')) {
+    throw new Error(
+      `Refusing to auto-provision Clerk smoke user ${emailAddress} against a live Clerk instance. Create that user first or set PLAYWRIGHT_CLERK_TEST_EMAIL.`
+    );
+  }
+
+  try {
+    await client.users.createUser({
+      emailAddress: [emailAddress],
+      firstName: 'Linejam',
+      lastName: 'Agentic QA',
+      skipLegalChecks: true,
+      skipPasswordChecks: true,
+      skipPasswordRequirement: true,
+    });
+  } catch (error) {
+    const retry = await client.users.getUserList({
+      emailAddress: [emailAddress],
+    });
+    if (!retry.data[0]) {
+      throw error;
+    }
+  }
+}
+
+function getRoomCode(page) {
+  const roomCode = page.url().match(/\/room\/([A-Z]{4})$/)?.[1] || '';
+
+  if (!/^[A-Z]{4}$/.test(roomCode)) {
+    throw new Error(`Unexpected room URL: ${page.url()}`);
+  }
+
+  return roomCode;
+}
+
+async function screenshot(manifest, page, outDir, label) {
+  const file = `${String(manifest.screenshots.length + 1).padStart(2, '0')}-${label}.png`;
+  await page.screenshot({ path: path.join(outDir, file), fullPage: true });
+  manifest.screenshots.push({ label, file });
+}
+
+async function observe(manifest, page, actor, label) {
+  const text = await page.locator('body').innerText({ timeout: 5_000 });
+  manifest.observations.push({
+    actor,
+    label,
+    text,
+    url: page.url(),
+  });
+}
+
+function attachRuntimeErrorLogging(page, actor, manifest) {
+  page.on('pageerror', (error) => {
+    manifest.runtimeErrors.push(`[${actor}] pageerror: ${error.message}`);
+  });
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      manifest.runtimeErrors.push(`[${actor}] console: ${msg.text()}`);
+    }
+  });
+}
+
+async function runGuestHostSignedInJoin({
+  baseUrl,
+  browser,
+  manifest,
+  outDir,
+  stagehand,
+}) {
+  const host = await createContextPage(browser, baseUrl);
+  const joiner = await createContextPage(browser, baseUrl);
+  attachRuntimeErrorLogging(host.page, 'guest-host', manifest);
+  attachRuntimeErrorLogging(joiner.page, 'signed-in-joiner', manifest);
+
+  try {
+    await runCheck(manifest, 'guest host creates room', async () => {
+      await host.page.goto('/host');
+      await perform({
+        actor: 'guest-host',
+        fallback: async () => {
+          await host.page.locator('input#name').fill('Agentic Guest Host');
+          await host.page.getByRole('button', { name: /Create Room/i }).click();
+        },
+        instruction:
+          'Fill the host pen name field with "Agentic Guest Host" and create the room.',
+        manifest,
+        page: host.page,
+        stagehand,
+      });
+      await host.page.waitForURL(/\/room\/[A-Z]{4}$/, { timeout: 30_000 });
+      await expect(host.page.getByText('Agentic Guest Host')).toBeVisible();
+      await screenshot(manifest, host.page, outDir, 'host-lobby');
+    });
+
+    const roomCode = getRoomCode(host.page);
+    await runCheck(manifest, 'signed-in player joins room', async () => {
+      await ensureClerkAuthState(joiner.page);
+      await joiner.page.goto(`/join?code=${roomCode}`);
+      await perform({
+        actor: 'signed-in-joiner',
+        fallback: async () => {
+          await joiner.page.locator('input#name').fill('Agentic Clerk User');
+          await joiner.page
+            .getByRole('button', { name: /Enter Room/i })
+            .click();
+        },
+        instruction:
+          'Fill the join pen name field with "Agentic Clerk User" and enter the room.',
+        manifest,
+        page: joiner.page,
+        stagehand,
+      });
+      await joiner.page.waitForURL(`/room/${roomCode}`, { timeout: 30_000 });
+      await expect(host.page.getByText('Agentic Clerk User')).toBeVisible({
+        timeout: 15_000,
+      });
+      await screenshot(manifest, joiner.page, outDir, 'signed-in-joined');
+    });
+
+    await observe(manifest, host.page, 'guest-host', 'post-join lobby');
+    await observe(manifest, joiner.page, 'signed-in-joiner', 'joined lobby');
+  } finally {
+    await Promise.allSettled([host.context.close(), joiner.context.close()]);
+  }
+}
+
+async function runSignedInHostGuestJoin({
+  baseUrl,
+  browser,
+  manifest,
+  outDir,
+  stagehand,
+}) {
+  const host = await createContextPage(browser, baseUrl);
+  const guest = await createContextPage(browser, baseUrl);
+  attachRuntimeErrorLogging(host.page, 'signed-in-host', manifest);
+  attachRuntimeErrorLogging(guest.page, 'guest-joiner', manifest);
+
+  try {
+    await runCheck(manifest, 'signed-in host creates room', async () => {
+      await ensureClerkAuthState(host.page);
+      await host.page.goto('/host');
+      await perform({
+        actor: 'signed-in-host',
+        fallback: async () => {
+          await host.page.locator('input#name').fill('Agentic Clerk Host');
+          await host.page.getByRole('button', { name: /Create Room/i }).click();
+        },
+        instruction:
+          'Fill the host pen name field with "Agentic Clerk Host" and create the room.',
+        manifest,
+        page: host.page,
+        stagehand,
+      });
+      await host.page.waitForURL(/\/room\/[A-Z]{4}$/, { timeout: 30_000 });
+      await expect(host.page.getByText('Agentic Clerk Host')).toBeVisible();
+      await screenshot(manifest, host.page, outDir, 'host-lobby');
+    });
+
+    const roomCode = getRoomCode(host.page);
+    await runCheck(manifest, 'guest player joins room', async () => {
+      await guest.page.goto(`/join?code=${roomCode}`);
+      await perform({
+        actor: 'guest-joiner',
+        fallback: async () => {
+          await guest.page.locator('input#name').fill('Agentic Guest User');
+          await guest.page.getByRole('button', { name: /Enter Room/i }).click();
+        },
+        instruction:
+          'Fill the join pen name field with "Agentic Guest User" and enter the room.',
+        manifest,
+        page: guest.page,
+        stagehand,
+      });
+      await guest.page.waitForURL(`/room/${roomCode}`, { timeout: 30_000 });
+      await expect(host.page.getByText('Agentic Guest User')).toBeVisible({
+        timeout: 15_000,
+      });
+      await screenshot(manifest, guest.page, outDir, 'guest-joined');
+    });
+
+    await observe(manifest, host.page, 'signed-in-host', 'post-join lobby');
+    await observe(manifest, guest.page, 'guest-joiner', 'joined lobby');
+  } finally {
+    await Promise.allSettled([host.context.close(), guest.context.close()]);
+  }
+}
+
+async function runMission(options) {
+  if (options.mission.id === 'guest-host-signed-in-join') {
+    await runGuestHostSignedInJoin(options);
+    return;
+  }
+
+  if (options.mission.id === 'signed-in-host-guest-join') {
+    await runSignedInHostGuestJoin(options);
+    return;
+  }
+
+  throw new Error(`No runner implemented for ${options.mission.id}`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const target = normalizeAgenticTarget(args.target);
+  const mission = resolveAgenticMission(args.missionId);
+  const baseUrl = resolveAgenticBaseUrl({
+    baseUrl: args.baseUrl,
+    target,
+  });
+
+  assertAgenticMissionEnvironment(mission);
+  requireStagehandModelEnv();
+
+  const runId = createAgenticRunId({ missionId: mission.id, target });
+  const outDir = args.outDir || path.join('.qa', 'runs', runId);
+  const manifestPath = path.join(outDir, 'manifest.json');
+  const manifest = createAgenticManifest({
+    baseUrl,
+    mission,
+    runId,
+    target,
+  });
+
+  await fs.mkdir(outDir, { recursive: true });
+
+  let browser;
+  let stagehand;
+  let runError = null;
+
+  try {
+    stagehand = await createStagehand();
+    browser = await chromium.launch({
+      headless: process.env.LINEJAM_AGENTIC_HEADFUL !== '1',
+    });
+    await runMission({
+      baseUrl,
+      browser,
+      manifest,
+      mission,
+      outDir,
+      stagehand,
+    });
+    markAgenticManifestFinished(manifest, 'PASS');
+  } catch (error) {
+    runError = error;
+    manifest.runtimeErrors.push(errorMessage(error));
+    markAgenticManifestFinished(manifest, 'FAIL');
+  } finally {
+    await Promise.allSettled([browser?.close(), stagehand?.close()]);
+  }
+
+  await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  const critic = await writeAgenticCriticArtifacts({
+    manifest,
+    mission,
+    outDir,
+  });
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        critic: critic.verdict,
+        manifest: manifestPath,
+        outDir,
+        result: manifest.status,
+        summary: critic.summaryPath,
+      },
+      null,
+      2
+    )}\n`
+  );
+
+  if (runError) {
+    throw runError;
+  }
+
+  if (critic.verdict !== 'pass') {
+    throw new Error(critic.summary);
+  }
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void main().catch((error) => {
+    console.error(errorMessage(error));
+    process.exit(1);
+  });
+}

--- a/scripts/qa/agentic-runner.mjs
+++ b/scripts/qa/agentic-runner.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { createClerkClient } from '@clerk/backend';
-import { clerk } from '@clerk/testing/playwright';
+import { clerk, clerkSetup } from '@clerk/testing/playwright';
 import { chromium, expect } from '@playwright/test';
 import { Stagehand } from '@browserbasehq/stagehand';
 import { promises as fs } from 'node:fs';
@@ -27,6 +27,7 @@ import {
 import { writeAgenticCriticArtifacts } from '../../qa/agentic/critic.mjs';
 
 const DEFAULT_CLERK_TEST_EMAIL = 'linejam-e2e+clerk_test@example.com';
+let clerkSetupPromise = null;
 
 function parseArgs(argv) {
   const args = {
@@ -108,6 +109,10 @@ async function createStagehand() {
   return stagehand;
 }
 
+function withBaseUrl(baseUrl, targetPath) {
+  return new URL(targetPath, `${baseUrl}/`).toString();
+}
+
 async function perform({
   actor,
   fallback,
@@ -164,25 +169,44 @@ async function runCheck(manifest, name, fn) {
   }
 }
 
-async function createContextPage(browser, baseUrl) {
+async function createContextPage(baseUrl) {
+  const stagehand = await createStagehand();
+
+  if (stagehand) {
+    const browser = await chromium.connectOverCDP(stagehand.connectURL());
+    const context = browser.contexts()[0];
+
+    if (!context) {
+      throw new Error(
+        'Stagehand Playwright bridge did not expose a browser context.'
+      );
+    }
+
+    const page = context.pages()[0] || (await context.newPage());
+    return { browser, context, page, stagehand };
+  }
+
+  const browser = await chromium.launch({
+    headless: process.env.LINEJAM_AGENTIC_HEADFUL !== '1',
+  });
   const context = await browser.newContext({ baseURL: baseUrl });
   const page = await context.newPage();
-  return { context, page };
+  return { browser, context, page, stagehand: null };
 }
 
-async function ensureClerkAuthState(page) {
+async function ensureClerkAuthState(page, baseUrl) {
   const secretKey = process.env.CLERK_SECRET_KEY?.trim();
   if (!secretKey) {
     throw new Error('CLERK_SECRET_KEY is required for signed-in agentic QA.');
   }
-  process.env.CLERK_PUBLISHABLE_KEY ??=
-    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+  await ensureClerkTestingSetup();
 
   const emailAddress =
     process.env.PLAYWRIGHT_CLERK_TEST_EMAIL?.trim() || DEFAULT_CLERK_TEST_EMAIL;
 
   await ensureClerkSmokeUser(secretKey, emailAddress);
-  await page.goto('/');
+  await page.goto(withBaseUrl(baseUrl, '/'));
   await clerk.signIn({ page, emailAddress });
   await clerk.loaded({ page });
   await page.waitForFunction(
@@ -205,6 +229,18 @@ async function ensureClerkAuthState(page) {
     },
     { timeout: 30_000 }
   );
+}
+
+async function ensureClerkTestingSetup() {
+  process.env.CLERK_PUBLISHABLE_KEY ??=
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+  clerkSetupPromise ??= clerkSetup().catch((error) => {
+    clerkSetupPromise = null;
+    throw error;
+  });
+
+  await clerkSetupPromise;
 }
 
 async function ensureClerkSmokeUser(secretKey, emailAddress) {
@@ -278,30 +314,41 @@ function attachRuntimeErrorLogging(page, actor, manifest) {
 
 async function runGuestHostSignedInJoin({
   baseUrl,
-  browser,
   manifest,
   outDir,
-  stagehand,
 }) {
-  const host = await createContextPage(browser, baseUrl);
-  const joiner = await createContextPage(browser, baseUrl);
+  const host = await createContextPage(baseUrl);
+  const joiner = await createContextPage(baseUrl);
   attachRuntimeErrorLogging(host.page, 'guest-host', manifest);
   attachRuntimeErrorLogging(joiner.page, 'signed-in-joiner', manifest);
 
   try {
     await runCheck(manifest, 'guest host creates room', async () => {
-      await host.page.goto('/host');
+      await host.page.goto(withBaseUrl(baseUrl, '/host'));
+      await host.page.locator('input#name').waitFor({
+        state: 'visible',
+        timeout: 30_000,
+      });
       await perform({
         actor: 'guest-host',
         fallback: async () => {
           await host.page.locator('input#name').fill('Agentic Guest Host');
-          await host.page.getByRole('button', { name: /Create Room/i }).click();
         },
         instruction:
-          'Fill the host pen name field with "Agentic Guest Host" and create the room.',
+          'Type "Agentic Guest Host" into the name input.',
         manifest,
         page: host.page,
-        stagehand,
+        stagehand: host.stagehand,
+      });
+      await perform({
+        actor: 'guest-host',
+        fallback: async () => {
+          await host.page.getByRole('button', { name: /Create Room/i }).click();
+        },
+        instruction: 'Click the "Create Room" button.',
+        manifest,
+        page: host.page,
+        stagehand: host.stagehand,
       });
       await host.page.waitForURL(/\/room\/[A-Z]{4}$/, { timeout: 30_000 });
       await expect(host.page.getByText('Agentic Guest Host')).toBeVisible();
@@ -310,23 +357,38 @@ async function runGuestHostSignedInJoin({
 
     const roomCode = getRoomCode(host.page);
     await runCheck(manifest, 'signed-in player joins room', async () => {
-      await ensureClerkAuthState(joiner.page);
-      await joiner.page.goto(`/join?code=${roomCode}`);
+      await ensureClerkAuthState(joiner.page, baseUrl);
+      await joiner.page.goto(withBaseUrl(baseUrl, `/join?code=${roomCode}`));
+      await joiner.page.locator('input#name').waitFor({
+        state: 'visible',
+        timeout: 30_000,
+      });
       await perform({
         actor: 'signed-in-joiner',
         fallback: async () => {
           await joiner.page.locator('input#name').fill('Agentic Clerk User');
+        },
+        instruction:
+          'Type "Agentic Clerk User" into the name input.',
+        manifest,
+        page: joiner.page,
+        stagehand: joiner.stagehand,
+      });
+      await perform({
+        actor: 'signed-in-joiner',
+        fallback: async () => {
           await joiner.page
             .getByRole('button', { name: /Enter Room/i })
             .click();
         },
-        instruction:
-          'Fill the join pen name field with "Agentic Clerk User" and enter the room.',
+        instruction: 'Click the "Enter Room" button.',
         manifest,
         page: joiner.page,
-        stagehand,
+        stagehand: joiner.stagehand,
       });
-      await joiner.page.waitForURL(`/room/${roomCode}`, { timeout: 30_000 });
+      await joiner.page.waitForURL(new RegExp(`/room/${roomCode}$`), {
+        timeout: 30_000,
+      });
       await expect(host.page.getByText('Agentic Clerk User')).toBeVisible({
         timeout: 15_000,
       });
@@ -336,37 +398,53 @@ async function runGuestHostSignedInJoin({
     await observe(manifest, host.page, 'guest-host', 'post-join lobby');
     await observe(manifest, joiner.page, 'signed-in-joiner', 'joined lobby');
   } finally {
-    await Promise.allSettled([host.context.close(), joiner.context.close()]);
+    await Promise.allSettled([
+      host.browser.close(),
+      host.stagehand?.close(),
+      joiner.browser.close(),
+      joiner.stagehand?.close(),
+    ]);
   }
 }
 
 async function runSignedInHostGuestJoin({
   baseUrl,
-  browser,
   manifest,
   outDir,
-  stagehand,
 }) {
-  const host = await createContextPage(browser, baseUrl);
-  const guest = await createContextPage(browser, baseUrl);
+  const host = await createContextPage(baseUrl);
+  const guest = await createContextPage(baseUrl);
   attachRuntimeErrorLogging(host.page, 'signed-in-host', manifest);
   attachRuntimeErrorLogging(guest.page, 'guest-joiner', manifest);
 
   try {
     await runCheck(manifest, 'signed-in host creates room', async () => {
-      await ensureClerkAuthState(host.page);
-      await host.page.goto('/host');
+      await ensureClerkAuthState(host.page, baseUrl);
+      await host.page.goto(withBaseUrl(baseUrl, '/host'));
+      await host.page.locator('input#name').waitFor({
+        state: 'visible',
+        timeout: 30_000,
+      });
       await perform({
         actor: 'signed-in-host',
         fallback: async () => {
           await host.page.locator('input#name').fill('Agentic Clerk Host');
-          await host.page.getByRole('button', { name: /Create Room/i }).click();
         },
         instruction:
-          'Fill the host pen name field with "Agentic Clerk Host" and create the room.',
+          'Type "Agentic Clerk Host" into the name input.',
         manifest,
         page: host.page,
-        stagehand,
+        stagehand: host.stagehand,
+      });
+      await perform({
+        actor: 'signed-in-host',
+        fallback: async () => {
+          await host.page.getByRole('button', { name: /Create Room/i }).click();
+        },
+        instruction: 'Click the "Create Room" button.',
+        manifest,
+        page: host.page,
+        stagehand: host.stagehand,
       });
       await host.page.waitForURL(/\/room\/[A-Z]{4}$/, { timeout: 30_000 });
       await expect(host.page.getByText('Agentic Clerk Host')).toBeVisible();
@@ -375,20 +453,35 @@ async function runSignedInHostGuestJoin({
 
     const roomCode = getRoomCode(host.page);
     await runCheck(manifest, 'guest player joins room', async () => {
-      await guest.page.goto(`/join?code=${roomCode}`);
+      await guest.page.goto(withBaseUrl(baseUrl, `/join?code=${roomCode}`));
+      await guest.page.locator('input#name').waitFor({
+        state: 'visible',
+        timeout: 30_000,
+      });
       await perform({
         actor: 'guest-joiner',
         fallback: async () => {
           await guest.page.locator('input#name').fill('Agentic Guest User');
-          await guest.page.getByRole('button', { name: /Enter Room/i }).click();
         },
         instruction:
-          'Fill the join pen name field with "Agentic Guest User" and enter the room.',
+          'Type "Agentic Guest User" into the name input.',
         manifest,
         page: guest.page,
-        stagehand,
+        stagehand: guest.stagehand,
       });
-      await guest.page.waitForURL(`/room/${roomCode}`, { timeout: 30_000 });
+      await perform({
+        actor: 'guest-joiner',
+        fallback: async () => {
+          await guest.page.getByRole('button', { name: /Enter Room/i }).click();
+        },
+        instruction: 'Click the "Enter Room" button.',
+        manifest,
+        page: guest.page,
+        stagehand: guest.stagehand,
+      });
+      await guest.page.waitForURL(new RegExp(`/room/${roomCode}$`), {
+        timeout: 30_000,
+      });
       await expect(host.page.getByText('Agentic Guest User')).toBeVisible({
         timeout: 15_000,
       });
@@ -398,7 +491,12 @@ async function runSignedInHostGuestJoin({
     await observe(manifest, host.page, 'signed-in-host', 'post-join lobby');
     await observe(manifest, guest.page, 'guest-joiner', 'joined lobby');
   } finally {
-    await Promise.allSettled([host.context.close(), guest.context.close()]);
+    await Promise.allSettled([
+      host.browser.close(),
+      host.stagehand?.close(),
+      guest.browser.close(),
+      guest.stagehand?.close(),
+    ]);
   }
 }
 
@@ -440,30 +538,20 @@ async function main() {
 
   await fs.mkdir(outDir, { recursive: true });
 
-  let browser;
-  let stagehand;
   let runError = null;
 
   try {
-    stagehand = await createStagehand();
-    browser = await chromium.launch({
-      headless: process.env.LINEJAM_AGENTIC_HEADFUL !== '1',
-    });
     await runMission({
       baseUrl,
-      browser,
       manifest,
       mission,
       outDir,
-      stagehand,
     });
     markAgenticManifestFinished(manifest, 'PASS');
   } catch (error) {
     runError = error;
     manifest.runtimeErrors.push(errorMessage(error));
     markAgenticManifestFinished(manifest, 'FAIL');
-  } finally {
-    await Promise.allSettled([browser?.close(), stagehand?.close()]);
   }
 
   await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/tests/scripts/agentic-qa.test.ts
+++ b/tests/scripts/agentic-qa.test.ts
@@ -211,13 +211,13 @@ describe('agentic QA Stagehand model environment', () => {
     expect(() =>
       assertStagehandModelEnvironment({
         env: { NODE_ENV: 'test' },
-        model: 'gpt-4.1-mini',
+        model: 'openai/gpt-4.1-mini',
       })
     ).toThrow(/OPENAI_API_KEY/);
     expect(() =>
       assertStagehandModelEnvironment({
         env: { NODE_ENV: 'test', OPENAI_API_KEY: 'sk-test' },
-        model: 'gpt-4.1-mini',
+        model: 'openai/gpt-4.1-mini',
       })
     ).not.toThrow();
   });

--- a/tests/scripts/agentic-qa.test.ts
+++ b/tests/scripts/agentic-qa.test.ts
@@ -1,0 +1,379 @@
+/** @vitest-environment node */
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { afterEach } from 'vitest';
+
+import {
+  DEFAULT_AGENTIC_MISSION,
+  assertAgenticMissionEnvironment,
+  createAgenticRunId,
+  listAgenticMissions,
+  normalizeAgenticTarget,
+  resolveAgenticBaseUrl,
+  resolveAgenticMission,
+} from '@/qa/agentic/missions.mjs';
+import {
+  createAgenticManifest,
+  detectGenericErrors,
+  markAgenticManifestFinished,
+  validateAgenticManifest,
+} from '@/qa/agentic/manifest.mjs';
+import {
+  assertStagehandModelEnvironment,
+  requiredStagehandProviderEnvKeys,
+} from '@/qa/agentic/modelEnv.mjs';
+import {
+  scoreAgenticManifest,
+  writeAgenticCriticArtifacts,
+} from '@/qa/agentic/critic.mjs';
+
+function createManifest(overrides = {}) {
+  const mission = resolveAgenticMission(DEFAULT_AGENTIC_MISSION);
+
+  return {
+    version: 1,
+    runId: 'test-run',
+    target: 'local',
+    baseUrl: 'http://localhost:3000',
+    mission,
+    startedAt: '2026-04-23T00:00:00.000Z',
+    finishedAt: '2026-04-23T00:00:01.000Z',
+    status: 'PASS',
+    checks: [{ name: 'signed-in join completed', status: 'PASS' }],
+    observations: [
+      { actor: 'host', label: 'lobby', text: 'Canary Clerk User' },
+    ],
+    runtimeErrors: [],
+    screenshots: mission.requiredScreenshots.map((label) => ({
+      label,
+      file: `${label}.png`,
+    })),
+    transcript: [],
+    ...overrides,
+  };
+}
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+describe('agentic QA mission config', () => {
+  it('resolves named missions and rejects unknown targets', () => {
+    expect(resolveAgenticMission('guest-host-signed-in-join').title).toBe(
+      'Guest host, signed-in joiner'
+    );
+    expect(resolveAgenticMission('signed-in-host-guest-join').title).toBe(
+      'Signed-in host, guest joiner'
+    );
+    expect(() => normalizeAgenticTarget('production')).toThrow(
+      /Expected local or preview/
+    );
+  });
+
+  it('lists missions defensively and rejects unknown mission ids', () => {
+    const listed = listAgenticMissions();
+
+    expect(listed).toHaveLength(2);
+    listed[0]!.title = 'mutated';
+
+    expect(resolveAgenticMission(DEFAULT_AGENTIC_MISSION).title).toBe(
+      'Guest host, signed-in joiner'
+    );
+    expect(() => resolveAgenticMission('missing-mission')).toThrow(
+      /Unknown agentic QA mission/
+    );
+  });
+
+  it('requires an explicit preview base URL', () => {
+    expect(
+      resolveAgenticBaseUrl({
+        target: 'local',
+        baseUrl: '',
+      })
+    ).toBe('http://localhost:3000');
+    expect(() =>
+      resolveAgenticBaseUrl({
+        target: 'preview',
+        baseUrl: '',
+      })
+    ).toThrow(/PLAYWRIGHT_BASE_URL/);
+  });
+
+  it('normalizes explicit targets, urls, and run ids', () => {
+    expect(normalizeAgenticTarget('preview')).toBe('preview');
+    expect(
+      resolveAgenticBaseUrl({
+        target: 'preview',
+        baseUrl: 'https://preview.linejam.app/',
+      })
+    ).toBe('https://preview.linejam.app');
+    expect(
+      createAgenticRunId({
+        missionId: DEFAULT_AGENTIC_MISSION,
+        now: new Date('2026-04-23T00:00:00.000Z'),
+        target: 'preview',
+      })
+    ).toBe('2026-04-23T00-00-00-000Z-preview-guest-host-signed-in-join');
+  });
+
+  it('fails closed when an authenticated mission lacks Clerk env', () => {
+    const mission = resolveAgenticMission(DEFAULT_AGENTIC_MISSION);
+
+    expect(() =>
+      assertAgenticMissionEnvironment(mission, { NODE_ENV: 'test' })
+    ).toThrow(/requires authenticated Clerk coverage/);
+    expect(() =>
+      assertAgenticMissionEnvironment(mission, {
+        NODE_ENV: 'test',
+        CLERK_SECRET_KEY: 'sk_test_example',
+        CLERK_PUBLISHABLE_KEY: 'pk_test_example',
+      })
+    ).not.toThrow();
+  });
+});
+
+describe('agentic QA manifest helpers', () => {
+  it('creates and finishes a manifest with the expected shape', () => {
+    const mission = resolveAgenticMission(DEFAULT_AGENTIC_MISSION);
+    const manifest = createAgenticManifest({
+      baseUrl: 'https://preview.linejam.app',
+      mission,
+      runId: 'run-123',
+      startedAt: '2026-04-23T00:00:00.000Z',
+      target: 'preview',
+    });
+
+    expect(manifest).toMatchObject({
+      version: 1,
+      runId: 'run-123',
+      status: 'RUNNING',
+      baseUrl: 'https://preview.linejam.app',
+      observations: [],
+      runtimeErrors: [],
+      screenshots: [],
+      transcript: [],
+    });
+
+    const finished = markAgenticManifestFinished(
+      manifest,
+      'PASS',
+      new Date('2026-04-23T00:00:01.000Z')
+    );
+
+    expect(finished.status).toBe('PASS');
+    expect(finished.finishedAt).toBe('2026-04-23T00:00:01.000Z');
+  });
+
+  it('detects generic error variants and truncates long excerpts', () => {
+    const genericErrors = detectGenericErrors([
+      'Something went wrong while joining the room.',
+      `${'x'.repeat(200)} application error`,
+    ]);
+
+    expect(genericErrors).toHaveLength(2);
+    expect(genericErrors[0]?.pattern).toContain('something went wrong');
+    expect(genericErrors[1]?.excerpt.length).toBeLessThanOrEqual(160);
+    expect(detectGenericErrors(['All clear.'])).toEqual([]);
+  });
+
+  it('validates malformed manifests and failing checks', () => {
+    const mission = resolveAgenticMission(DEFAULT_AGENTIC_MISSION);
+
+    expect(validateAgenticManifest(null, mission)).toEqual({
+      ok: false,
+      errors: ['manifest must be an object'],
+    });
+
+    const result = validateAgenticManifest(
+      createManifest({
+        version: 2,
+        status: 'BROKEN',
+        checks: [{ name: 'join completed', status: 'FAIL' }],
+      }),
+      mission
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain('manifest version must be 1');
+    expect(result.errors).toContain('status must be RUNNING, PASS, or FAIL');
+    expect(result.errors).toContain('check failed: join completed');
+  });
+});
+
+describe('agentic QA Stagehand model environment', () => {
+  it('requires OPENAI_API_KEY for the default OpenAI Stagehand model', () => {
+    expect(() =>
+      assertStagehandModelEnvironment({
+        env: { NODE_ENV: 'test' },
+        model: 'gpt-4.1-mini',
+      })
+    ).toThrow(/OPENAI_API_KEY/);
+    expect(() =>
+      assertStagehandModelEnvironment({
+        env: { NODE_ENV: 'test', OPENAI_API_KEY: 'sk-test' },
+        model: 'gpt-4.1-mini',
+      })
+    ).not.toThrow();
+  });
+
+  it('accepts Google provider keys for Gemini Stagehand models', () => {
+    expect(() =>
+      assertStagehandModelEnvironment({
+        env: { NODE_ENV: 'test', GOOGLE_GENERATIVE_AI_API_KEY: 'google-key' },
+        model: 'gemini-2.0-flash',
+      })
+    ).not.toThrow();
+  });
+
+  it('maps provider-specific env requirements across supported model families', () => {
+    expect(requiredStagehandProviderEnvKeys('claude-sonnet-4-5')).toEqual([
+      'ANTHROPIC_API_KEY',
+    ]);
+    expect(requiredStagehandProviderEnvKeys('groq/llama-3.3-70b')).toEqual([
+      'GROQ_API_KEY',
+    ]);
+    expect(
+      requiredStagehandProviderEnvKeys('cerebras/llama-4-scout-17b')
+    ).toEqual(['CEREBRAS_API_KEY']);
+    expect(requiredStagehandProviderEnvKeys('custom-model')).toEqual([
+      'ANTHROPIC_API_KEY',
+      'CEREBRAS_API_KEY',
+      'GOOGLE_API_KEY',
+      'GOOGLE_GENERATIVE_AI_API_KEY',
+      'GROQ_API_KEY',
+      'OPENAI_API_KEY',
+    ]);
+  });
+
+  it('accepts Anthropic, Groq, Cerebras, and fallback provider credentials', () => {
+    expect(() =>
+      assertStagehandModelEnvironment({
+        env: { NODE_ENV: 'test', ANTHROPIC_API_KEY: 'anthropic-key' },
+        model: 'claude-sonnet-4-5',
+      })
+    ).not.toThrow();
+    expect(() =>
+      assertStagehandModelEnvironment({
+        env: { NODE_ENV: 'test', GROQ_API_KEY: 'groq-key' },
+        model: 'groq/llama-3.3-70b',
+      })
+    ).not.toThrow();
+    expect(() =>
+      assertStagehandModelEnvironment({
+        env: { NODE_ENV: 'test', CEREBRAS_API_KEY: 'cerebras-key' },
+        model: 'cerebras/llama-4-scout-17b',
+      })
+    ).not.toThrow();
+    expect(() =>
+      assertStagehandModelEnvironment({
+        env: { NODE_ENV: 'test', GOOGLE_API_KEY: 'google-key' },
+        model: 'custom-model',
+      })
+    ).not.toThrow();
+  });
+});
+
+describe('agentic QA critic', () => {
+  it('passes a healthy mission manifest', () => {
+    const mission = resolveAgenticMission(DEFAULT_AGENTIC_MISSION);
+    const result = scoreAgenticManifest(createManifest(), mission);
+
+    expect(result.verdict).toBe('pass');
+    expect(result.blockingReasons).toEqual([]);
+  });
+
+  it('fails a manifest that shows generic join error UI', () => {
+    const mission = resolveAgenticMission(DEFAULT_AGENTIC_MISSION);
+    const result = scoreAgenticManifest(
+      createManifest({
+        observations: [
+          {
+            actor: 'signed-in-joiner',
+            label: 'join',
+            text: 'An unexpected error occurred while joining the room.',
+          },
+        ],
+      }),
+      mission
+    );
+
+    expect(result.verdict).toBe('fail');
+    expect(result.blockingReasons.join('\n')).toMatch(/generic error UI/);
+  });
+
+  it('fails a manifest that is missing required screenshot artifacts', () => {
+    const mission = resolveAgenticMission(DEFAULT_AGENTIC_MISSION);
+    const result = scoreAgenticManifest(
+      createManifest({
+        screenshots: [{ label: 'host-lobby', file: 'host-lobby.png' }],
+      }),
+      mission
+    );
+
+    expect(result.verdict).toBe('fail');
+    expect(result.blockingReasons).toContain(
+      'missing required screenshot: signed-in-joined'
+    );
+  });
+
+  it('fails a manifest that captured browser runtime errors', () => {
+    const mission = resolveAgenticMission(DEFAULT_AGENTIC_MISSION);
+    const result = scoreAgenticManifest(
+      createManifest({
+        runtimeErrors: ['[host] console: application exploded'],
+      }),
+      mission
+    );
+
+    expect(result.verdict).toBe('fail');
+    expect(result.blockingReasons).toContain('runtime errors captured: 1');
+  });
+
+  it('writes critic artifacts for both passing and failing manifests', async () => {
+    const passDir = await mkdtemp(
+      path.join(os.tmpdir(), 'linejam-agentic-pass-')
+    );
+    const failDir = await mkdtemp(
+      path.join(os.tmpdir(), 'linejam-agentic-fail-')
+    );
+    tempDirs.push(passDir, failDir);
+
+    const mission = resolveAgenticMission(DEFAULT_AGENTIC_MISSION);
+    const passArtifacts = await writeAgenticCriticArtifacts({
+      manifest: createManifest(),
+      mission,
+      outDir: passDir,
+    });
+    const failArtifacts = await writeAgenticCriticArtifacts({
+      manifest: createManifest({
+        observations: [
+          {
+            actor: 'joiner',
+            label: 'join',
+            text: 'Something went wrong while joining.',
+          },
+        ],
+      }),
+      mission,
+      outDir: failDir,
+    });
+
+    expect(passArtifacts.verdict).toBe('pass');
+    expect(failArtifacts.verdict).toBe('fail');
+    await expect(
+      readFile(passArtifacts.summaryPath, 'utf8')
+    ).resolves.toContain('- None');
+    await expect(readFile(failArtifacts.resultPath, 'utf8')).resolves.toContain(
+      '"verdict": "fail"'
+    );
+    await expect(
+      readFile(failArtifacts.summaryPath, 'utf8')
+    ).resolves.toContain('generic error UI detected');
+  });
+});

--- a/tests/scripts/canary-store.test.ts
+++ b/tests/scripts/canary-store.test.ts
@@ -1,5 +1,5 @@
 /** @vitest-environment node */
-import { mkdtemp, readFile, rm, utimes } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, utimes } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -99,6 +99,19 @@ describe('canary store helpers', () => {
     expect(await readFile(summaryPath, 'utf8')).toBe('# Summary');
   });
 
+  it('builds agentic artifact paths from the configured store root', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'linejam-canary-store-'));
+    tempDirs.push(dir);
+    const store = await loadStoreModule(dir);
+
+    expect(store.agenticArtifactDir('evt:abc/123')).toBe(
+      path.join(dir, 'agentic', 'evt-abc-123')
+    );
+    expect(store.agenticArtifactDir('')).toBe(
+      path.join(dir, 'agentic', 'manual')
+    );
+  });
+
   it('persists fingerprints and reports existence', async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), 'linejam-canary-store-'));
     tempDirs.push(dir);
@@ -156,5 +169,46 @@ describe('canary store helpers', () => {
     expect(result.deletedFiles).toEqual([staleDelivery]);
     await expect(readFile(staleDelivery, 'utf8')).rejects.toThrow();
     await expect(readFile(freshSummary, 'utf8')).resolves.toBe('# Fresh');
+  });
+
+  it('prunes stale agentic run directories after the retention window', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'linejam-canary-store-'));
+    tempDirs.push(dir);
+    const store = await loadStoreModule(dir);
+    const staleRun = path.join(dir, 'agentic', 'evt-old');
+    const freshRun = path.join(dir, 'agentic', 'evt-fresh');
+
+    await mkdir(staleRun, { recursive: true });
+    await mkdir(freshRun, { recursive: true });
+    const staleManifest = await store.persistJson(
+      'agentic/evt-old',
+      'manifest',
+      {
+        stale: true,
+      }
+    );
+    const freshManifest = await store.persistJson(
+      'agentic/evt-fresh',
+      'manifest',
+      {
+        stale: false,
+      }
+    );
+
+    const staleDate = new Date('2024-01-01T00:00:00.000Z');
+    const freshDate = new Date('2026-04-08T00:00:00.000Z');
+    await utimes(staleRun, staleDate, staleDate);
+    await utimes(freshRun, freshDate, freshDate);
+
+    const result = await store.pruneExpiredArtifacts({
+      now: new Date('2026-04-08T00:00:00.000Z').getTime(),
+      retentionDays: 30,
+    });
+
+    expect(result.deletedFiles).toEqual([staleRun]);
+    await expect(readFile(staleManifest, 'utf8')).rejects.toThrow();
+    await expect(readFile(freshManifest, 'utf8')).resolves.toContain(
+      '"stale": false'
+    );
   });
 });

--- a/tests/scripts/canary-trigger-smoke.test.ts
+++ b/tests/scripts/canary-trigger-smoke.test.ts
@@ -57,6 +57,11 @@ describe('runSmoke', () => {
     'CLERK_PUBLISHABLE_KEY',
     'CLERK_SECRET_KEY',
     'CANARY_API_KEY',
+    'LINEJAM_AGENTIC_MISSION',
+    'LINEJAM_AGENTIC_MODE',
+    'LINEJAM_AGENTIC_OUT_DIR',
+    'LINEJAM_STAGEHAND_MODEL',
+    'OPENAI_API_KEY',
   ] as const;
   const originalEnv = Object.fromEntries(
     trackedEnvKeys.map((key) => [key, process.env[key]])
@@ -158,6 +163,45 @@ describe('runSmoke', () => {
       })
     );
     expect(result.runner).toBe('playwright');
+  });
+
+  it('can run smoke with the agentic runner for Canary evidence handoff', async () => {
+    const child = createMockChild(0);
+    const spawnMock = vi.fn().mockReturnValue(child);
+    const { runSmoke } = await import('@/scripts/canary/trigger-smoke.mjs');
+    process.env.LINEJAM_AGENTIC_MISSION = 'guest-host-signed-in-join';
+    process.env.LINEJAM_AGENTIC_MODE = 'deterministic';
+    process.env.OPENAI_API_KEY = 'stagehand-key';
+    process.env.CLERK_PUBLISHABLE_KEY = 'pk_test_agentic';
+
+    const pending = runSmoke({
+      baseUrl: 'https://www.linejam.app',
+      eventName: 'error.new_class',
+      deliveryId: 'evt-agentic',
+      runner: 'agentic',
+      spawnProcess: spawnMock,
+      timeoutMs: 1000,
+    });
+    await Promise.resolve();
+    child.emit('close', child.exitCode);
+    const result = await pending;
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'pnpm',
+      ['qa:agentic:preview'],
+      expect.objectContaining({
+        cwd: REPO_ROOT,
+        env: expect.objectContaining({
+          LINEJAM_AGENTIC_MISSION: 'guest-host-signed-in-join',
+          LINEJAM_AGENTIC_MODE: 'deterministic',
+          LINEJAM_AGENTIC_OUT_DIR: '.canary/agentic/evt-agentic',
+          CLERK_PUBLISHABLE_KEY: 'pk_test_agentic',
+          OPENAI_API_KEY: 'stagehand-key',
+          PLAYWRIGHT_BASE_URL: 'https://www.linejam.app',
+        }),
+      })
+    );
+    expect(result.runner).toBe('agentic');
   });
 
   it('returns failed execution result when smoke exits non-zero', async () => {
@@ -319,6 +363,7 @@ describe('runSmoke', () => {
 
   it('forwards only the smoke allowlist into the child environment', async () => {
     process.env.UNRELATED_SECRET = 'should-not-leak';
+    process.env.OPENAI_API_KEY = 'stagehand-only-secret';
     process.env.CLERK_SECRET_KEY = 'clerk-secret';
     process.env.LINEJAM_ENFORCE_SMOKE_URL_ALLOWLIST = '1';
     process.env.LINEJAM_ALLOWED_SMOKE_ORIGINS = 'https://www.linejam.app';
@@ -357,6 +402,7 @@ describe('runSmoke', () => {
 
     const options = spawnMock.mock.calls[0]?.[2];
     expect(options.env.UNRELATED_SECRET).toBeUndefined();
+    expect(options.env.OPENAI_API_KEY).toBeUndefined();
   });
 
   it('fails fast when LINEJAM_SMOKE_RUNNER is invalid', async () => {
@@ -369,12 +415,12 @@ describe('runSmoke', () => {
       runner: 'bogus',
     });
 
-    expect(result).toMatchObject({
-      ok: false,
-      skipped: false,
-      reason:
-        'Unsupported LINEJAM_SMOKE_RUNNER: bogus. Expected one of dagger, playwright',
-    });
+    expect(result.ok).toBe(false);
+    expect(result.skipped).toBe(false);
+    expect(result.reason).toContain('Unsupported LINEJAM_SMOKE_RUNNER: bogus.');
+    expect(result.reason).toContain('agentic');
+    expect(result.reason).toContain('dagger');
+    expect(result.reason).toContain('playwright');
   });
 
   it('fails fast when smoke allowlisting rejects the base url', async () => {

--- a/tests/scripts/dagger-call.test.ts
+++ b/tests/scripts/dagger-call.test.ts
@@ -71,13 +71,18 @@ function runDaggerCall(
   command: string,
   env: Record<string, string> = {}
 ) {
+  const baseEnv = { ...process.env };
+  delete baseEnv.NODE_CHANNEL_FD;
+  delete baseEnv.NODE_CHANNEL_SERIALIZATION_MODE;
+  delete baseEnv.NODE_UNIQUE_ID;
+
   return spawnSync(
     'bash',
     ['--noprofile', '--norc', '-lc', `scripts/ci/dagger-call.sh ${command}`],
     {
       cwd: workspace,
       env: {
-        ...process.env,
+        ...baseEnv,
         ...env,
         PATH: `${binDir}:${process.env.PATH ?? ''}`,
       },
@@ -199,6 +204,114 @@ exit 1
     expect(result.stderr).toContain(
       'Dagger transport cleanup failed after format-check completed successfully; treating the run as passed.'
     );
+  });
+
+  it('passes advisory agentic QA preview args without requiring Canary browser config', () => {
+    const { workspace, scriptsDir, binDir } = createWorkspaceFixture();
+    workspaces.push(workspace);
+
+    const argsLog = join(workspace, 'dagger-args.log');
+
+    copyFileSync(
+      resolve(process.cwd(), 'scripts/ci/dotenv.mjs'),
+      join(scriptsDir, 'dotenv.mjs')
+    );
+    writeFileSync(
+      join(workspace, '.env.local'),
+      [
+        'PLAYWRIGHT_BASE_URL=https://preview.linejam.app',
+        'LINEJAM_AGENTIC_MISSION=guest-host-signed-in-join',
+      ].join('\n')
+    );
+    writeExecutable(
+      join(binDir, 'dagger'),
+      `#!/bin/sh
+printf '%s\n' "$@" > "${argsLog}"
+`
+    );
+
+    initGitRepo(workspace);
+
+    const result = runDaggerCall(workspace, binDir, 'agentic-qa-preview');
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+
+    const args = readFileSync(argsLog, 'utf8').trim().split('\n');
+    expect(args).toContain('call');
+    expect(args).toContain('agentic-qa-preview');
+    expect(args).toContain('--base-url=https://preview.linejam.app');
+    expect(args).toContain('--mission=guest-host-signed-in-join');
+  });
+
+  it('runs advisory agentic QA fixture mode without a base URL', () => {
+    const { workspace, scriptsDir, binDir } = createWorkspaceFixture();
+    workspaces.push(workspace);
+
+    const argsLog = join(workspace, 'dagger-args.log');
+
+    copyFileSync(
+      resolve(process.cwd(), 'scripts/ci/dotenv.mjs'),
+      join(scriptsDir, 'dotenv.mjs')
+    );
+    writeFileSync(
+      join(workspace, '.env.local'),
+      [
+        'LINEJAM_ENFORCE_SMOKE_URL_ALLOWLIST=1',
+        'LINEJAM_AGENTIC_MISSION=guest-host-signed-in-join',
+      ].join('\n')
+    );
+    writeExecutable(
+      join(binDir, 'dagger'),
+      `#!/bin/sh
+printf '%s\n' "$@" > "${argsLog}"
+`
+    );
+
+    initGitRepo(workspace);
+
+    const result = runDaggerCall(workspace, binDir, 'agentic-qa');
+
+    expect(result.status).toBe(0);
+    const args = readFileSync(argsLog, 'utf8').trim().split('\n');
+    expect(args).toContain('agentic-qa');
+    expect(args.some((arg) => arg.startsWith('--base-url='))).toBe(false);
+    expect(args.some((arg) => arg.startsWith('--mission='))).toBe(false);
+  });
+
+  it('rejects untrusted advisory agentic QA preview origins before invoking dagger', () => {
+    const { workspace, scriptsDir, binDir } = createWorkspaceFixture();
+    workspaces.push(workspace);
+
+    const invokeLog = join(workspace, 'dagger-invoked.log');
+
+    copyFileSync(
+      resolve(process.cwd(), 'scripts/ci/dotenv.mjs'),
+      join(scriptsDir, 'dotenv.mjs')
+    );
+    writeFileSync(
+      join(workspace, '.env.local'),
+      [
+        'LINEJAM_ENFORCE_SMOKE_URL_ALLOWLIST=1',
+        'PLAYWRIGHT_BASE_URL=https://evil.example',
+      ].join('\n')
+    );
+    writeExecutable(
+      join(binDir, 'dagger'),
+      `#!/bin/sh
+printf 'called' > "${invokeLog}"
+`
+    );
+
+    initGitRepo(workspace);
+
+    const result = runDaggerCall(workspace, binDir, 'agentic-qa-preview');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Refusing to run smoke against untrusted origin https://evil.example.'
+    );
+    expect(existsSync(invokeLog)).toBe(false);
   });
 
   it('rejects untrusted smoke origins before invoking dagger', () => {


### PR DESCRIPTION
## Summary
- add an agentic QA harness with missions, manifest/critic utilities, promptfoo config, and runner scripts
- harden the preview runner to use the Stagehand-owned browser context, absolute target URLs, Clerk testing bootstrap, and a provider-qualified default model
- wire advisory Dagger lanes and Canary smoke handoff support for agentic runs
- document the workflow, codify runtime-path verification rules, and mark backlog item 007 done

## Verification
- pnpm test --run tests/scripts/agentic-qa.test.ts tests/scripts/canary-store.test.ts tests/scripts/canary-trigger-smoke.test.ts tests/scripts/dagger-call.test.ts
- pnpm qa:agentic:critic:fixtures
- pnpm ci:dagger:agentic-qa
- pnpm test --run tests/scripts/agentic-qa.test.ts
- pnpm lint
- pnpm ci:prepush

## Runtime Verification
- exercised command: `set -a && source .env.production.local && set +a && pnpm qa:agentic:preview --mission guest-host-signed-in-join --base-url https://www.linejam.app`
- target: `https://www.linejam.app`
- result: `PASS`
- artifact manifest: `.qa/runs/2026-04-23T16-26-20-550Z-preview-guest-host-signed-in-join/manifest.json`
- critic summary: `.qa/runs/2026-04-23T16-26-20-550Z-preview-guest-host-signed-in-join/critic-summary.md`
- screenshots: `01-host-lobby.png`, `02-signed-in-joined.png`

## Review And Refactor
- ran review lenses for shippability, module depth, and complexity; no blocking findings remained after synthesis
- absorbed the concrete refactor by centralizing the agentic artifact path in scripts/canary/store.mjs
- codified the same runtime-proof rule at the spellbook source and pulled the doctrine-level rule into this repo's AGENTS layer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agentic QA testing framework with Stagehand support for automated browser missions
  * New npm scripts for running agentic QA locally and in preview environments
  * New CI/CD advisory lanes for agentic QA testing and critic fixture generation

* **Documentation**
  * Added agentic QA usage guide and configuration reference
  * Updated testing documentation with agentic QA workflows

* **Tests**
  * Expanded test coverage for agentic QA mission resolution, manifest validation, and critic scoring

* **Chores**
  * Added Stagehand dependency for automated browser interactions
  * Updated .gitignore for QA directories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->