### PR TITLE
chore(ci): expose fast host gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,9 +172,11 @@ jobs:
 
       - name: Set QA evidence paths
         run: |
-          echo "LINEJAM_EVIDENCE_DIR=$RUNNER_TEMP/linejam-evidence" >> "$GITHUB_ENV"
-          echo "LINEJAM_EVIDENCE_SERVER_LOG=$RUNNER_TEMP/linejam-evidence-server.log" >> "$GITHUB_ENV"
-          echo "LINEJAM_EVIDENCE_SERVER_PID=$RUNNER_TEMP/linejam-evidence-server.pid" >> "$GITHUB_ENV"
+          {
+            echo "LINEJAM_EVIDENCE_DIR=$RUNNER_TEMP/linejam-evidence"
+            echo "LINEJAM_EVIDENCE_SERVER_LOG=$RUNNER_TEMP/linejam-evidence-server.log"
+            echo "LINEJAM_EVIDENCE_SERVER_PID=$RUNNER_TEMP/linejam-evidence-server.pid"
+          } >> "$GITHUB_ENV"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -202,7 +204,7 @@ jobs:
           PORT=3333 pnpm start:next > "$LINEJAM_EVIDENCE_SERVER_LOG" 2>&1 &
           echo $! > "$LINEJAM_EVIDENCE_SERVER_PID"
 
-          for attempt in {1..60}; do
+          for _ in {1..60}; do
             if curl -sf "$LINEJAM_BASE_URL" >/dev/null; then
               exit 0
             fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ pnpm typecheck
 pnpm lint:fix
 
 # Gate
+pnpm ci:fast
 pnpm ci:prepush
 pnpm ci:dagger:{lint,typecheck,format-check,build-check,unit-test,e2e,audit,secret-scan,smoke,all-no-e2e,all}
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ pnpm test         # Run once
 pnpm test:watch   # Watch mode
 pnpm test:ci      # With coverage
 
-# Local-first CI via Dagger
+# Fast local CI
+pnpm ci:fast
+pnpm ci:prepush
+
+# Full local Dagger parity
 pnpm ci:dagger:all-no-e2e
 pnpm ci:dagger:all
 
@@ -120,8 +124,8 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for system overview: domain mod
 - Canary is the primary error and incident system. Client errors, request failures, and explicit `captureError()` calls all flow there.
 - Critical route telemetry is structured JSON. `/api/health` and `/api/guest/session` log method, route, status, and duration without guest tokens, display names, or raw request payloads.
 - Completed rooms end in a shared recap hub. Players can replay every poem, share `/recap/<room-code>`, and keep the same group moving into the next round without relying on one-off archive links.
-- Treat Dagger as the source of truth for local engineering validation: `pnpm ci:dagger:all`.
-- GitHub Actions still enforces branch protection remotely. Keep the local Dagger contract green first, then expect hosted `merge-gate` and preview/prod smoke to mirror that branch on remote infrastructure.
+- Use `pnpm ci:fast` for the fast host loop: typecheck, lint, and tests without Docker. `pnpm ci:prepush` is the same command under the pre-push hook.
+- GitHub Actions enforces the authoritative full contract through hosted `merge-gate`. Run `pnpm ci:dagger:all` on demand for full local parity when Docker and the required env are available.
 - Local Dagger auto-hydrates `GUEST_TOKEN_SECRET` from the active Convex deployment when `NEXT_PUBLIC_CONVEX_URL` points at the same Convex dev or prod backend that the CLI resolves.
 - Local Dagger auto-syncs the active Convex dev deployment before `all` and `e2e` runs. It refuses to push production Convex code unless you explicitly set `LINEJAM_ALLOW_PROD_CONVEX_SYNC=1`.
 - Local Dagger ensures the Clerk `convex` JWT template exists before local auth-heavy browser coverage. Dev/test Clerk keys can be bootstrapped automatically; live-key mutation stays blocked unless you explicitly set `LINEJAM_ALLOW_LIVE_CLERK_TEMPLATE_CREATE=1`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -225,14 +225,17 @@ If you see `500 Internal Server Error` or "Token signature verification failed",
 - The values are **identical** in both environments
 - No trailing whitespace or encoding issues in the secret
 
-### 4. Run Local-First CI
+### 4. Run Local CI
 
 ```bash
-# Run the local-first CI contract
+# Run the fast host gate
+pnpm ci:fast
+
+# Run full local Dagger parity for the hosted merge-gate
 pnpm ci:dagger:all
 ```
 
-This should pass without guest-token verification mismatches. Local Dagger hydrates `GUEST_TOKEN_SECRET` from the matching Convex deployment automatically.
+The fast gate should pass before push. The full Dagger parity gate should pass without guest-token verification mismatches. Local Dagger hydrates `GUEST_TOKEN_SECRET` from the matching Convex deployment automatically.
 It also ensures the Clerk `convex` JWT template exists before authenticated browser coverage runs.
 
 ## Deployment Workflow

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,8 @@ Linejam uses a hybrid testing stack: Vitest for unit/integration tests and Playw
 pnpm test          # Run unit tests once
 pnpm test:watch    # Watch mode for development
 pnpm test:ci       # CI mode with coverage
