### PR TITLE
docs(backlog): refresh north star + reconcile backlog from strategic groom

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ depth.
 
 Read these when you need the truth:
 
+- `project.md` — product north star: vision, current focus, anti-goals. Read first to know what excellence means here before changing direction.
 - `convex/_generated/api.d.ts` — current Convex API surface.
 - `convex/schema.ts` — source of truth for data model.
 - `convex/lib/assignmentMatrix.ts` — load-bearing derangement-like assignment logic.
@@ -34,7 +35,7 @@ Read these when you need the truth:
 
 ## Invariants
 
-1. **Never push on red Dagger.** `pnpm ci:prepush` must be green. Never use `--no-verify`.
+1. **Never push on red `pnpm ci:prepush`.** Pre-push runs the fast Docker-free subset (typecheck + lint + test); it must be green. Never use `--no-verify`.
 2. **Never run `pnpm dev`, `pnpm dev:convex`, `convex dev`, or other local server processes yourself.** The user runs them elsewhere.
 3. **Never deploy Convex production without `LINEJAM_ALLOW_PROD_CONVEX_SYNC=1`.**
 4. **Never rely on placeholder Canary browser keys in build-bearing lanes.**
@@ -47,10 +48,19 @@ Read these when you need the truth:
 
 ## Gate Contract
 
