### PR TITLE
feat(game): consolidate to one core mode — delete rhyme + quick

### DIFF
--- a/backlog.d/019-drop-legacy-mode-columns.md
+++ b/backlog.d/019-drop-legacy-mode-columns.md
@@ -1,0 +1,28 @@
+# Drop the legacy mode columns from games + rooms
+
+Priority: P3 · Status: ready · Estimate: S
+
+## Goal
+
+The single-mode consolidation widened `games.mode` and `rooms.selectedMode` to
+`v.optional(v.string())` and left them in place — nothing reads or writes them,
+but dropping them outright would fail Convex schema validation against existing
+rows that still carry a value. Remove the dead columns properly so the "legacy,
+unused" comments don't become permanent fixtures.
+
+## Oracle
+
+- [ ] A one-shot `internalMutation` migration patches every `games` row to remove
+      `mode` and every `rooms` row to remove `selectedMode` (or sets them
+      undefined), run once against the deployment.
+- [ ] A follow-up schema change drops `games.mode` and `rooms.selectedMode`
+      entirely; `pnpm typecheck` + `pnpm test` stay green.
+- [ ] No reader/writer of either field exists (already true post-consolidation;
+      re-verify with a grep before dropping).
+
+## Notes
+
+Deferred from the mode consolidation (PR #275). Sequencing matters: migrate the
+data first, deploy, then drop the columns in a second change — dropping the
+validator while rows still carry the field breaks the deploy. Low priority; the
+optional columns are inert, this is pure hygiene.

--- a/components/Lobby.tsx
+++ b/components/Lobby.tsx
@@ -4,14 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useMutation } from 'convex/react';
 import { api } from '../convex/_generated/api';
-import {
-  GAME_MODES,
-  getGameRules,
-  normalizeGameMode,
-  type GameMode,
-} from '../convex/lib/gameRules';
 import { useUser } from '../lib/auth';
-import { cn } from '../lib/utils';
 import { errorToFeedback } from '../lib/errorFeedback';
 import { Alert } from './ui/Alert';
 import { Avatar } from './ui/Avatar';
@@ -49,12 +42,8 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
   const removeAiMutation = useMutation(api.ai.removeAiPlayer);
   const leaveLobbyMutation = useMutation(api.rooms.leaveLobby);
   const closeRoomMutation = useMutation(api.rooms.closeRoom);
-  const selectGameModeMutation = useMutation(api.rooms.selectGameMode);
   const [error, setError] = useState<string | null>(null);
   const [aiLoading, setAiLoading] = useState(false);
-  const [modeSaving, setModeSaving] = useState(false);
-
-  const selectedMode = normalizeGameMode(room.selectedMode);
 
   // For unique avatar colors
   const allStableIds = players.map((p) => p.stableId);
@@ -117,24 +106,6 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
       setError(feedback.message);
     } finally {
       setAiLoading(false);
-    }
-  };
-
-  const handleSelectMode = async (mode: GameMode) => {
-    if (!isHost || modeSaving || mode === selectedMode) return;
-    setError(null);
-    setModeSaving(true);
-    try {
-      await selectGameModeMutation({
-        roomCode: room.code,
-        mode,
-        guestToken: guestToken || undefined,
-      });
-    } catch (err) {
-      const feedback = errorToFeedback(err);
-      setError(feedback.message);
-    } finally {
-      setModeSaving(false);
     }
   };
 
@@ -231,60 +202,6 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
               <p className="text-base leading-relaxed text-text-secondary">
                 Share the code from the top bar. Add an AI player if needed.
               </p>