-pnpm ci:dagger:all # Local-first CI contract
+pnpm ci:fast       # Fast local gate: typecheck, lint, tests
+pnpm ci:dagger:all # Full local Dagger parity for hosted merge-gate
 pnpm test:e2e      # Run deterministic E2E tests (excludes @evidence)
 pnpm test:e2e:smoke # Remote preview/prod smoke
 pnpm test:e2e:evidence # Run the tagged evidence capture spec

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:e2e:ui": "playwright test --ui --grep-invert \"@evidence|@slow\"",
     "qa:agentic:local": "node ./scripts/qa/agentic.mjs --target local",
     "qa:agentic:preview": "node ./scripts/qa/agentic.mjs --target preview",
+    "ci:fast": "pnpm ci:prepush",
     "ci:dagger:all": "./scripts/ci/dagger-call.sh all",
     "ci:dagger:all-no-e2e": "./scripts/ci/dagger-call.sh all-no-e2e",
     "ci:dagger:agentic-qa": "./scripts/ci/dagger-call.sh agentic-qa",

--- a/scripts/ci/dagger-call.sh
+++ b/scripts/ci/dagger-call.sh
@@ -2,6 +2,23 @@
 
 set -euo pipefail
 
+unset \
+	GIT_DIR \
+	GIT_WORK_TREE \
+	GIT_COMMON_DIR \
+	GIT_CONFIG \
+	GIT_CONFIG_PARAMETERS \
+	GIT_CONFIG_COUNT \
+	GIT_INDEX_FILE \
+	GIT_OBJECT_DIRECTORY \
+	GIT_ALTERNATE_OBJECT_DIRECTORIES \
+	GIT_PREFIX \
+	GIT_IMPLICIT_WORK_TREE \
+	GIT_GRAFT_FILE \
+	GIT_NO_REPLACE_OBJECTS \
+	GIT_REPLACE_REF_BASE \
+	GIT_SHALLOW_FILE
+
 FUNCTION_NAME="${1:?Usage: scripts/ci/dagger-call.sh <function> [extra dagger args...]}"
 shift || true
 

--- a/tests/scripts/dagger-call.test.ts
+++ b/tests/scripts/dagger-call.test.ts
@@ -14,9 +14,35 @@ import { join, resolve } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+const GIT_LOCAL_ENV_VARS = [
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_CONFIG',
+  'GIT_CONFIG_PARAMETERS',
+  'GIT_CONFIG_COUNT',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_IMPLICIT_WORK_TREE',
+  'GIT_GRAFT_FILE',
+  'GIT_INDEX_FILE',
+  'GIT_NO_REPLACE_OBJECTS',
+  'GIT_REPLACE_REF_BASE',
+  'GIT_PREFIX',
+  'GIT_SHALLOW_FILE',
+  'GIT_COMMON_DIR',
+];
+
 function writeExecutable(path: string, contents: string) {
   writeFileSync(path, contents);
   chmodSync(path, 0o755);
+}
+
+function cleanGitLocalEnv(env = process.env) {
+  const clean = { ...env };
+  for (const key of GIT_LOCAL_ENV_VARS) {
+    delete clean[key];
+  }
+  return clean;
 }
 
 function createWorkspaceFixture() {
@@ -59,6 +85,7 @@ for (const relative of raw) {
 function initGitRepo(workspace: string) {
   const gitInit = spawnSync('git', ['init', '-q'], {
     cwd: workspace,
+    env: cleanGitLocalEnv(),
     encoding: 'utf8',
   });
 
@@ -77,7 +104,7 @@ function runDaggerCall(
     {
       cwd: workspace,
       env: {
-        ...process.env,
+        ...cleanGitLocalEnv(),
         ...env,
         PATH: `${binDir}:${process.env.PATH ?? ''}`,
       },
@@ -124,7 +151,11 @@ printf '%s' "\${NEXT_PUBLIC_CANARY_API_KEY:-}" > "${envLog}"
 
     initGitRepo(workspace);
 
-    const result = runDaggerCall(workspace, binDir, 'format-check');
+    const result = runDaggerCall(workspace, binDir, 'format-check', {
+      GIT_DIR: join(workspace, 'not-this-repo.git'),
+      GIT_WORK_TREE: join(workspace, 'not-this-worktree'),
+      GIT_INDEX_FILE: join(workspace, 'not-this-index'),
+    });
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe('');


### PR DESCRIPTION
## Summary
- expose `pnpm ci:fast` as the existing host-local pre-push gate
- keep the hosted merge-gate/Dagger workflow as the full ship contract
- harden `scripts/ci/dagger-call.sh` against Git hook-local env leakage before snapshotting sources
- document the fast/full CI split in README and AGENTS

## Verification
- `pnpm vitest run tests/scripts/dagger-call.test.ts`
- `pnpm ci:fast`
- real `git push -u origin HEAD` pre-push path: `typecheck`, `lint`, and `test` all passed
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## Notes
- Local Dagger `all-no-e2e` still requires `GUEST_TOKEN_SECRET` for remote Convex; hosted merge-gate remains the full Dagger proof surface.
- Thermo-nuclear review approved the branch; hard-coded Git-local env cleanup was noted as a non-blocking centralized durability risk.