-**`pnpm ci:prepush` IS the gate.** It shells to `pnpm ci:dagger:all`, which
-drives the Dagger module in `dagger/src/index.ts`.
+**Pre-push runs the fast, Docker-free subset, not the full Dagger contract.**
+`pnpm ci:prepush` = `typecheck` + `lint` + `test` (no Docker, ~45s, can't OOM).
+The monolithic `dagger-call.sh all` was removed from pre-push on 2026-06-21
+because it crammed build + authenticated browser E2E into one engine and
+OOM-killed (exit 137) on memory-limited machines.
 
-Composition:
+The **authoritative** full contract is the hosted `merge-gate`
+(`.github/workflows/ci.yml`) — the same Dagger functions decomposed across
+parallel runners, enforced by branch protection. Run `pnpm ci:dagger:all` on
+demand for full local fidelity (one monolithic engine; wants ample Docker
+memory).
+
+Full-contract composition (hosted / on-demand):
 
 - `format-check`
 - `lint`
@@ -64,18 +74,19 @@ Composition:
 Local enforcement:
 
 - Pre-commit: `gitleaks protect`, `eslint --fix`, `prettier --write`
-- Pre-push: `pnpm ci:prepush`
+- Pre-push: `pnpm ci:prepush` (fast subset only)
 - Commit-msg: commitlint
 
 Hosted workflows:
 
-- `.github/workflows/ci.yml` — split mirror jobs: `quality-gates`, `test-build`, `e2e`, advisory `qa-evidence`
+- `.github/workflows/ci.yml` — authoritative `merge-gate`: `quality-gates`, `test-build`, `e2e`, advisory `qa-evidence`
 - `.github/workflows/preview-smoke.yml` — preview smoke
 - `.github/workflows/prod-smoke.yml` — production smoke
-- `.github/workflows/release.yml` — semantic-release plus Gemini note synthesis
+- `.github/workflows/release.yml` — semantic-release plus note synthesis
 - `.github/workflows/trufflehog.yml` — extra hosted secret scan
 
-Local Dagger is authoritative. Hosted CI is secondary confirmation.
+The hosted `merge-gate` is authoritative; `pnpm ci:dagger:all` mirrors it
+locally on demand. Pre-push is the fast pre-filter, not the gate.
 
 ## Known-Debt Map
 

--- a/backlog.d/020-launch-gate-hardening.md
+++ b/backlog.d/020-launch-gate-hardening.md
@@ -1,0 +1,70 @@
+# Harden the app for public exposure: security headers, abuse + cost controls
+
+Priority: P0 · Status: ready · Estimate: L
+
+## Goal
+
+Linejam can be promoted publicly without a runaway OpenRouter bill,
+clickjacking/XSS exposure, or a blind outage — meeting the project.md Quality
+Bar gate "security headers and rate limits in place before public promotion."
+
+## Oracle
+
+- [ ] A fresh production request returns CSP, HSTS, X-Frame-Options/frame-ancestors,
+      X-Content-Type-Options, Referrer-Policy, and a tight Permissions-Policy
+      (set once in `next.config.ts` `headers()`).
+- [ ] A scripted loop of guest-session-mint → createRoom → addAiPlayer → startGame
+      is throttled (429 / ConvexError) and cannot drive more than a fixed budget
+      of OpenRouter calls: a per-IP throttle on `GET /api/guest/session` plus a
+      global daily AI call/cost budget that flips new AI turns to the
+      deterministic fallback when exceeded.
+- [ ] Rate limiting covers the abuse-relevant mutations (createRoom, joinRoom,
+      startGame, submitLine, addAiPlayer), IP-bucketed — not only `user._id`
+      (which a guest can mint for free).
+- [ ] The guest token is no longer mirrored into localStorage (httpOnly cookie is
+      the sole carrier); its 30-day TTL is shortened and a revocation path exists.
+- [ ] A `rateLimits` cleanup cron sweeps expired rows (`by_reset_time`).
+- [ ] `/api/health` is polled by a committed external monitor that pages on 503.
+
+## Verification System
+
+- Claim: a public, unauthenticated attacker cannot run up unbounded LLM cost,
+  clickjack the app, or take it down unseen.
+- Falsifier: a script minting N guests creates N rooms each firing ~9 OpenRouter
+  calls with no global cap; or curl shows missing security headers; or an outage
+  emits no page.
+- Driver: an abuse script (mint→create→start loop) + a header curl + a forced
+  budget-breach test.
+- Grader: header assertion passes; the budget counter flips new turns to
+  fallback; the throttle returns 429.
+- Evidence packet: curl header dump, abuse-script run showing throttle,
+  budget-breach test output, monitor screenshot.
+- Cadence: re-run before public launch; the header check rides the merge-gate.
+
+## Notes
+
+Convergent finding across the security, runtime-reliability, and ops grooming
+lanes. Today: zero security headers (`next.config.ts` has no `headers()`); rate
+limiting covers only 2 of 16 mutations keyed on `user._id`
+(`convex/lib/rateLimit.ts`, `convex/rooms.ts:43`); `GET /api/guest/session` mints
+guests unthrottled (`app/api/guest/session/route.ts`); no global OpenRouter
+budget or circuit-breaker (`convex/ai.ts`, `convex/lib/ai/providers/openrouter.ts`);
+guest token mirrored to localStorage (`lib/guestSession.ts`), 30-day TTL, no
+revocation; `rateLimits` table never swept; no uptime poller.
+
+NOTE: the 2 critical + 11 high Dependabot alerts are STALE false positives —
+already remediated via `pnpm.overrides` (verified one-version-per-package in
+`pnpm-lock.yaml`). The action is an ops re-trigger of the Dependabot scan, NOT
+engineering work; explicitly out of scope. The openrouter prompt-injection
+(`previousLineText` unescaped) remains an accepted/deprioritized risk — out of
+scope.
+
+## Children
+
+1. (S, ship first) Global OpenRouter daily call/cost budget + per-IP throttle on
+   `/api/guest/session` — the real-money launch blocker.
+2. (S) Security headers in `next.config.ts` `headers()`.
+3. (S) Extend rate limiting to abuse-relevant mutations, IP-bucketed.
+4. (S) Drop the localStorage guest-token mirror; shorten TTL; add revocation.
+5. (XS) `rateLimits` cleanup cron.
+6. (S) Wire an external uptime monitor polling `/api/health` with paging.

--- a/backlog.d/021-launch-read-path-and-resilience.md
+++ b/backlog.d/021-launch-read-path-and-resilience.md
@@ -1,0 +1,52 @@
+# Make the launch read paths index-backed and the live game crash-resilient
+
+Priority: P1 · Status: ready · Estimate: L
+
+## Goal
+
+The busiest public surface (landing/auth page) and the live game stay within
+Convex read/scan limits and degrade gracefully under load instead of
+full-table-scanning or white-screening the whole room.
+
+## Oracle
+
+- [ ] `getRecentPublicPoems` no longer full-table-scans: `rooms` gains a
+      `by_status` (or `by_status_completedAt`) index and the poems/lines fan-out
+      uses indexed lookups, not `q.or()` `.filter()` scans.
+- [ ] A single failing `useQuery` degrades only its panel, not the whole room —
+      a per-surface React `ErrorBoundary` around live game panels with retry UX
+      (not the `app/error.tsx` full-screen reset).
+- [ ] AI generation issues at most one in-flight OpenRouter call per (game, round)
+      — a dedup/in-flight marker so re-nudges don't fan out — plus a
+      circuit-breaker when OpenRouter is down.
+- [ ] History queries (`getMyPoems`, community archive) are page-windowed, not
+      lifetime `.collect()`.
+- [ ] A synthetic many-room / busy-session load run shows Convex read counts and
+      OpenRouter QPS within limits.
+
+## Verification System
+
+- Claim: the app stays responsive and recoverable under launch-scale traffic and
+  partial failure.
+- Falsifier: the landing query scan grows with total rooms ever created; one
+  query error blanks the room; N human submits fan out to N OpenRouter calls for
+  one cell.
+- Driver: a synthetic load script (many completed rooms + a busy multi-room
+  session) + a query-error injection.
+- Grader: Convex function read-count dashboard, OpenRouter QPS, observed
+  per-panel error isolation.
+- Evidence packet: load-run metrics + an error-injection screenshot showing one
+  degraded panel.
+- Cadence: before launch; the index/error-boundary changes ride the normal gate.
+
+## Notes
+
+From the runtime-reliability lane. `getRecentPublicPoems` (`convex/archive.ts:219`)
+runs three full-table scans and is called unauthenticated from
+`components/auth/AuthShowcase.tsx` on the landing/auth pages — the busiest surface
+at launch. No React `ErrorBoundary` exists anywhere (only `app/error.tsx`);
+`useQuery` in Convex 1.x throws on error. AI re-nudge
+(`convex/lib/sessionLifecycle.ts:166`) schedules a fresh generation per human
+submit. The abandonment/never-die subsystem verified clean — no work there.
+Shares the cost-cap/circuit-breaker concern with [020]; coordinate the AI
+in-flight marker so it isn't built twice.

--- a/backlog.d/022-e2e-selector-contract-and-smoke-gate.md
+++ b/backlog.d/022-e2e-selector-contract-and-smoke-gate.md
@@ -1,0 +1,57 @@
+# Decouple browser proof from UI copy: testid contract + early smoke gate
+
+Priority: P1 · Status: ready · Estimate: M
+
+## Goal
+
+A UI copy/structure rename can no longer ship green through pre-push + the full
+unit suite while silently breaking the hosted E2E and the hourly production
+smoke.
+
+## Oracle
+
+- [ ] The ~10 load-bearing E2E touchpoints (start/submit/seal controls, reveal
+      controls, word-slots, phase headings) are targeted via a frozen
+      `data-testid` (or deliberately-frozen aria) contract in
+      `tests/e2e/support/guestFlow.ts` and `tests/e2e/prod-smoke.spec.ts` — not
+      display strings.
+- [ ] A fast headless smoke (host create → start → submit round 1 → reveal
+      heading, ~60s) runs in pre-push or an independent non-draft-gated CI job,
+      surfacing structural breaks before the ~25-min hosted E2E and the hourly
+      prod canary.
+- [ ] A lint/unit check fails if a contract `data-testid` is removed from source.
+
+## Verification System
+
+- Claim: structural/copy UI changes are caught by a fast pre-merge check, not
+  only the slow hosted E2E or the prod canary.
+- Falsifier: rename a button's copy → unit suite + pre-push stay green but the
+  change is unguarded until the hosted E2E (or prod).
+- Driver: rename a control's text in a branch and run the smoke.
+- Grader: the smoke fails on the rename; after retargeting to the testid, passes.
+- Evidence packet: the smoke output on a deliberate rename.
+- Cadence: every push (smoke), every merge (full E2E).
+
+## Notes
+
+This bit the team live on 2026-06-24 (PR #278): the writing-chrome change
+("Round N of 9" → "Round N · M words", Seal → Submit, controls into an overflow
+menu) passed pre-push + 1019 unit tests but failed E2E Mirror / QA Evidence on
+`getByText('Round 1 of 9')`; the same coupling also breaks
+`tests/e2e/prod-smoke.spec.ts`. Only 3 `data-testid` exist in the whole tree;
+pre-push is Docker-free (no E2E); the hosted `e2e` job is gated `if draft==false`.
+Smoke infra already exists (`playwright.smoke.config.ts`, `test:e2e:smoke`) but
+isn't wired pre-merge. See [[project_e2e_selectors_coupled_to_ui_copy]].
+
+## Children
+
+1. (M) `data-testid` contract on the load-bearing touchpoints; retarget
+   `guestFlow.ts` / `prod-smoke.spec.ts`.
+2. (S) Wire `test:e2e:smoke` into pre-push or an early independent CI job.
+3. (S) Land the planned mock-boundary ESLint rule (`no-restricted-imports`
+   banning `vi.mock('@/…')` outside a boundary allowlist) and de-mock the
+   adjacent-green tests (`tests/app/room-page.test.tsx` mocks Lobby /
+   WritingScreen / RevealPhase).
+4. (S) Add a repo-local `verify`/`qa` SKILL.md encoding the real run routes
+   (`pnpm dev`, `evidence:guest-flow`, `qa:agentic:local`, the smoke path) — the
+   highest-leverage agent-readiness gap.

--- a/backlog.d/023-reveal-ceremony-and-shareable-artifact.md
+++ b/backlog.d/023-reveal-ceremony-and-shareable-artifact.md
@@ -1,0 +1,51 @@
+# Make the reveal a ceremony and a one-tap shareable group artifact
+
+Priority: P1 · Status: pending · Estimate: L
+
+Milestone: aesthetic polish + growth loop (sequence after the launch-readiness
+items 020–022).
+
+## Goal
+
+The payoff moment — the reveal — lands as a paced, delightful ceremony AND
+produces one screenshot-worthy shareable artifact of the whole session, turning
+the funniest minute of game night into the acquisition channel.
+
+## Oracle
+
+- [ ] Reveal pacing follows the poem's own 1,2,3,4,5,4,3,2,1 word-shape with a
+      crescendo into the final line (not a flat 1000ms/line metronome),
+      respecting `prefers-reduced-motion`.
+- [ ] The room-favorite "crown" is a distinct ceremonial moment (heart-burst →
+      crown settle), not a static badge.
+- [ ] Optional sound + haptic punctuation on reveal/crown (mobile-first,
+      default-on with a mute) — zero exists today.
+- [ ] At session end the group gets ONE "Share the whole set" action backed by a
+      typeset session OG image at `/recap/[code]/opengraph-image`; the two
+      near-identical recap share buttons collapse to one.
+- [ ] Per-poem share text is seeded with the poem's actual opening line (not the
+      generic "Read this poem from our Linejam session").
+
+## Verification System
+
+- Claim: the reveal is worth screenshotting and sharing, and the share drives new
+  players.
+- Falsifier: the reveal is a uniform metronome with no climax; the only shareable
+  unit is a generic-text single poem.
+- Driver: a 4-theme reveal walkthrough + a rendered `/recap/[code]/opengraph-image`.
+- Grader: visual review of pacing/crown/motion across themes; the OG card renders
+  the session.
+- Evidence packet: a screen recording of the reveal + the recap OG image.
+- Cadence: milestone-2 polish; verified by a screenshot/recording walk.
+
+## Notes
+
+Convergent across the design and product/exemplar lanes. Today
+`components/PoemDisplay.tsx:27` hardcodes `BASE_REVEAL_DELAY=1000ms`; grep for
+vibrate/Audio/confetti returns empty; the crown is a static `Heart`
+(`SessionRecapHub.tsx:129`); the reveal is private per-poem (`RevealPhase.tsx`)
+with no single-frame group artifact. The single-poem OG pipeline already exists
+(`app/poem/[id]/opengraph-image.tsx`) — reuse it for the session recap. Gartic
+Phone / Jackbox prove the reveal is the category's growth engine. Depends on the
+design-token wiring in [025] for the motion to feel coherent. Stays within
+anti-goals (no gamification).

--- a/backlog.d/024-zero-friction-join-and-onboarding.md
+++ b/backlog.d/024-zero-friction-join-and-onboarding.md
@@ -1,0 +1,48 @@
+# Zero-friction join (QR + tap-copy) and teach-by-doing onboarding
+
+Priority: P1 · Status: pending · Estimate: L
+
+Milestone: spans launch-readiness (join friction) and aesthetic polish
+(onboarding feel).
+
+## Goal
+
+A first-time group of friends on phones gets from landing → playing → reveal with
+one person never opening "How to Play" and a second person joining by
+scanning/tapping the code, not retyping it.
+
+## Oracle
+
+- [ ] The lobby shows a scannable QR that drops a phone straight into
+      `/join?code=…`; tapping the room code copies the bare 4-char code (distinct
+      from the invite URL) — closes the long-standing issue #170 properly.
+- [ ] A first-run inline coachmark on the writing screen teaches the
+      partial-visibility + word-count mechanic, shown once per device, without
+      opening the help modal.
+- [ ] A late/mid-game arrival sees an explanatory "game in progress — you're in
+      for the next round" state instead of an empty waiting screen.
+- [ ] The landing/join page has a one-sentence "what happens" beat before a
+      cold-linked friend commits a name.
+- [ ] The submit-failure path routes through `errorToFeedback` (not the hardcoded
+      English string), matching the rest of the app.
+
+## Verification System
+
+- Claim: friends can start and join without friction or explanation on phones.
+- Falsifier: joining requires retyping a 4-char code; a first writer has no idea
+  the rest of the poem is hidden; a late arrival hits a dead end.
+- Driver: a mobile-viewport walkthrough — host creates → second device scans QR →
+  both play → reveal.
+- Grader: the walkthrough completes with no help-modal open and a scan-based join.
+- Evidence packet: a mobile screen recording of scan-to-join + the coachmark.
+- Cadence: milestone-1/2; verified by a mobile walkthrough.
+
+## Notes
+
+From the UX and product/exemplar lanes. Today the room code is a non-interactive
+`<span>` (`RoomChrome.tsx:116`) and `Lobby.tsx:203` tells users to "share the code
+from the top bar" — text they can't copy; no QR exists anywhere. Rules are two
+taps deep (behind the overflow menu). Mid-game join lands on an empty
+`WaitingScreen` with no explanation (`WritingScreen.tsx:287`). Submit failure uses
+a hardcoded string (`WritingScreen.tsx:154`). Jackbox's QR join is the category
+table-stakes; reuse the existing `useShareLink` flow in `RoomChrome.tsx`.

--- a/backlog.d/025-make-the-design-system-real.md
+++ b/backlog.d/025-make-the-design-system-real.md
@@ -1,0 +1,39 @@
+# Wire the themed design tokens so the system is real, not aspirational
+
+Priority: P2 · Status: ready · Estimate: M
+
+Milestone: aesthetic polish (foundational — do before the reveal-ceremony motion
+in 023).
+
+## Goal
+
+The defined typographic scale, spacing, leading, and tracking actually render
+across all four themes — closing the gap between a design system that exists in
+data and one that ships, the foundation of Stripe-level coherence.
+
+## Oracle
+
+- [ ] `text-*`, `space-*`, `leading-*`, `tracking-*` tokens are registered in
+      `@theme` (`app/globals.css`) so components stop falling back to Tailwind
+      defaults; a 4-theme visual diff shows the tuned scales applying.
+- [ ] `app/error.tsx` and `app/global-error.tsx` are on-system (Button component,
+      theme colors, display font) matching `not-found.tsx`; the undefined
+      `text-muted-foreground` token is gone.
+- [ ] The font story is reconciled: either `kenya` restores the documented
+      Cormorant + Inter pairing, or the docs document the real per-theme pairings
+      (no doc/preset drift).
+- [ ] Hardcoded color/shadow escapes (e.g. `Lobby.tsx:274` raw rgba shadow) are
+      replaced with theme tokens; the Quality Bar "themes render without hardcoded
+      overrides" holds.
+
+## Notes
+
+From the design/aesthetic lane. `lib/themes/apply.ts:33` writes every token as a
+CSS var, but `app/globals.css` `@theme` registers ONLY colors/shadows/radius/
+durations — not type/space/leading/tracking — so the Perfect-Fourth / modular
+scales are defined-but-unapplied (components reference `var(--text-*)` twice,
+`var(--space-*)` zero times). Error boundaries use the shadcn
+`text-muted-foreground` token, undefined in this repo. Only `vintage-paper` uses
+the documented Cormorant; `kenya` (the default, the face of the product) uses
+Libre Baskerville + IBM Plex. This is near-zero-per-component leverage: wiring the
+tokens once makes all four themes instantly more intentional.

--- a/backlog.d/026-doc-truth-and-runbook-sweep.md
+++ b/backlog.d/026-doc-truth-and-runbook-sweep.md
@@ -1,0 +1,35 @@
+# Doc-truth sweep: retire orphaned vision.md, de-date stale sections, add ops runbook notes
+
+Priority: P2 · Status: ready · Estimate: S
+
+## Goal
+
+A cold agent gets one un-contradicted answer to "what is the north star, what
+runs when I push, and how do I roll back" — no stale or competing docs.
+
+## Oracle
+
+- [ ] `docs/vision.md` (self-declared "canonical" but contradicted by `project.md`,
+      which says it was removed) is retired or demoted to a one-line pointer to
+      `project.md`; `grep -ri "canonical" docs/` yields no competing
+      product-vision doc.
+- [ ] CLAUDE.md "Recent Features (Dec 2025)" and "Known Issues (None currently
+      tracked)" frozen boilerplate are removed or derived from `backlog.d/`.
+- [ ] The "Patterns to Follow" code snippets exist in exactly one file
+      (AGENTS.md or CLAUDE.md); `project.md` references rather than restates them.
+- [ ] A short release/rollback runbook captures the operational gotchas that
+      currently live only in agent memory: Landmark has no pnpm on PATH (don't add
+      pnpm-exec to `.releaserc.js`); Vercel promote-back + Convex
+      forward-redeploy-of-prior-SHA + a Convex export/restore drill.
+
+## Notes
+
+From the agent-readiness and ops lanes. The AGENTS.md gate-contract drift (it
+claimed `ci:prepush` shells to `ci:dagger:all`) was already fixed during this
+groom, along with an AGENTS.md → `project.md` north-star pointer. Remaining:
+`docs/vision.md:3` still says "Status: canonical" while `project.md` says it was
+removed; CLAUDE.md carries frozen "(Dec 2025)" / "Known Issues (None)" sections;
+the Patterns snippets are triplicated (`project.md:43`, `CLAUDE.md:278`,
+`AGENTS.md:43`); rollback is one prose sentence (`docs/deployment.md:354`) with no
+command and no Convex data export/restore drill. (Deleting `docs/vision.md` is a
+proposal pending ratification — demote-to-pointer is the non-destructive default.)