-            </div>
-
-            <div className="w-full space-y-3">
-              <p className="text-xs font-mono uppercase tracking-[0.32em] text-text-muted">
-                Game mode
-              </p>
-              <div
-                role="radiogroup"
-                aria-label="Game mode"
-                className="space-y-2"
-              >
-                {GAME_MODES.map((mode) => {
-                  const rules = getGameRules(mode);
-                  const isSelected = selectedMode === mode;
-                  return (
-                    <button
-                      key={mode}
-                      type="button"
-                      role="radio"
-                      aria-checked={isSelected}
-                      aria-label={rules.label}
-                      disabled={!isHost || modeSaving}
-                      onClick={() => handleSelectMode(mode)}
-                      className={cn(
-                        'w-full min-h-14 border px-4 py-3 text-left transition-all duration-[var(--duration-normal)]',
-                        isSelected
-                          ? 'border-primary bg-surface shadow-sm'
-                          : 'border-border-subtle opacity-60',
-                        isHost &&
-                          !isSelected &&
-                          'hover:opacity-100 hover:border-border cursor-pointer',
-                        !isHost && 'cursor-default'
-                      )}
-                    >
-                      <span className="flex items-baseline justify-between gap-3">
-                        <span className="font-medium text-text-primary">
-                          {rules.label}
-                        </span>
-                        <span className="text-[10px] font-mono uppercase tracking-widest text-text-muted">
-                          {rules.wordCounts.length} rounds
-                        </span>
-                      </span>
-                      <span className="mt-0.5 block text-sm leading-snug text-text-secondary">
-                        {rules.tagline}
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-              {!isHost && (
-                <p className="text-xs text-text-muted">
-                  The host picks the mode.
-                </p>
-              )}
             </div>
 
             {canAddAi && (

--- a/components/PoemDisplay.tsx
+++ b/components/PoemDisplay.tsx
@@ -56,30 +56,6 @@ interface PoemDisplayProps {
   allStableIds?: string[];
   variant?: 'reveal' | 'archive';
   metadata?: PoemMetadata;
-  /** Rhyme Relay: spotlight the bookend words once the poem is fully revealed. */
-  rhymeMode?: boolean;
-}
-
-function LineText({
-  text,
-  emphasizeLastWord,
-}: {
-  text: string;
-  emphasizeLastWord: boolean;
-}) {
-  if (!emphasizeLastWord) return <>{text}</>;
-  const match = text.match(/^([\s\S]*?)(\S+)(\s*)$/);
-  if (!match) return <>{text}</>;
-  const [, head, last, tail] = match;
-  return (
-    <>
-      {head}
-      <span className="text-primary transition-colors duration-700">
-        {last}
-      </span>
-      {tail}
-    </>
-  );
 }
 
 function formatDate(timestamp: number): string {
@@ -96,7 +72,6 @@ export function PoemDisplay({
   allStableIds,
   variant = 'reveal',
   metadata,
-  rhymeMode = false,
 }: PoemDisplayProps) {
   const isArchive = variant === 'archive';
 
@@ -298,14 +273,7 @@ export function PoemDisplay({
                         clipPath: isVisible ? undefined : 'inset(0 100% 0 0)',
                       }}
                     >
-                      <LineText
-                        text={line.text}
-                        emphasizeLastWord={
-                          rhymeMode &&
-                          allRevealed &&
-                          (index === 0 || index === normalizedLines.length - 1)
-                        }
-                      />
+                      {line.text}
                     </p>
 
                     {/* Author byline.

--- a/components/RevealPhase.tsx
+++ b/components/RevealPhase.tsx
@@ -153,7 +153,6 @@ export function RevealPhase({
           onDone={() => setShowingPoemId(null)}
           alreadyRevealed={displayingPoem.isRevealed}
           allStableIds={allStableIds}
-          rhymeMode={state.mode === 'rhyme'}
           metadata={{
             createdAt: displayingPoem.createdAt,
             firstLine: displayingPoem.preview,

--- a/components/WritingScreen.tsx
+++ b/components/WritingScreen.tsx
@@ -30,9 +30,7 @@ interface WritingAssignment {
   lineIndex: number;
   targetWordCount: number;
   totalRounds?: number;
-  mode?: string;
   isFinalRound?: boolean;
-  rhymeTargetWord?: string | null;
   previousLineText?: string | null;
   roundStartedAt?: number;
 }
@@ -181,21 +179,6 @@ function WritingComposer({
           <div className="mb-16 animate-fade-in-up">
             <p className="text-2xl md:text-4xl lg:text-5xl font-[var(--font-display)] italic leading-relaxed text-text-secondary">
               {assignment.previousLineText}
-            </p>
-          </div>
-        )}
-
-        {/* Rhyme Relay: the closer's charge */}
-        {assignment.rhymeTargetWord && (
-          <div className="mb-12 animate-fade-in-up border-l-2 border-primary pl-4">
-            <p className="text-xs font-mono uppercase tracking-[0.32em] text-primary mb-1">
-              The last line
-            </p>
-            <p className="text-base text-text-secondary">
-              End on a word that rhymes with{' '}
-              <span className="font-[var(--font-display)] italic text-xl text-primary">
-                {assignment.rhymeTargetWord}
-              </span>
             </p>
           </div>
         )}

--- a/convex/abandonment.ts
+++ b/convex/abandonment.ts
@@ -30,8 +30,8 @@ import { applyLineLifecycleTransition } from './lib/sessionLifecycle';
 import {
   ABANDONMENT_HARD_DEADLINE_MS,
   ABANDONMENT_THRESHOLD_MS,
+  WORD_COUNTS,
   getFinalRoundIndex,
-  getGameRules,
   isPresenceStale,
 } from './lib/gameRules';
 import { log } from './lib/errors';
@@ -182,9 +182,9 @@ export const finishAbandonedGame = internalMutation({
       return { completed: false, filled: 0 };
     }
 
-    const rules = getGameRules(initial.mode);
     // One pass advances at most one round; bound the loop (CLAUDE.md loop-safety).
-    const maxPasses = getFinalRoundIndex(rules) + 2;
+    // Round count comes from the game's own matrix (legacy games may differ).
+    const maxPasses = getFinalRoundIndex(initial.assignmentMatrix) + 2;
 
     const poems = await ctx.db
       .query('poems')
@@ -241,7 +241,7 @@ export const finishAbandonedGame = internalMutation({
       const assignees = await Promise.all(
         missing.map((poem) => ctx.db.get(roundAssignments[poem.indexInRoom]))
       );
-      const expectedCount = rules.wordCounts[round];
+      const expectedCount = WORD_COUNTS[round];
 
       for (let i = 0; i < missing.length; i++) {
         const poem = missing[i];

--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -17,7 +17,7 @@ import { Id } from './_generated/dataModel';
 import { getUser } from './lib/auth';
 import { requireRoomByCode, getActiveGame } from './lib/room';
 import { getMatrixRound } from './lib/assignmentMatrix';
-import { getGameRules } from './lib/gameRules';
+import { WORD_COUNTS } from './lib/gameRules';
 import {
   pickRandomPersona,
   getPersona,
@@ -267,7 +267,7 @@ export const ensureAiLine = internalMutation({
       .first();
     if (!poem) return;
 
-    const expectedCount = getGameRules(game.mode).wordCounts[round];
+    const expectedCount = WORD_COUNTS[round];
     const committed = await commitAssignedLine(ctx, {
       roomId,
       gameId,
@@ -343,7 +343,7 @@ export const generateLineForRound = internalAction({
 
     // Get persona
     const persona = getPersona(aiPlayer.aiPersonaId as AiPersonaId);
-    const targetWordCount = getGameRules(game.mode).wordCounts[round];
+    const targetWordCount = WORD_COUNTS[round];
 
     // Generate line - graceful fallback if API key missing
     const apiKey = initialOpenRouterApiKey;
@@ -450,7 +450,7 @@ export async function commitAssignedLine(
   if (assignedUserId !== authorUserId) return false;
 
   const wordCount = countWords(text);
-  const expectedCount = getGameRules(game.mode).wordCounts[lineIndex];
+  const expectedCount = WORD_COUNTS[lineIndex];
   const finalText =
     wordCount === expectedCount ? text.trim() : getFallbackLine(expectedCount);
 
@@ -529,7 +529,7 @@ export const generateGhostLine = internalAction({
           })
         : null;
 
-    const targetWordCount = getGameRules(game.mode).wordCounts[round];
+    const targetWordCount = WORD_COUNTS[round];
     const apiKey = initialOpenRouterApiKey;
     const result = await (async () => {
       if (!apiKey) {

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -10,11 +10,11 @@ import {
   AUTO_GHOST_FILL_MS,
   GHOSTWRITER_OVERTIME_MS,
   PRESENCE_AWAY_MS,
+  WORD_COUNTS,
   getFinalRoundIndex,
-  getGameRules,
   isPresenceStale,
 } from './lib/gameRules';
-import { countWords, getLastWord } from './lib/wordCount';
+import { countWords } from './lib/wordCount';
 import { getUser, checkParticipation } from './lib/auth';
 import {
   getRoomByCode,
@@ -73,14 +73,11 @@ export const startGame = mutation({
       )
     );
 
-    // Resolve rules from the lobby's mode selection
-    const rules = getGameRules(room.selectedMode);
-
-    // Generate assignment matrix
+    // Generate assignment matrix — one game, WORD_COUNTS.length rounds.
     const playerIds = shuffledPlayers.map((p) => p.userId);
     const assignmentMatrix = generateAssignmentMatrix(
       playerIds,
-      rules.wordCounts.length
+      WORD_COUNTS.length
     );
 
     // Create Game
@@ -88,7 +85,6 @@ export const startGame = mutation({
       roomId: room._id,
       status: 'IN_PROGRESS',
       cycle: (room.currentCycle || 0) + 1,
-      mode: rules.mode,
       currentRound: 0,
       roundStartedAt: Date.now(),
       assignmentMatrix,
@@ -221,29 +217,15 @@ export const getCurrentAssignment = query({
       previousLineText = prevLine?.text;
     }
 
-    const rules = getGameRules(game.mode);
-    const isFinalRound = currentRound === getFinalRoundIndex(rules);
-
-    // Rhyme Relay: the closer rhymes with the poem's opening word.
-    let rhymeTargetWord: string | undefined;
-    if (rules.finalRhyme && isFinalRound) {
-      const openingLine = await ctx.db
-        .query('lines')
-        .withIndex('by_poem_index', (q) =>
-          q.eq('poemId', poem._id).eq('indexInPoem', 0)
-        )
-        .first();
-      rhymeTargetWord = openingLine ? getLastWord(openingLine.text) : undefined;
-    }
+    const isFinalRound =
+      currentRound === getFinalRoundIndex(game.assignmentMatrix);
 
     return {
       poemId: poem._id,
       lineIndex: currentRound,
-      targetWordCount: rules.wordCounts[currentRound],
-      totalRounds: rules.wordCounts.length,
-      mode: rules.mode,
+      targetWordCount: WORD_COUNTS[currentRound],
+      totalRounds: game.assignmentMatrix.length,
       isFinalRound,
-      rhymeTargetWord,
       previousLineText,
       roundStartedAt: game.roundStartedAt ?? game.createdAt,
     };
@@ -314,9 +296,9 @@ export const submitLine = mutation({
       );
     }
 
-    // Validate word count against the game's rules
+    // Validate word count against the poem shape
     const wordCount = countWords(text);
-    const expectedCount = getGameRules(game.mode).wordCounts[lineIndex];
+    const expectedCount = WORD_COUNTS[lineIndex];
     if (wordCount !== expectedCount) {
       throw new Error(`Expected ${expectedCount} words, got ${wordCount}`);
     }
@@ -539,7 +521,6 @@ export const getRevealPhaseState = query({
     const myPoem = myPoems.length > 0 ? myPoems[0] : null;
 
     return {
-      mode: getGameRules(game.mode).mode,
       poems: poemsWithPreview,
       myPoem,
       myPoems,
@@ -670,7 +651,7 @@ export const getRoundProgress = query({
 
     return {
       round: game.currentRound,
-      totalRounds: getGameRules(game.mode).wordCounts.length,
+      totalRounds: game.assignmentMatrix.length,
       roundStartedAt: game.roundStartedAt ?? game.createdAt,
       isHost: room.hostUserId === user._id,
       players: progress,

--- a/convex/lib/gameRules.ts
+++ b/convex/lib/gameRules.ts
@@ -1,77 +1,23 @@
-import { v } from 'convex/values';
-
 /**
- * Game rules are data, keyed by mode. Every round structure literal in the
- * codebase lives in this module; game-path code resolves rules from the
- * game document's `mode` and never assumes a round count.
+ * The one game: a nine-round paper-fold, 1·2·3·4·5·4·3·2·1 words per line.
+ * `WORD_COUNTS` is the single source for the poem shape; per-game round bounds
+ * come from the game's own `assignmentMatrix` (so a legacy in-flight game with a
+ * different length still completes against its own structure).
  */
 
-/** Legacy alias for the classic shape. Game-path code must use getGameRules. */
+/** Words per line, by round. The poem shape — and the round count — of every game. */
 export const WORD_COUNTS = [1, 2, 3, 4, 5, 4, 3, 2, 1] as const;
 
-export const GAME_MODES = ['classic', 'rhyme', 'quick'] as const;
-export type GameMode = (typeof GAME_MODES)[number];
-
-/** Convex arg/schema validator matching GAME_MODES. */
-export const gameModeValidator = v.union(
-  v.literal('classic'),
-  v.literal('rhyme'),
-  v.literal('quick')
-);
-
-export interface GameRules {
-  mode: GameMode;
-  label: string;
-  tagline: string;
-  wordCounts: readonly number[];
-  /** Final line must rhyme with the poem's opening word. Judged by the room, never the server. */
-  finalRhyme: boolean;
-}
-
-const RULES: Record<GameMode, GameRules> = {
-  classic: {
-    mode: 'classic',
-    label: 'Classic',
-    tagline: 'The original 1·2·3·4·5·4·3·2·1.',
-    wordCounts: WORD_COUNTS,
-    finalRhyme: false,
-  },
-  rhyme: {
-    mode: 'rhyme',
-    label: 'Rhyme Relay',
-    tagline: 'Same shape — but the last word must rhyme with the first.',
-    wordCounts: WORD_COUNTS,
-    finalRhyme: true,
-  },
-  quick: {
-    mode: 'quick',
-    label: 'Quick Jam',
-    tagline: 'A five-round espresso shot: 1·2·3·2·1.',
-    wordCounts: [1, 2, 3, 2, 1] as const,
-    finalRhyme: false,
-  },
-};
-
-export const DEFAULT_GAME_MODE: GameMode = 'classic';
-
-export function isGameMode(value: unknown): value is GameMode {
-  return (
-    typeof value === 'string' &&
-    (GAME_MODES as readonly string[]).includes(value)
-  );
-}
-
-/** Legacy games predate modes; anything unrecognized plays classic. */
-export function normalizeGameMode(value: string | null | undefined): GameMode {
-  return isGameMode(value) ? value : DEFAULT_GAME_MODE;
-}
-
-export function getGameRules(mode?: string | null): GameRules {
-  return RULES[normalizeGameMode(mode)];
-}
-
-export function getFinalRoundIndex(rules: GameRules): number {
-  return rules.wordCounts.length - 1;
+/**
+ * Index of a game's final round, derived from its own assignment matrix. New
+ * games have `WORD_COUNTS.length` rounds; legacy games predating the
+ * single-mode consolidation may differ, so the matrix — not a constant — is the
+ * authority for how many rounds *this* game has.
+ */
+export function getFinalRoundIndex(
+  assignmentMatrix: readonly unknown[][]
+): number {
+  return assignmentMatrix.length - 1;
 }
 
 /** Soft pacing target for a round. The clock pressures; it never blocks. */
@@ -117,8 +63,8 @@ export const PRESENCE_AWAY_MS = 45_000;
  * How long the host may be silent before a present participant is promoted to
  * host (backlog 017). Longer than the "away" indicator so a brief host blip
  * doesn't hand off ownership, far shorter than ABANDONMENT_THRESHOLD_MS so host
- * agency (summon ghostwriter, close room, pick the next mode) is never stranded
- * behind a vanished host while the room is still live.
+ * agency (summon ghostwriter, close room) is never stranded behind a vanished
+ * host while the room is still live.
  */
 export const HOST_MIGRATION_STALE_MS = 60_000;
 

--- a/convex/lib/gameRules.ts
+++ b/convex/lib/gameRules.ts
@@ -1,22 +1,29 @@
 /**
  * The one game: a nine-round paper-fold, 1·2·3·4·5·4·3·2·1 words per line.
- * `WORD_COUNTS` is the single source for the poem shape; per-game round bounds
- * come from the game's own `assignmentMatrix` (so a legacy in-flight game with a
- * different length still completes against its own structure).
+ * `WORD_COUNTS` is the single source for the poem shape.
+ *
+ * Round *bounds* come from each game's own `assignmentMatrix` length, not from a
+ * constant — so a pre-consolidation game still in flight at deploy (the only way
+ * a non-nine-round matrix can exist; no new game is ever anything but classic)
+ * finishes without an out-of-bounds throw. Its per-round *word counts* still read
+ * from the canonical shape below: a legacy 5-round "quick" game would see classic
+ * counts on its two divergent rounds (the original shape lived in the now-deleted
+ * `mode` field and isn't recoverable from the matrix). That cosmetic mismatch is
+ * acceptable for a deploy-window-only game; the crash the matrix bound avoids is
+ * not.
  */
 
 /** Words per line, by round. The poem shape — and the round count — of every game. */
 export const WORD_COUNTS = [1, 2, 3, 4, 5, 4, 3, 2, 1] as const;
 
 /**
- * Index of a game's final round, derived from its own assignment matrix. New
- * games have `WORD_COUNTS.length` rounds; legacy games predating the
- * single-mode consolidation may differ, so the matrix — not a constant — is the
- * authority for how many rounds *this* game has.
+ * A game's final round index = the last row of its own assignment matrix (see
+ * the module header on why this is matrix-derived, not a constant). Typed to
+ * what it uses — only the length — so it never widens a caller's matrix.
  */
-export function getFinalRoundIndex(
-  assignmentMatrix: readonly unknown[][]
-): number {
+export function getFinalRoundIndex(assignmentMatrix: {
+  readonly length: number;
+}): number {
   return assignmentMatrix.length - 1;
 }
 

--- a/convex/lib/sessionLifecycle.ts
+++ b/convex/lib/sessionLifecycle.ts
@@ -3,16 +3,12 @@ import type { Doc, Id } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
 import { getMatrixRound } from './assignmentMatrix';
 import { assignPoemReaders } from './assignPoemReaders';
-import {
-  AUTO_GHOST_FILL_MS,
-  getFinalRoundIndex,
-  getGameRules,
-} from './gameRules';
+import { AUTO_GHOST_FILL_MS, getFinalRoundIndex } from './gameRules';
 
 type LifecycleCtx = Pick<MutationCtx, 'db' | 'scheduler'>;
 type LifecycleGame = Pick<
   Doc<'games'>,
-  '_id' | 'assignmentMatrix' | 'currentRound' | 'status' | 'mode'
+  '_id' | 'assignmentMatrix' | 'currentRound' | 'status'
 >;
 type LifecyclePoem = Pick<Doc<'poems'>, '_id' | 'indexInRoom'>;
 type LifecyclePlayer = Pick<Doc<'users'>, '_id' | 'kind'>;
@@ -47,10 +43,10 @@ type CompletionPatchPlan = {
 };
 
 export function getSubmissionWindow(
-  game: Pick<Doc<'games'>, 'status' | 'currentRound' | 'mode'>,
+  game: Pick<Doc<'games'>, 'status' | 'currentRound' | 'assignmentMatrix'>,
   lineIndex: number
 ): SubmissionWindowResult {
-  const finalRoundIndex = getFinalRoundIndex(getGameRules(game.mode));
+  const finalRoundIndex = getFinalRoundIndex(game.assignmentMatrix);
   if (
     !Number.isInteger(lineIndex) ||
     lineIndex < 0 ||
@@ -220,7 +216,7 @@ export async function applyLineLifecycleTransition(
     return;
   }
 
-  if (args.lineIndex < getFinalRoundIndex(getGameRules(args.game.mode))) {
+  if (args.lineIndex < getFinalRoundIndex(args.game.assignmentMatrix)) {
     const nextRound = args.lineIndex + 1;
     await ctx.db.patch(args.game._id, {
       currentRound: nextRound,

--- a/convex/lib/wordCount.ts
+++ b/convex/lib/wordCount.ts
@@ -1,12 +1,3 @@
 export function countWords(text: string): number {
   return text.trim().split(/\s+/).filter(Boolean).length;
 }
-
-/** Final word of a line, stripped of trailing punctuation. Used as the rhyme target. */
-export function getLastWord(text: string): string | undefined {
-  const words = text.trim().split(/\s+/).filter(Boolean);
-  const last = words[words.length - 1];
-  if (!last) return undefined;
-  const cleaned = last.replace(/[^\p{L}\p{N}'-]+$/u, '');
-  return cleaned || last;
-}

--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -2,11 +2,7 @@ import { v, ConvexError } from 'convex/values';
 import { mutation, query } from './_generated/server';
 import { ensureUserHelper } from './users';
 import { getUser, checkParticipation } from './lib/auth';
-import {
-  gameModeValidator,
-  PRESENCE_AWAY_MS,
-  isPresenceStale,
-} from './lib/gameRules';
+import { PRESENCE_AWAY_MS, isPresenceStale } from './lib/gameRules';
 import { checkRateLimit } from './lib/rateLimit';
 import {
   getRoomByCode,
@@ -218,31 +214,6 @@ export const getRoomState = query({
     const isHost = user._id === room.hostUserId;
 
     return { room: { ...room, status }, players, isHost };
-  },
-});
-
-export const selectGameMode = mutation({
-  args: {
-    roomCode: v.string(),
-    mode: gameModeValidator,
-    guestToken: v.optional(v.string()),
-  },
-  handler: async (ctx, { roomCode, mode, guestToken }) => {
-    const user = await getUser(ctx, guestToken);
-    if (!user) throw new Error('User not found');
-
-    const room = await requireRoomByCode(ctx, roomCode);
-    if (room.hostUserId !== user._id) {
-      throw new Error('Only host can pick the game mode');
-    }
-
-    // Mode is a lobby decision; mid-game switches would orphan the matrix
-    const activeGame = await getActiveGame(ctx, room._id);
-    if (activeGame) {
-      throw new Error('Cannot change mode while a game is in progress');
-    }
-
-    await ctx.db.patch(room._id, { selectedMode: mode });
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,6 +1,5 @@
 import { defineSchema, defineTable } from 'convex/server';
 import { v } from 'convex/values';
-import { gameModeValidator } from './lib/gameRules';
 
 export default defineSchema({
   users: defineTable({
@@ -34,8 +33,9 @@ export default defineSchema({
     completedAt: v.optional(v.number()),
     currentGameId: v.optional(v.id('games')),
     currentCycle: v.optional(v.number()),
-    /** Host's lobby mode selection; stamped onto the game at start. */
-    selectedMode: v.optional(gameModeValidator),
+    /** Legacy, unused: the game is single-mode. Retained (optional string) so
+     *  existing rows that carry a mode value stay valid without a migration. */
+    selectedMode: v.optional(v.string()),
   })
     .index('by_code', ['code'])
     .index('by_host', ['hostUserId']),
@@ -58,8 +58,9 @@ export default defineSchema({
     status: v.union(v.literal('IN_PROGRESS'), v.literal('COMPLETED')),
     /** Game session count for this room. First game = 1. */
     cycle: v.number(),
-    /** Rules preset. Legacy games predate this field and play classic. */
-    mode: v.optional(gameModeValidator),
+    /** Legacy, unused: the game is single-mode. Retained (optional string) so
+     *  existing rows that carry a mode value stay valid without a migration. */
+    mode: v.optional(v.string()),
     /** Round index within current game. Shape comes from convex/lib/gameRules.ts. */
     currentRound: v.number(),
     /** When the current round opened. Drives the soft clock and ghostwriter overtime gate. */

--- a/tests/components/Lobby.test.tsx
+++ b/tests/components/Lobby.test.tsx
@@ -16,7 +16,6 @@ const mockMutations = {
   removeAi: vi.fn(),
   leaveLobby: vi.fn().mockResolvedValue(undefined),
   closeRoom: vi.fn().mockResolvedValue(undefined),
-  selectMode: vi.fn().mockResolvedValue(undefined),
 };
 
 // Mock Convex (external) - use call order tracking
@@ -28,7 +27,6 @@ const MUTATION_ORDER = [
   mockMutations.removeAi, // api.ai.removeAiPlayer
   mockMutations.leaveLobby, // api.rooms.leaveLobby
   mockMutations.closeRoom, // api.rooms.closeRoom
-  mockMutations.selectMode, // api.rooms.selectGameMode
 ];
 
 vi.mock('convex/react', () => ({
@@ -95,8 +93,6 @@ describe('Lobby component', () => {
     mockMutations.leaveLobby.mockResolvedValue(undefined);
     mockMutations.closeRoom.mockClear();
     mockMutations.closeRoom.mockResolvedValue(undefined);
-    mockMutations.selectMode.mockClear();
-    mockMutations.selectMode.mockResolvedValue(undefined);
 
     // Mock fetch at boundary - useUser calls /api/guest/session
     mockFetch.mockResolvedValue({
@@ -261,45 +257,6 @@ describe('Lobby component', () => {
       });
       expect(mockPush).toHaveBeenCalledWith('/');
     });
-  });
-
-  it('lets the host pick a game mode', async () => {
-    const user = userEvent.setup();
-    render(<Lobby room={mockRoom} players={mockPlayers} isHost={true} />);
-
-    const rhymeOption = screen.getByRole('radio', { name: 'Rhyme Relay' });
-    expect(rhymeOption).not.toBeDisabled();
-    expect(rhymeOption).toHaveAttribute('aria-checked', 'false');
-    // Classic is the default selection
-    expect(screen.getByRole('radio', { name: 'Classic' })).toHaveAttribute(
-      'aria-checked',
-      'true'
-    );
-
-    await user.click(rhymeOption);
-
-    await waitFor(() => {
-      expect(mockMutations.selectMode).toHaveBeenCalledWith({
-        roomCode: 'ABCD',
-        mode: 'rhyme',
-        guestToken: 'mock-token',
-      });
-    });
-  });
-
-  it('shows the room selection to non-hosts without letting them change it', () => {
-    render(
-      <Lobby
-        room={{ ...mockRoom, selectedMode: 'quick' }}
-        players={mockPlayers}
-        isHost={false}
-      />
-    );
-
-    const quickOption = screen.getByRole('radio', { name: 'Quick Jam' });
-    expect(quickOption).toBeDisabled();
-    expect(quickOption).toHaveAttribute('aria-checked', 'true');
-    expect(screen.getByText(/the host picks the mode/i)).toBeInTheDocument();
   });
 
   it('shows host badge for host player', () => {

--- a/tests/components/PoemDisplay.test.tsx
+++ b/tests/components/PoemDisplay.test.tsx
@@ -445,49 +445,4 @@ describe('PoemDisplay component', () => {
       expect(screen.getByText('Three simple words')).toBeInTheDocument();
     });
   });
-
-  describe('rhyme mode', () => {
-    it('emphasizes the bookend words once the poem is fully revealed', () => {
-      const rhymeLines: PoemLine[] = [
-        { text: 'moon', authorName: 'Alice', authorStableId: 'a' },
-        { text: 'a quiet afternoon', authorName: 'Bob', authorStableId: 'b' },
-      ];
-
-      const { container } = render(
-        <PoemDisplay
-          poemId={mockPoemId}
-          lines={rhymeLines}
-          onDone={mockOnDone}
-          alreadyRevealed={true}
-          rhymeMode={true}
-        />
-      );
-
-      // Both bookends are emphasized: the opening word and the closing word
-      const emphasized = Array.from(
-        container.querySelectorAll('span.text-primary')
-      ).map((el) => el.textContent);
-      expect(emphasized).toContain('moon');
-      expect(emphasized).toContain('afternoon');
-    });
-
-    it('leaves lines unstyled when rhyme mode is off', () => {
-      const lines: PoemLine[] = [
-        { text: 'moon', authorName: 'Alice', authorStableId: 'a' },
-        { text: 'afternoon', authorName: 'Bob', authorStableId: 'b' },
-      ];
-
-      const { container } = render(
-        <PoemDisplay
-          poemId={mockPoemId}
-          lines={lines}
-          onDone={mockOnDone}
-          alreadyRevealed={true}
-          rhymeMode={false}
-        />
-      );
-
-      expect(container.querySelector('span.text-primary')).toBeNull();
-    });
-  });
 });

--- a/tests/convex/game.test.ts
+++ b/tests/convex/game.test.ts
@@ -143,7 +143,9 @@ async function seedInProgressGame(
     code?: string;
     currentRound?: number;
     roundStartedAt?: number;
-    mode?: 'classic' | 'rhyme' | 'quick';
+    /** Matrix round count. Defaults to the one-game shape; a smaller value
+     *  seeds a legacy in-flight game (e.g. a pre-consolidation 5-round). */
+    rounds?: number;
   }
 ): Promise<{
   roomId: Id<'rooms'>;
@@ -155,9 +157,7 @@ async function seedInProgressGame(
 }> {
   const code = opts.code ?? 'TEST';
   const currentRound = opts.currentRound ?? 0;
-  const mode = opts.mode ?? 'classic';
-  const wordCounts = mode === 'quick' ? [1, 2, 3, 2, 1] : WORD_COUNTS;
-  const rounds = wordCounts.length;
+  const rounds = opts.rounds ?? WORD_COUNTS.length;
   const now = Date.now();
   const roundStartedAt = opts.roundStartedAt ?? now;
 
@@ -205,7 +205,6 @@ async function seedInProgressGame(
       roomId,
       status: 'IN_PROGRESS',
       cycle: 1,
-      mode,
       currentRound,
       roundStartedAt,
       assignmentMatrix: matrix,
@@ -1258,8 +1257,10 @@ describe('getRoundProgress', () => {
     expect((alice as Record<string, unknown>)['lastSeenAt']).toBeUndefined();
   });
 
-  it('returns correct totalRounds for quick mode', async () => {
+  it("reports a legacy short-matrix game's own round count", async () => {
     const t = setupConvexTest();
+    // A pre-consolidation game shipped a 5-round matrix; getRoundProgress must
+    // report 5 (the matrix length), not the 9-round one-game shape.
     await seedInProgressGame(t, {
       players: [
         { name: 'Alice', clerkUserId: 'clerk_aliceGP06' },
@@ -1267,7 +1268,7 @@ describe('getRoundProgress', () => {
       ],
       code: 'GP06',
       currentRound: 0,
-      mode: 'quick',
+      rounds: 5,
     });
 
     const result = await asUser(t, 'aliceGP06').query(

--- a/tests/convex/game.test.ts
+++ b/tests/convex/game.test.ts
@@ -116,9 +116,12 @@ async function seedCompletedRoom(
       roomId,
       status: 'COMPLETED',
       cycle: 1,
-      mode: 'classic',
       currentRound: 8,
-      assignmentMatrix: [[hostId, guestId]],
+      // A real nine-round matrix (alternating, no consecutive same-poem author),
+      // so round bounds derive consistently from its length.
+      assignmentMatrix: Array.from({ length: 9 }, (_, r) =>
+        r % 2 === 0 ? [hostId, guestId] : [guestId, hostId]
+      ),
       createdAt: 0,
     });
     return { roomId, gameId, hostId, guestId, code };
@@ -626,95 +629,10 @@ describe('getCurrentAssignment', () => {
     expect(result).not.toBeNull();
     expect(result!.poemId).toBe(poemIds[0]);
     expect(result!.lineIndex).toBe(2);
-    expect(result!.targetWordCount).toBe(3); // classic wordCounts[2]
+    expect(result!.targetWordCount).toBe(3); // WORD_COUNTS[2]
     expect(result!.totalRounds).toBe(9);
-    expect(result!.mode).toBe('classic');
     expect(result!.isFinalRound).toBe(false);
     expect(result!.previousLineText).toBe('one two');
-  });
-
-  it('exposes the rhyme target on the final round of rhyme relay', async () => {
-    const t = setupConvexTest();
-    const { code, poemIds, userIds } = await seedInProgressGame(t, {
-      players: [
-        { name: 'Alice', clerkUserId: 'clerk_aliceCA06' },
-        { name: 'Bob', clerkUserId: 'clerk_bobCA06' },
-      ],
-      code: 'CA06',
-      currentRound: 8,
-      mode: 'rhyme',
-    });
-
-    // matrix[8][0] = userIds[(0+8)%2] = userIds[0] = Alice → poem 0
-    await t.run((ctx) =>
-      ctx.db.insert('lines', {
-        poemId: poemIds[0],
-        indexInPoem: 0,
-        text: 'moon',
-        wordCount: 1,
-        authorUserId: userIds[0],
-        createdAt: Date.now(),
-      })
-    );
-    await t.run((ctx) =>
-      ctx.db.insert('lines', {
-        poemId: poemIds[0],
-        indexInPoem: 7,
-        text: 'two words',
-        wordCount: 2,
-        authorUserId: userIds[1],
-        createdAt: Date.now(),
-      })
-    );
-
-    const result = await asUser(t, 'aliceCA06').query(
-      api.game.getCurrentAssignment,
-      { roomCode: code }
-    );
-
-    expect(result).not.toBeNull();
-    expect(result!.lineIndex).toBe(8);
-    expect(result!.targetWordCount).toBe(1);
-    expect(result!.mode).toBe('rhyme');
-    expect(result!.isFinalRound).toBe(true);
-    expect(result!.rhymeTargetWord).toBe('moon');
-  });
-
-  it('uses quick-jam word counts for quick games', async () => {
-    const t = setupConvexTest();
-    const { code, poemIds, userIds } = await seedInProgressGame(t, {
-      players: [
-        { name: 'Alice', clerkUserId: 'clerk_aliceCA07' },
-        { name: 'Bob', clerkUserId: 'clerk_bobCA07' },
-      ],
-      code: 'CA07',
-      currentRound: 2,
-      mode: 'quick',
-    });
-
-    // matrix[2][0] = userIds[0] = Alice → poem 0
-    await t.run((ctx) =>
-      ctx.db.insert('lines', {
-        poemId: poemIds[0],
-        indexInPoem: 1,
-        text: 'two words',
-        wordCount: 2,
-        authorUserId: userIds[1],
-        createdAt: Date.now(),
-      })
-    );
-
-    const result = await asUser(t, 'aliceCA07').query(
-      api.game.getCurrentAssignment,
-      { roomCode: code }
-    );
-
-    expect(result).not.toBeNull();
-    expect(result!.lineIndex).toBe(2);
-    expect(result!.targetWordCount).toBe(3); // quick wordCounts[2] = 3
-    expect(result!.totalRounds).toBe(5);
-    expect(result!.mode).toBe('quick');
-    expect(result!.isFinalRound).toBe(false);
   });
 });
 

--- a/tests/convex/gameRules.test.ts
+++ b/tests/convex/gameRules.test.ts
@@ -1,75 +1,33 @@
 import { describe, expect, it } from 'vitest';
 import {
-  DEFAULT_GAME_MODE,
-  GAME_MODES,
   WORD_COUNTS,
   getFinalRoundIndex,
-  getGameRules,
-  isGameMode,
   isPresenceStale,
-  normalizeGameMode,
 } from '../../convex/lib/gameRules';
 
 describe('gameRules', () => {
-  it('exposes the three launch modes', () => {
-    expect(GAME_MODES).toEqual(['classic', 'rhyme', 'quick']);
-    expect(DEFAULT_GAME_MODE).toBe('classic');
+  it('is one game: the 1·2·3·4·5·4·3·2·1 paper-fold', () => {
+    expect([...WORD_COUNTS]).toEqual([1, 2, 3, 4, 5, 4, 3, 2, 1]);
   });
 
-  it('keeps the classic shape as the legacy WORD_COUNTS', () => {
-    expect(getGameRules('classic').wordCounts).toEqual([
-      1, 2, 3, 4, 5, 4, 3, 2, 1,
-    ]);
-    expect(getGameRules('classic').wordCounts).toEqual([...WORD_COUNTS]);
+  it('opens and closes on a single word — the read-aloud bookends', () => {
+    expect(WORD_COUNTS[0]).toBe(1);
+    expect(WORD_COUNTS[WORD_COUNTS.length - 1]).toBe(1);
   });
 
-  it('gives rhyme relay the classic shape plus the rhyme twist', () => {
-    const rules = getGameRules('rhyme');
-    expect(rules.wordCounts).toEqual([1, 2, 3, 4, 5, 4, 3, 2, 1]);
-    expect(rules.finalRhyme).toBe(true);
-  });
+  describe('getFinalRoundIndex', () => {
+    const matrixOf = (rounds: number) =>
+      Array.from({ length: rounds }, () => []);
 
-  it('gives quick jam a five-round palindrome', () => {
-    const rules = getGameRules('quick');
-    expect(rules.wordCounts).toEqual([1, 2, 3, 2, 1]);
-    expect(rules.finalRhyme).toBe(false);
-    expect(getFinalRoundIndex(rules)).toBe(4);
-  });
+    it('is the last index of a new game (nine rounds)', () => {
+      expect(getFinalRoundIndex(matrixOf(WORD_COUNTS.length))).toBe(8);
+    });
 
-  it('every mode has a label, tagline, and a sane palindrome shape', () => {
-    for (const mode of GAME_MODES) {
-      const rules = getGameRules(mode);
-      expect(rules.mode).toBe(mode);
-      expect(rules.label.length).toBeGreaterThan(0);
-      expect(rules.tagline.length).toBeGreaterThan(0);
-      expect(rules.wordCounts.length).toBeGreaterThanOrEqual(3);
-      rules.wordCounts.forEach((count) => {
-        expect(Number.isInteger(count)).toBe(true);
-        expect(count).toBeGreaterThanOrEqual(1);
-        expect(count).toBeLessThanOrEqual(5);
-      });
-      // Opening and closing lines are single words: the read-aloud bookends.
-      expect(rules.wordCounts[0]).toBe(1);
-      expect(rules.wordCounts[rules.wordCounts.length - 1]).toBe(1);
-    }
-  });
-
-  it('normalizes legacy and junk modes to classic', () => {
-    expect(normalizeGameMode(undefined)).toBe('classic');
-    expect(normalizeGameMode(null)).toBe('classic');
-    expect(normalizeGameMode('')).toBe('classic');
-    expect(normalizeGameMode('sonnet-battle')).toBe('classic');
-    expect(normalizeGameMode('rhyme')).toBe('rhyme');
-    expect(getGameRules(undefined).mode).toBe('classic');
-    expect(getGameRules('quick').mode).toBe('quick');
-  });
-
-  it('type-guards mode strings', () => {
-    expect(isGameMode('classic')).toBe(true);
-    expect(isGameMode('quick')).toBe(true);
-    expect(isGameMode('CLASSIC')).toBe(false);
-    expect(isGameMode(42)).toBe(false);
-    expect(isGameMode(null)).toBe(false);
+    it("honors a legacy game's own (shorter) matrix, not a global constant", () => {
+      // A pre-consolidation "quick jam" game shipped a 5-round matrix; it must
+      // still complete against its own structure, not crash expecting 9.
+      expect(getFinalRoundIndex(matrixOf(5))).toBe(4);
+    });
   });
 
   describe('isPresenceStale', () => {

--- a/tests/convex/hostMigration.test.ts
+++ b/tests/convex/hostMigration.test.ts
@@ -272,7 +272,7 @@ describe('host migration via heartbeat (real engine)', () => {
     expect(await hostOf(t, roomId)).toBe(userIds[0]); // host keeps the room
   });
 
-  it('gives the migrated host full agency once the game ends; the old host gets nothing', async () => {
+  it('gives the migrated host close-room agency once the game ends; the old host gets nothing', async () => {
     const t = setupConvexTest();
     const { roomId, gameId, userIds } = await seedGame(t, [
       { name: 'host', seatIndex: 0, lastSeenAt: staleStamp() },
@@ -291,22 +291,7 @@ describe('host migration via heartbeat (real engine)', () => {
       await ctx.db.patch(roomId, { status: 'COMPLETED' });
     });
 
-    // New host can pick the next-cycle mode…
-    await asUser(t, 'guest').mutation(api.rooms.selectGameMode, {
-      roomCode: 'ABCD',
-      mode: 'quick',
-    });
-    expect(
-      await t.run((ctx) => ctx.db.get(roomId)).then((r) => r?.selectedMode)
-    ).toBe('quick');
-
-    // …while the departed old host has no host power.
-    await expect(
-      asUser(t, 'host').mutation(api.rooms.selectGameMode, {
-        roomCode: 'ABCD',
-        mode: 'classic',
-      })
-    ).rejects.toThrow('Only host can pick the game mode');
+    // The departed old host has no host power…
     await expect(
       asUser(t, 'host').mutation(api.rooms.closeRoom, { roomCode: 'ABCD' })
     ).rejects.toThrow('Only the host can close the room');

--- a/tests/convex/lib/sessionLifecycle.test.ts
+++ b/tests/convex/lib/sessionLifecycle.test.ts
@@ -6,11 +6,7 @@ import {
   getSubmissionWindow,
   isRevealReady,
 } from '../../../convex/lib/sessionLifecycle';
-import {
-  WORD_COUNTS,
-  getGameRules,
-  getFinalRoundIndex,
-} from '../../../convex/lib/gameRules';
+import { WORD_COUNTS } from '../../../convex/lib/gameRules';
 import { setupConvexTest } from '../../helpers/convexTest';
 import { type T } from '../../helpers/convexSeed';
 import { getFallbackLine } from '../../../convex/lib/ai/fallbacks';
@@ -28,7 +24,9 @@ async function seedGame(
   t: T,
   opts: {
     players: Array<{ name: string; kind?: 'AI' | 'human' }>;
-    mode?: 'classic' | 'quick';
+    /** Round count for the matrix. Defaults to the one-game shape; a smaller
+     *  value seeds a legacy in-flight game (e.g. a pre-consolidation 5-round). */
+    rounds?: number;
     currentRound?: number;
     /** Pre-insert lines for these (poemIndex, lineIndex) pairs. */
     existingLines?: Array<{ poemIndex: number; lineIndex: number }>;
@@ -36,10 +34,8 @@ async function seedGame(
     gameStatus?: 'IN_PROGRESS' | 'COMPLETED';
   }
 ) {
-  const mode = opts.mode ?? 'classic';
   const currentRound = opts.currentRound ?? 0;
-  const rules = getGameRules(mode);
-  const rounds = rules.wordCounts.length;
+  const rounds = opts.rounds ?? WORD_COUNTS.length;
   const now = Date.now();
 
   return t.run(async (ctx) => {
@@ -86,7 +82,6 @@ async function seedGame(
       roomId,
       status: opts.gameStatus ?? 'IN_PROGRESS',
       cycle: 1,
-      mode,
       currentRound,
       roundStartedAt: now,
       assignmentMatrix,
@@ -107,7 +102,7 @@ async function seedGame(
 
     if (opts.existingLines) {
       for (const { poemIndex, lineIndex } of opts.existingLines) {
-        const wc = rules.wordCounts[lineIndex];
+        const wc = WORD_COUNTS[lineIndex];
         await ctx.db.insert('lines', {
           poemId: poemIds[poemIndex],
           indexInPoem: lineIndex,
@@ -146,13 +141,15 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('getSubmissionWindow (pure)', () => {
+  // The round count comes from the game's own matrix length; content is irrelevant here.
+  const matrixOf = (rounds: number): Id<'users'>[][] =>
+    Array.from({ length: rounds }, () => []);
+  const nine = matrixOf(WORD_COUNTS.length);
+
   it('allows final-round late submissions after completion', () => {
     expect(
       getSubmissionWindow(
-        {
-          status: 'COMPLETED',
-          currentRound: 8,
-        },
+        { status: 'COMPLETED', currentRound: 8, assignmentMatrix: nine },
         8
       )
     ).toEqual({ ok: true });
@@ -161,10 +158,7 @@ describe('getSubmissionWindow (pure)', () => {
   it('rejects future-round submissions while the game is in progress', () => {
     expect(
       getSubmissionWindow(
-        {
-          status: 'IN_PROGRESS',
-          currentRound: 2,
-        },
+        { status: 'IN_PROGRESS', currentRound: 2, assignmentMatrix: nine },
         3
       )
     ).toEqual({ ok: false, reason: 'ROUND_NOT_STARTED' });
@@ -173,34 +167,32 @@ describe('getSubmissionWindow (pure)', () => {
   it('rejects invalid round indexes before checking game state', () => {
     expect(
       getSubmissionWindow(
-        {
-          status: 'IN_PROGRESS',
-          currentRound: 2,
-        },
+        { status: 'IN_PROGRESS', currentRound: 2, assignmentMatrix: nine },
         -1
       )
     ).toEqual({ ok: false, reason: 'INVALID_ROUND' });
   });
 
-  it('scopes the submission window to the game mode', () => {
-    // Quick jam ends at round index 4; classic would still be mid-game there.
+  it("scopes the submission window to the game's round count (matrix length)", () => {
+    // A legacy 5-round game ends at index 4; a nine-round game is still mid-game there.
+    const five = matrixOf(5);
     expect(
       getSubmissionWindow(
-        { status: 'COMPLETED', currentRound: 4, mode: 'quick' },
+        { status: 'COMPLETED', currentRound: 4, assignmentMatrix: five },
         4
       )
     ).toEqual({ ok: true });
 
     expect(
       getSubmissionWindow(
-        { status: 'IN_PROGRESS', currentRound: 4, mode: 'quick' },
+        { status: 'IN_PROGRESS', currentRound: 4, assignmentMatrix: five },
         5
       )
     ).toEqual({ ok: false, reason: 'INVALID_ROUND' });
 
     expect(
       getSubmissionWindow(
-        { status: 'COMPLETED', currentRound: 4, mode: 'classic' },
+        { status: 'COMPLETED', currentRound: 4, assignmentMatrix: nine },
         4
       )
     ).toEqual({ ok: false, reason: 'GAME_NOT_IN_PROGRESS' });
@@ -467,16 +459,17 @@ describe('applyLineLifecycleTransition (real engine)', () => {
     expect(after?.status).toBe('IN_PROGRESS');
   });
 
-  it('completes a quick-jam game at its five-round boundary', async () => {
+  it('completes a legacy 5-round game at its own (shorter) boundary', async () => {
     const t = setupConvexTest();
-    const quickRules = getGameRules('quick');
-    const finalRound = getFinalRoundIndex(quickRules); // 4
+    // A pre-consolidation game shipped a 5-round matrix; its final round is index
+    // 4, derived from the matrix length — not the 9-round one-game shape.
+    const finalRound = 4;
 
-    // Seed a quick-jam game at the final round with all poems except one written.
-    // Then seed the last missing poem line and call the transition.
+    // Seed the 5-round game at the final round with every line written, then call
+    // the transition and expect completion at the game's own boundary.
     const { roomId, gameId } = await seedGame(t, {
       players: [{ name: 'Alice' }, { name: 'Bob' }],
-      mode: 'quick',
+      rounds: 5,
       currentRound: finalRound,
       existingLines: [
         // All rounds 0-3 fully written (both poems each)
@@ -516,9 +509,9 @@ describe('applyLineLifecycleTransition (real engine)', () => {
 
   it('treats final-round completion re-entry as stale once the game is completed', async () => {
     const t = setupConvexTest();
-    const finalRound = getFinalRoundIndex(getGameRules('classic')); // 8
+    const finalRound = WORD_COUNTS.length - 1; // 8
 
-    // Seed a classic game that is ALREADY COMPLETED at round 8.
+    // Seed a (default nine-round) game that is ALREADY COMPLETED at round 8.
     // The lifecycle should bail (freshGame.status !== IN_PROGRESS) and make no writes.
     const { roomId, gameId } = await seedGame(t, {
       players: [{ name: 'Alice' }, { name: 'Bob' }],

--- a/tests/convex/rooms.test.ts
+++ b/tests/convex/rooms.test.ts
@@ -674,67 +674,6 @@ describe('leaveLobby', () => {
 // selectGameMode
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('selectGameMode', () => {
-  it('lets the host pick a mode in the lobby: DB row reflects selection', async () => {
-    const t = setupConvexTest();
-    await seedClerkUser(t, 'modehost', { displayName: 'ModeHost' });
-
-    const { code, roomId } = await seedLobbyRoom(t, 'modehost');
-
-    await asUser(t, 'modehost').mutation(api.rooms.selectGameMode, {
-      roomCode: code,
-      mode: 'rhyme',
-    });
-
-    const room = await t.run((ctx) => ctx.db.get(roomId));
-    expect(room?.selectedMode).toBe('rhyme');
-  });
-
-  it('rejects mode change by a non-host participant', async () => {
-    const t = setupConvexTest();
-    await seedClerkUser(t, 'modehosta', { displayName: 'ModeHostA' });
-    await seedClerkUser(t, 'modeguest', { displayName: 'ModeGuest' });
-
-    const { code } = await seedLobbyRoom(t, 'modehosta');
-    await asUser(t, 'modeguest').mutation(api.rooms.joinRoom, {
-      code,
-      displayName: 'ModeGuest',
-    });
-
-    await expect(
-      asUser(t, 'modeguest').mutation(api.rooms.selectGameMode, {
-        roomCode: code,
-        mode: 'quick',
-      })
-    ).rejects.toThrow('Only host can pick the game mode');
-  });
-
-  it('rejects mode change while a game is in progress', async () => {
-    const t = setupConvexTest();
-    const { code } = await seedRoomWithActiveGame(t, 'modehostb', 'modeguestb');
-
-    await expect(
-      asUser(t, 'modehostb').mutation(api.rooms.selectGameMode, {
-        roomCode: code,
-        mode: 'quick',
-      })
-    ).rejects.toThrow('Cannot change mode while a game is in progress');
-  });
-
-  it('rejects mode change when user is not authenticated', async () => {
-    const t = setupConvexTest();
-    await seedClerkUser(t, 'modehostc', { displayName: 'ModeHostC' });
-    const { code } = await seedLobbyRoom(t, 'modehostc');
-
-    await expect(
-      t.mutation(api.rooms.selectGameMode, {
-        roomCode: code,
-        mode: 'quick',
-      })
-    ).rejects.toThrow('User not found');
-  });
-});
-
 // ─────────────────────────────────────────────────────────────────────────────
 // closeRoom
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/convex/rooms.test.ts
+++ b/tests/convex/rooms.test.ts
@@ -9,8 +9,7 @@ import { type T, asUser, seedClerkUser } from '../helpers/convexSeed';
  * read-your-writes + real auth (Clerk identity), asserting observable DB state
  * and return values instead of mock-call stubs.
  *
- * Covers: createRoom, joinRoom, getRoom, getRoomState, leaveLobby, closeRoom,
- * selectGameMode.
+ * Covers: createRoom, joinRoom, getRoom, getRoomState, leaveLobby, closeRoom.
  */
 
 /**

--- a/tests/convex/wordCount.test.ts
+++ b/tests/convex/wordCount.test.ts
@@ -1,33 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { countWords, getLastWord } from '../../convex/lib/wordCount';
+import { countWords } from '../../convex/lib/wordCount';
 
 describe('convex/lib/wordCount', () => {
   it('counts words correctly', () => {
     expect(countWords('hello world')).toBe(2);
     expect(countWords('  spaces  ')).toBe(1);
     expect(countWords('')).toBe(0);
-  });
-});
-
-describe('getLastWord', () => {
-  it('returns the final word of a line', () => {
-    expect(getLastWord('the silver moon')).toBe('moon');
-    expect(getLastWord('moon')).toBe('moon');
-  });
-
-  it('strips trailing punctuation but keeps inner apostrophes and hyphens', () => {
-    expect(getLastWord('goodnight, moon!')).toBe('moon');
-    expect(getLastWord("it's the cat's...")).toBe("cat's");
-    expect(getLastWord('half-light?')).toBe('half-light');
-  });
-
-  it('handles whitespace and empty input', () => {
-    expect(getLastWord('  moon  ')).toBe('moon');
-    expect(getLastWord('')).toBeUndefined();
-    expect(getLastWord('   ')).toBeUndefined();
-  });
-
-  it('falls back to the raw token when it is all punctuation', () => {
-    expect(getLastWord('wait —')).toBe('—');
   });
 });


### PR DESCRIPTION
## One game, no modes

Linejam plays exactly one game — the original **1·2·3·4·5·4·3·2·1** nine-round paper-fold. This deletes the three-mode machinery (rhyme relay, quick jam, mode selection); there is no `mode` branching left anywhere in the game path.

**Net −530 lines.** Deleted: `GAME_MODES` / `GameMode` / `gameModeValidator` / `GameRules` / `RULES` / `DEFAULT_GAME_MODE` / `isGameMode` / `normalizeGameMode` / `getGameRules`, the `selectGameMode` mutation, the Lobby mode picker, the client rhyme UI (`WritingScreen` hint, `RevealPhase`/`PoemDisplay` `rhymeMode` + the now-dead `LineText`), and the orphaned `getLastWord` (rhyme-only). `WORD_COUNTS` is the single source for per-round word counts.

## Legacy-safe with no migration — the one non-obvious decision

A game already IN_PROGRESS at deploy may carry a non-classic matrix (a legacy "quick" game has a **5-round** matrix). So round count derives from **each game's own `assignmentMatrix.length`** (`getFinalRoundIndex(matrix)`), *not* a global constant — a 5-round legacy game completes against its own structure instead of crashing (`getMatrixRound` out-of-bounds). Per-round word count is `WORD_COUNTS[round]`; any mismatch on a legacy game is absorbed by the existing fallback committer.

The `games.mode` / `rooms.selectedMode` columns are **widened** (enum → `v.optional(v.string())`) and left in place — existing rows stay valid, nothing reads them, zero migration. (A later migration could drop the columns; not worth it now.)

## Evidence
- `pnpm typecheck` + `pnpm lint`: clean. `pnpm test`: **1024 passed / 1 skipped**.
- **Grep-zero:** no `GAME_MODES|getGameRules|gameModeValidator|selectGameMode|finalRhyme|rhymeMode|rhymeTargetWord|GameMode` references remain in `convex/` `components/` `app/`.
- Legacy-safety is tested at two levels: a `gameRules` unit (matrix-length round bound, incl. a 5-round case) and a `sessionLifecycle` integration test (**a legacy 5-round game completes at its own boundary**).
- The local prod build is env-gated (`GUEST_TOKEN_SECRET`, pre-existing); the hosted merge-gate's E2E Mirror is the live browser proof.

Reviewed fresh-context (grok + Claude) on the three adversarial points: remaining constant-bounded round logic, the schema widening, and any client still reading `assignment.mode`/`rhymeTargetWord`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Game mode selection removed from the lobby—games now start with a standard configuration
  * Rhyme relay mode discontinued—poem display no longer emphasizes bookend words

<!-- end of auto-generated comment: release notes by coderabbit.ai -->