--- a/backlog.d/027-collapse-dual-analytics-surface.md
+++ b/backlog.d/027-collapse-dual-analytics-surface.md
@@ -1,0 +1,28 @@
+# Collapse the dual analytics surface to one funnel path
+
+Priority: P3 · Status: blocked · Estimate: S
+
+Blocked on a product decision: PostHog-as-events vs Vercel-as-events.
+
+## Goal
+
+One analytics dependency owns product-funnel events; the other is removed or
+given a documented single-responsibility role — ending the "two deps, the
+deprecated one does all the real work" split.
+
+## Oracle
+
+- [ ] Exactly one analytics path owns the 7 product-funnel events; grep shows no
+      event flowing through a path the docs call deprecated.
+- [ ] The other surface is either removed (drop the dependency) or has a
+      documented, deliberate role (e.g. PostHog = session/pageview only).
+- [ ] `project.md` / CLAUDE.md analytics notes match the implemented reality.
+
+## Notes
+
+From the architecture/simplification lane. `lib/analytics.ts` (Vercel `track()`)
+carries all 7 funnel events; `lib/posthog/` only ever captures `$pageview` — so
+PostHog is event-dead despite the memory note that "new event work goes through
+PostHog." Either finish the migration (move events to PostHog, drop
+`@vercel/analytics` + `lib/analytics.ts`) or demote PostHog and accept Vercel as
+the funnel surface. Low stakes; pure coherence. Decision-required before pickup.

--- a/project.md
+++ b/project.md
@@ -6,7 +6,7 @@ A digital version of the paper-folding poetry game—casual multiplayer fun with
 
 **North Star:** World-class casual party game with Stripe-level design and polish. Players feel delighted, not overwhelmed. The game works, it's fun, it creates memorable moments with friends.
 **Target User:** Friends at a gathering who want a quick, creative, funny activity. No signup required (guest mode). Works on phones. Minimal explanation needed.
-**Current Focus:** Polish and production-readiness—Stripe-level design quality, award-winning aesthetic (Kenya Hara minimalism + premium themes), rock-solid infrastructure. Don't overcomplicate—core works, ship and refine.
+**Current Focus:** One core loop, polished to a world-class bar. The mechanic is settled—9 rounds, 1,2,3,4,5,4,3,2,1 words—and depth now comes from design, feel, and reliability, not from more modes. Sequenced path: public-launch readiness → deeper aesthetic polish → revenue stretch. Don't overcomplicate; ship and refine.
 **Key Differentiators:** Lower friction than paper; persistent shareable artifacts; digital-native sharing; can evolve mechanics without physical constraints.
 
 ## Domain Glossary
@@ -27,9 +27,10 @@ A digital version of the paper-folding poetry game—casual multiplayer fun with
 
 ## Active Focus
 
-- **Milestone:** Party-game depth — make the room experience magical, not just functional
-- **Key Items:** `backlog.d/` is authoritative. Current arc: 010 (game modes platform: Rhyme Relay + Quick Jam), 011 (realtime resilience: ghostwriter rescue, rematch for all), 012 (round clock + sparks), 013 (reveal ceremony staging), 014 (mobile thumb test), 015 (doc truth)
-- **Theme:** Engineered fun — tension, theater, and resilience on top of the proven core loop
+- **Milestone:** Public-launch readiness — close the Quality Bar gaps (open security advisories, security headers + rate limits, mobile polish) so Linejam can be promoted publicly with no caveats.
+- **Then:** deeper aesthetic polish (award-winning feel) → revenue stretch (print-on-demand booklets; see Stretch Goal).
+- **Stance:** The 010–012 expansion arc (multiple modes, per-line sparks) was deliberately rolled back — Linejam is **one core mode, refined**. The reliability + infra foundation is laid (presence/self-heal, host migration, convex-test, Landmark releases). `backlog.d/` is authoritative for shaped work; strategic bets get groomed in before they're built.
+- **Theme:** Restraint as the product — Kenya Hara minimalism applied to the mechanics as much as the visuals.
 
 ## Quality Bar
 
@@ -79,8 +80,10 @@ them, small revenue cut per book.
 
 ## Anti-Goals
 
-- Heavy monetization (no subscriptions, no ads)
+- Multiple game modes — one core loop, refined; variety comes from the players, not the mechanics (Rhyme Relay + Quick Jam were built and deleted, #275)
+- Ornamental in-game nudges — e.g. per-line "sparks"; the word constraint is the only prompt the player needs (deleted #278)
 - Feature bloat (no gamification, leaderboards, achievements)
+- Heavy monetization (no subscriptions, no ads) — print-on-demand booklets are the only revenue bet
 - Social network aspirations
 
 ## Lessons Learned
@@ -92,5 +95,5 @@ them, small revenue cut per book.
 
 ---
 
-_Last updated: 2026-06-12_
+_Last updated: 2026-06-25_
 _Updated during: /groom session (absorbed vision.md, which is now removed)_


### PR DESCRIPTION
Strategic `/groom` (9 parallel fresh-context lanes + web research) against a refreshed `project.md` north star (simplify & polish; milestone path launch-readiness → aesthetic polish → revenue).

## Applied
- **project.md** — Current/Active Focus reconciled to the simplify-and-polish thesis; Anti-Goals now explicitly reject multiple modes + sparks so the #275/#278 deletions can't drift back.
- **AGENTS.md** — fixed the stale Gate Contract (claimed `ci:prepush` shells to `ci:dagger:all`; it's the fast Docker-free subset, hosted merge-gate is authoritative — the 2026-06-21 re-tier AGENTS.md missed); added a `project.md` north-star pointer.
- Released 5 stale `.claims` locks for done items (local, gitignored).

## Backlog emissions (019 was the only prior active item)
| ID | P | Theme |
|----|---|-------|
| 020 | P0 | Launch-gate hardening — headers + abuse/cost controls (free guest minting → unbounded OpenRouter spend; convergent security/runtime/ops finding) |
| 021 | P1 | Launch read-path & resilience (public-page full-table scan, error boundaries, AI fan-out dedup) |
| 022 | P1 | E2E selector contract + early smoke gate (the UI-copy coupling that broke #278 and the prod canary) |
| 023 | P1 | Reveal as ceremony + shareable group artifact (growth loop) |
| 024 | P1 | Zero-friction join (QR + tap-copy) + teach-by-doing onboarding |
| 025 | P2 | Make the design system real (wire the dead themed tokens) |
| 026 | P2 | Doc-truth + runbook sweep (retire orphaned `docs/vision.md`, de-date CLAUDE.md) |
| 027 | P3 | Collapse dual analytics surface (decision-required) |

Docs/backlog only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)