### PR TITLE
feat(observability): wire Convex backend failures to Canary

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as abandonment from "../abandonment.js";
 import type * as ai from "../ai.js";
 import type * as archive from "../archive.js";
 import type * as crons from "../crons.js";
+import type * as errors from "../errors.js";
 import type * as favorites from "../favorites.js";
 import type * as game from "../game.js";
 import type * as health from "../health.js";
@@ -51,6 +52,7 @@ declare const fullApi: ApiFromModules<{
   ai: typeof ai;
   archive: typeof archive;
   crons: typeof crons;
+  errors: typeof errors;
   favorites: typeof favorites;
   game: typeof game;
   health: typeof health;

--- a/convex/abandonment.ts
+++ b/convex/abandonment.ts
@@ -32,7 +32,7 @@ import {
   getFinalRoundIndex,
   isPresenceStale,
 } from './lib/gameRules';
-import { log } from './lib/errors';
+import { log, logError } from './lib/errors';
 
 /** The human roomPlayers rows for a game (AI players excluded). */
 async function getHumanPlayers(
@@ -125,34 +125,50 @@ function anyHumanPresent(
 export const sweepAbandonedGames = internalMutation({
   args: {},
   handler: async (ctx) => {
-    const now = Date.now();
-    const idleCutoff = now - ABANDONMENT_THRESHOLD_MS;
-    const idleGames = await ctx.db
-      .query('games')
-      .withIndex('by_status_round', (q) =>
-        q.eq('status', 'IN_PROGRESS').lte('roundStartedAt', idleCutoff)
-      )
-      .collect();
+    try {
+      const now = Date.now();
+      const idleCutoff = now - ABANDONMENT_THRESHOLD_MS;
+      const idleGames = await ctx.db
+        .query('games')
+        .withIndex('by_status_round', (q) =>
+          q.eq('status', 'IN_PROGRESS').lte('roundStartedAt', idleCutoff)
+        )
+        .collect();
 
-    let scheduled = 0;
-    for (const game of idleGames) {
-      if (!(await isGameAbandoned(ctx, game, now))) continue;
+      let scheduled = 0;
+      for (const game of idleGames) {
+        if (!(await isGameAbandoned(ctx, game, now))) continue;
+        await ctx.scheduler.runAfter(
+          0,
+          internal.abandonment.finishAbandonedGame,
+          { gameId: game._id }
+        );
+        scheduled++;
+      }
+
+      if (scheduled > 0) {
+        log.warn('Abandonment sweep scheduled stranded games for completion', {
+          scheduled,
+          scanned: idleGames.length,
+        });
+      }
+
+      return { scheduled, scanned: idleGames.length };
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logError('sweepAbandonedGames failed', err, {});
       await ctx.scheduler.runAfter(
         0,
-        internal.abandonment.finishAbandonedGame,
-        { gameId: game._id }
+        internal.errors.reportBackendErrorToCanary,
+        {
+          errorName: err.name || 'Error',
+          errorMessage: err.message,
+          errorStack: err.stack,
+          operation: 'sweepAbandonedGames',
+        }
       );
-      scheduled++;
+      throw error;
     }
-
-    if (scheduled > 0) {
-      log.warn('Abandonment sweep scheduled stranded games for completion', {
-        scheduled,
-        scanned: idleGames.length,
-      });
-    }
-
-    return { scheduled, scanned: idleGames.length };
   },
 });
 
@@ -168,104 +184,121 @@ export const sweepAbandonedGames = internalMutation({
 export const finishAbandonedGame = internalMutation({
   args: { gameId: v.id('games') },
   handler: async (ctx, { gameId }) => {
-    const initial = await ctx.db.get(gameId);
-    if (!initial || initial.status !== 'IN_PROGRESS') {
-      return { completed: false, filled: 0 };
-    }
+    try {
+      const initial = await ctx.db.get(gameId);
+      if (!initial || initial.status !== 'IN_PROGRESS') {
+        return { completed: false, filled: 0 };
+      }
 
-    // Re-derive abandonment from scratch. The sweep decided in an earlier
-    // transaction; a human may have reconnected since. Never complete a room
-    // out from under someone who just came back.
-    if (!(await isGameAbandoned(ctx, initial, Date.now()))) {
-      return { completed: false, filled: 0 };
-    }
+      // Re-derive abandonment from scratch. The sweep decided in an earlier
+      // transaction; a human may have reconnected since. Never complete a room
+      // out from under someone who just came back.
+      if (!(await isGameAbandoned(ctx, initial, Date.now()))) {
+        return { completed: false, filled: 0 };
+      }
 
-    // One pass advances at most one round; bound the loop (CLAUDE.md loop-safety).
-    // Round count comes from the game's own matrix (legacy games may differ).
-    const maxPasses = getFinalRoundIndex(initial.assignmentMatrix) + 2;
+      // One pass advances at most one round; bound the loop (CLAUDE.md loop-safety).
+      // Round count comes from the game's own matrix (legacy games may differ).
+      const maxPasses = getFinalRoundIndex(initial.assignmentMatrix) + 2;
 
-    const poems = await ctx.db
-      .query('poems')
-      .withIndex('by_game', (q) => q.eq('gameId', gameId))
-      .collect();
+      const poems = await ctx.db
+        .query('poems')
+        .withIndex('by_game', (q) => q.eq('gameId', gameId))
+        .collect();
 
-    let filled = 0;
-    for (let pass = 0; pass < maxPasses; pass++) {
-      const game = await ctx.db.get(gameId);
-      if (!game || game.status !== 'IN_PROGRESS') break;
+      let filled = 0;
+      for (let pass = 0; pass < maxPasses; pass++) {
+        const game = await ctx.db.get(gameId);
+        if (!game || game.status !== 'IN_PROGRESS') break;
 
-      // A returning human ends the backstop immediately — judged by presence,
-      // not idle-age, because our own round advances reset roundStartedAt.
-      const humanPlayers = await getHumanPlayers(ctx, game.roomId);
-      if (anyHumanPresent(humanPlayers, Date.now())) break;
+        // A returning human ends the backstop immediately — judged by presence,
+        // not idle-age, because our own round advances reset roundStartedAt.
+        const humanPlayers = await getHumanPlayers(ctx, game.roomId);
+        if (anyHumanPresent(humanPlayers, Date.now())) break;
 
-      const round = game.currentRound;
-      const roundAssignments = getMatrixRound(game.assignmentMatrix, round);
+        const round = game.currentRound;
+        const roundAssignments = getMatrixRound(game.assignmentMatrix, round);
 
-      const lineChecks = await Promise.all(
-        poems.map((poem) =>
-          ctx.db
-            .query('lines')
-            .withIndex('by_poem_index', (q) =>
-              q.eq('poemId', poem._id).eq('indexInPoem', round)
-            )
-            .first()
-        )
-      );
-      const missing = poems.filter((_, index) => lineChecks[index] === null);
+        const lineChecks = await Promise.all(
+          poems.map((poem) =>
+            ctx.db
+              .query('lines')
+              .withIndex('by_poem_index', (q) =>
+                q.eq('poemId', poem._id).eq('indexInPoem', round)
+              )
+              .first()
+          )
+        );
+        const missing = poems.filter((_, index) => lineChecks[index] === null);
 
-      if (missing.length === 0) {
-        // Round fully present but the game has not advanced — a wedged state the
-        // per-line transition normally prevents (legacy data, a prior bug, a
-        // manual repair). Nudge the canonical transition to heal it instead of
-        // letting the cron reschedule a no-op forever.
-        await applyLineLifecycleTransition(ctx, {
-          game,
-          roomId: game.roomId,
-          lineIndex: round,
-        });
-        const after = await ctx.db.get(gameId);
-        if (
-          after &&
-          after.status === 'IN_PROGRESS' &&
-          after.currentRound === round
-        ) {
-          // Could not advance — nothing more this backstop can do.
-          break;
+        if (missing.length === 0) {
+          // Round fully present but the game has not advanced — a wedged state the
+          // per-line transition normally prevents (legacy data, a prior bug, a
+          // manual repair). Nudge the canonical transition to heal it instead of
+          // letting the cron reschedule a no-op forever.
+          await applyLineLifecycleTransition(ctx, {
+            game,
+            roomId: game.roomId,
+            lineIndex: round,
+          });
+          const after = await ctx.db.get(gameId);
+          if (
+            after &&
+            after.status === 'IN_PROGRESS' &&
+            after.currentRound === round
+          ) {
+            // Could not advance — nothing more this backstop can do.
+            break;
+          }
+          continue;
         }
-        continue;
+
+        const assignees = await Promise.all(
+          missing.map((poem) => ctx.db.get(roundAssignments[poem.indexInRoom]))
+        );
+        for (let i = 0; i < missing.length; i++) {
+          const poem = missing[i];
+          const assignee = assignees[i];
+          const baseName = assignee?.displayName ?? 'A poet';
+          // Honest byline: ghost for humans, the AI's own name for AI poems.
+          const authorDisplayName =
+            assignee?.kind === 'AI' ? baseName : `${baseName} (ghost)`;
+          const committed = await commitFallbackLine(ctx, {
+            roomId: game.roomId,
+            gameId,
+            poemId: poem._id,
+            lineIndex: round,
+            authorUserId: roundAssignments[poem.indexInRoom],
+            authorDisplayName,
+          });
+          if (committed) filled++;
+        }
       }
 
-      const assignees = await Promise.all(
-        missing.map((poem) => ctx.db.get(roundAssignments[poem.indexInRoom]))
-      );
-      for (let i = 0; i < missing.length; i++) {
-        const poem = missing[i];
-        const assignee = assignees[i];
-        const baseName = assignee?.displayName ?? 'A poet';
-        // Honest byline: ghost for humans, the AI's own name for AI poems.
-        const authorDisplayName =
-          assignee?.kind === 'AI' ? baseName : `${baseName} (ghost)`;
-        const committed = await commitFallbackLine(ctx, {
-          roomId: game.roomId,
+      const finalGame = await ctx.db.get(gameId);
+      const completed = finalGame?.status === 'COMPLETED';
+      if (completed) {
+        log.warn('Abandonment backstop completed a stranded game', {
           gameId,
-          poemId: poem._id,
-          lineIndex: round,
-          authorUserId: roundAssignments[poem.indexInRoom],
-          authorDisplayName,
+          filled,
         });
-        if (committed) filled++;
       }
+      return { completed, filled };
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logError('finishAbandonedGame failed', err, { gameId });
+      await ctx.scheduler.runAfter(
+        0,
+        internal.errors.reportBackendErrorToCanary,
+        {
+          errorName: err.name || 'Error',
+          errorMessage: err.message,
+          errorStack: err.stack,
+          operation: 'finishAbandonedGame',
+          gameId,
+        }
+      );
+      throw error;
     }
-
-    const finalGame = await ctx.db.get(gameId);
-    const completed = finalGame?.status === 'COMPLETED';
-    if (completed) {
-      log.warn('Abandonment backstop completed a stranded game', {
-        gameId,
-        filled,
-      });
-    }
-    return { completed, filled };
   },
 });

--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -33,7 +33,7 @@ import {
 } from './lib/ai/llm';
 import { normalizeText, validateWordCount } from './lib/ai/wordCountGuard';
 import { getConvexRuntimeConfig } from './lib/env';
-import { log } from './lib/errors';
+import { log, logError } from './lib/errors';
 import {
   applyLineLifecycleTransition,
   getSubmissionWindow,
@@ -394,58 +394,77 @@ export const scheduleAiTurn = internalMutation({
     round: v.number(),
   },
   handler: async (ctx, { roomId, gameId, round }) => {
-    // Verify game state - use game directly, not room.currentGameId (race-prone)
-    const game = await ctx.db.get(gameId);
+    try {
+      // Verify game state - use game directly, not room.currentGameId (race-prone)
+      const game = await ctx.db.get(gameId);
 
-    if (!game) return;
-    if (game.status !== 'IN_PROGRESS') return;
-    // Allow scheduling for current round or past rounds (late arrivals OK)
-    if (round > game.currentRound) return;
+      if (!game) return;
+      if (game.status !== 'IN_PROGRESS') return;
+      // Allow scheduling for current round or past rounds (late arrivals OK)
+      if (round > game.currentRound) return;
 
-    // Schedule once if ANY AI-assigned cell this round is still empty. The
-    // generation action and the safety net each fill *every* open AI cell, so
-    // one schedule covers all bots; re-nudge re-enters here idempotently.
-    const openCells = await getOpenAiCells(ctx, {
-      roomId,
-      gameId,
-      round,
-      matrix: game.assignmentMatrix,
-    });
-    if (openCells.length === 0) return;
-
-    let authorizedCells = 0;
-    for (const cell of openCells) {
-      const authorized = await prepareAiCellForGeneration(ctx, {
+      // Schedule once if ANY AI-assigned cell this round is still empty. The
+      // generation action and the safety net each fill *every* open AI cell, so
+      // one schedule covers all bots; re-nudge re-enters here idempotently.
+      const openCells = await getOpenAiCells(ctx, {
         roomId,
         gameId,
         round,
-        cell,
+        matrix: game.assignmentMatrix,
       });
-      if (authorized) authorizedCells += 1;
+      if (openCells.length === 0) return;
+
+      let authorizedCells = 0;
+      for (const cell of openCells) {
+        const authorized = await prepareAiCellForGeneration(ctx, {
+          roomId,
+          gameId,
+          round,
+          cell,
+        });
+        if (authorized) authorizedCells += 1;
+      }
+      if (authorizedCells === 0) return;
+
+      // Schedule with random delay (2-4 seconds)
+      const randomBytes = new Uint32Array(1);
+      crypto.getRandomValues(randomBytes);
+      const delayMs = 2000 + (randomBytes[0] % 2001); // 2000-4000ms
+
+      await ctx.scheduler.runAfter(delayMs, internal.ai.generateLineForRound, {
+        roomId,
+        gameId,
+        round,
+      });
+
+      // Safety net: actions are not retried by Convex. If generation dies,
+      // commit a deterministic fallback so the AI can never strand the round.
+      // Fills EVERY open AI cell (not one) — the multi-bot never-die backstop,
+      // which in solo play is the *only* backstop (the abandonment cron never
+      // fires while the human is present).
+      await ctx.scheduler.runAfter(AI_SAFETY_NET_MS, internal.ai.ensureAiLine, {
+        roomId,
+        gameId,
+        round,
+      });
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logError('scheduleAiTurn failed', err, { roomId, gameId, round });
+      await ctx.scheduler.runAfter(
+        0,
+        internal.errors.reportBackendErrorToCanary,
+        {
+          errorName: err.name || 'Error',
+          errorMessage: err.message,
+          errorStack: err.stack,
+          operation: 'scheduleAiTurn',
+          roomId,
+          gameId,
+          round,
+        }
+      );
+      throw error;
     }
-    if (authorizedCells === 0) return;
-
-    // Schedule with random delay (2-4 seconds)
-    const randomBytes = new Uint32Array(1);
-    crypto.getRandomValues(randomBytes);
-    const delayMs = 2000 + (randomBytes[0] % 2001); // 2000-4000ms
-
-    await ctx.scheduler.runAfter(delayMs, internal.ai.generateLineForRound, {
-      roomId,
-      gameId,
-      round,
-    });
-
-    // Safety net: actions are not retried by Convex. If generation dies,
-    // commit a deterministic fallback so the AI can never strand the round.
-    // Fills EVERY open AI cell (not one) — the multi-bot never-die backstop,
-    // which in solo play is the *only* backstop (the abandonment cron never
-    // fires while the human is present).
-    await ctx.scheduler.runAfter(AI_SAFETY_NET_MS, internal.ai.ensureAiLine, {
-      roomId,
-      gameId,
-      round,
-    });
   },
 });
 
@@ -463,39 +482,58 @@ export const ensureAiLine = internalMutation({
     round: v.number(),
   },
   handler: async (ctx, { roomId, gameId, round }) => {
-    const game = await ctx.db.get(gameId);
-    if (!game || game.status !== 'IN_PROGRESS') return;
-    if (round > game.currentRound) return;
+    try {
+      const game = await ctx.db.get(gameId);
+      if (!game || game.status !== 'IN_PROGRESS') return;
+      if (round > game.currentRound) return;
 
-    // Fill EVERY open AI cell — keyed on the actual line row, never on any
-    // generation claim. A dead generation action can therefore never strand a
-    // cell. Idempotent: commitAssignedLine no-ops on an already-filled cell.
-    const openCells = await getOpenAiCells(ctx, {
-      roomId,
-      gameId,
-      round,
-      matrix: game.assignmentMatrix,
-    });
-    for (const cell of openCells) {
-      const aiUser = await ctx.db.get(cell.aiUserId);
-      const committed = await commitFallbackLine(ctx, {
+      // Fill EVERY open AI cell — keyed on the actual line row, never on any
+      // generation claim. A dead generation action can therefore never strand a
+      // cell. Idempotent: commitAssignedLine no-ops on an already-filled cell.
+      const openCells = await getOpenAiCells(ctx, {
         roomId,
         gameId,
-        poemId: cell.poemId,
-        lineIndex: round,
-        authorUserId: cell.aiUserId,
-        authorDisplayName: aiUser?.displayName ?? 'AI',
+        round,
+        matrix: game.assignmentMatrix,
       });
+      for (const cell of openCells) {
+        const aiUser = await ctx.db.get(cell.aiUserId);
+        const committed = await commitFallbackLine(ctx, {
+          roomId,
+          gameId,
+          poemId: cell.poemId,
+          lineIndex: round,
+          authorUserId: cell.aiUserId,
+          authorDisplayName: aiUser?.displayName ?? 'AI',
+        });
 
-      if (committed) {
-        await recordAiUsage(ctx, { day: aiUsageDay(), fallbacks: 1 });
-        log.warn('AI safety net committed a fallback line', {
+        if (committed) {
+          await recordAiUsage(ctx, { day: aiUsageDay(), fallbacks: 1 });
+          log.warn('AI safety net committed a fallback line', {
+            roomId,
+            gameId,
+            round,
+            poemId: cell.poemId,
+          });
+        }
+      }
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logError('ensureAiLine failed', err, { roomId, gameId, round });
+      await ctx.scheduler.runAfter(
+        0,
+        internal.errors.reportBackendErrorToCanary,
+        {
+          errorName: err.name || 'Error',
+          errorMessage: err.message,
+          errorStack: err.stack,
+          operation: 'ensureAiLine',
           roomId,
           gameId,
           round,
-          poemId: cell.poemId,
-        });
-      }
+        }
+      );
+      throw error;
     }
   },
 });
@@ -511,128 +549,151 @@ export const generateLineForRound = internalAction({
     round: v.number(),
   },
   handler: async (ctx, { roomId, gameId, round }) => {
-    // Load game state directly (not through room.currentGameId which is race-prone)
-    const game = await ctx.runQuery(internal.ai.getGameState, { gameId });
-    if (!game) return;
-    if (game.status !== 'IN_PROGRESS') return;
-    // Allow generation for current round or past rounds (late arrivals OK)
-    if (round > game.currentRound) return;
+    try {
+      // Load game state directly (not through room.currentGameId which is race-prone)
+      const game = await ctx.runQuery(internal.ai.getGameState, { gameId });
+      if (!game) return;
+      if (game.status !== 'IN_PROGRESS') return;
+      // Allow generation for current round or past rounds (late arrivals OK)
+      if (round > game.currentRound) return;
 
-    // Generate for EVERY open AI cell this round (multi-bot). One dead cell
-    // never blocks the others, and any cell left empty is still covered by the
-    // ensureAiLine safety net.
-    const cells = await ctx.runQuery(internal.ai.getOpenAiCellsForRound, {
-      roomId,
-      gameId,
-      round,
-    });
-    if (cells.length === 0) return;
-
-    const targetWordCount = WORD_COUNTS[round];
-    const apiKey = initialOpenRouterApiKey;
-
-    for (const cell of cells) {
-      const turn = await ctx.runQuery(internal.ai.getAiTurnForCell, {
-        poemId: cell.poemId,
+      // Generate for EVERY open AI cell this round (multi-bot). One dead cell
+      // never blocks the others, and any cell left empty is still covered by the
+      // ensureAiLine safety net.
+      const cells = await ctx.runQuery(internal.ai.getOpenAiCellsForRound, {
+        roomId,
+        gameId,
         round,
       });
-      if (turn?.status !== 'authorized') continue;
+      if (cells.length === 0) return;
 
-      // Re-check idempotency: another cell's commit may have advanced state.
-      const alreadySubmitted = await ctx.runQuery(internal.ai.hasLineForRound, {
-        poemId: cell.poemId,
-        round,
-      });
-      if (alreadySubmitted) continue;
+      const targetWordCount = WORD_COUNTS[round];
+      const apiKey = initialOpenRouterApiKey;
 
-      const aiUser = await ctx.runQuery(internal.ai.getUserById, {
-        userId: cell.aiUserId,
-      });
-      // Explicit invariant: a bot cell must resolve to an AI user with a
-      // persona. If not (e.g. user deleted mid-game), skip — the safety net
-      // fills the cell rather than throwing inside the action.
-      if (!aiUser?.aiPersonaId) continue;
-      const persona = getPersona(aiUser.aiPersonaId as AiPersonaId);
+      for (const cell of cells) {
+        const turn = await ctx.runQuery(internal.ai.getAiTurnForCell, {
+          poemId: cell.poemId,
+          round,
+        });
+        if (turn?.status !== 'authorized') continue;
 
-      // Bots see ONLY the previous line — same constraint as a human (the
-      // game's defining symmetry, kept on purpose).
-      const previousLine =
-        round > 0
-          ? await ctx.runQuery(internal.ai.getPreviousLine, {
-              poemId: cell.poemId,
-              round: round - 1,
-            })
-          : null;
+        // Re-check idempotency: another cell's commit may have advanced state.
+        const alreadySubmitted = await ctx.runQuery(
+          internal.ai.hasLineForRound,
+          {
+            poemId: cell.poemId,
+            round,
+          }
+        );
+        if (alreadySubmitted) continue;
 
-      const result = await (async () => {
-        if (!apiKey) {
-          log.error('OPENROUTER_API_KEY not configured - using fallback line', {
+        const aiUser = await ctx.runQuery(internal.ai.getUserById, {
+          userId: cell.aiUserId,
+        });
+        // Explicit invariant: a bot cell must resolve to an AI user with a
+        // persona. If not (e.g. user deleted mid-game), skip — the safety net
+        // fills the cell rather than throwing inside the action.
+        if (!aiUser?.aiPersonaId) continue;
+        const persona = getPersona(aiUser.aiPersonaId as AiPersonaId);
+
+        // Bots see ONLY the previous line — same constraint as a human (the
+        // game's defining symmetry, kept on purpose).
+        const previousLine =
+          round > 0
+            ? await ctx.runQuery(internal.ai.getPreviousLine, {
+                poemId: cell.poemId,
+                round: round - 1,
+              })
+            : null;
+
+        const result = await (async () => {
+          if (!apiKey) {
+            log.error(
+              'OPENROUTER_API_KEY not configured - using fallback line',
+              {
+                roomId,
+                gameId,
+                round,
+              }
+            );
+            return {
+              text: getFallbackLine(
+                targetWordCount,
+                fallbackSeed(cell.poemId, round)
+              ),
+              fallbackUsed: true,
+              attemptsUsed: 0,
+            };
+          }
+
+          const config: LLMConfig = {
+            provider: 'openrouter',
+            model: getAiModel(),
+            apiKey,
+            timeoutMs: 10000,
+            maxRetries: 2,
+          };
+
+          return generateLine(
+            {
+              persona,
+              previousLineText: previousLine?.text,
+              targetWordCount,
+            },
+            config
+          );
+        })();
+        if (result.attemptsUsed > 0) {
+          await ctx.runMutation(internal.ai.recordAiHttpAttempts, {
+            day: turn.day,
+            attempts: result.attemptsUsed,
+          });
+        }
+
+        // On any fallback (no key, API failure, or word-count miss) use the
+        // varied bank seeded by the cell, so multi-bot fallback reveals don't
+        // repeat one canned line.
+        const text = result.fallbackUsed
+          ? getFallbackLine(targetWordCount, fallbackSeed(cell.poemId, round))
+          : result.text;
+
+        const committed = await ctx.runMutation(internal.ai.commitAiLine, {
+          poemId: cell.poemId,
+          lineIndex: round,
+          text,
+          aiUserId: cell.aiUserId,
+          roomId,
+          gameId,
+        });
+
+        if (result.fallbackUsed && committed) {
+          await ctx.runMutation(internal.ai.recordAiFallback, {
+            day: turn.day,
+            count: 1,
+          });
+          log.warn('AI fallback used', {
             roomId,
             gameId,
             round,
+            poemId: cell.poemId,
           });
-          return {
-            text: getFallbackLine(
-              targetWordCount,
-              fallbackSeed(cell.poemId, round)
-            ),
-            fallbackUsed: true,
-            attemptsUsed: 0,
-          };
         }
-
-        const config: LLMConfig = {
-          provider: 'openrouter',
-          model: getAiModel(),
-          apiKey,
-          timeoutMs: 10000,
-          maxRetries: 2,
-        };
-
-        return generateLine(
-          {
-            persona,
-            previousLineText: previousLine?.text,
-            targetWordCount,
-          },
-          config
-        );
-      })();
-      if (result.attemptsUsed > 0) {
-        await ctx.runMutation(internal.ai.recordAiHttpAttempts, {
-          day: turn.day,
-          attempts: result.attemptsUsed,
-        });
       }
-
-      // On any fallback (no key, API failure, or word-count miss) use the
-      // varied bank seeded by the cell, so multi-bot fallback reveals don't
-      // repeat one canned line.
-      const text = result.fallbackUsed
-        ? getFallbackLine(targetWordCount, fallbackSeed(cell.poemId, round))
-        : result.text;
-
-      const committed = await ctx.runMutation(internal.ai.commitAiLine, {
-        poemId: cell.poemId,
-        lineIndex: round,
-        text,
-        aiUserId: cell.aiUserId,
-        roomId,
-        gameId,
-      });
-
-      if (result.fallbackUsed && committed) {
-        await ctx.runMutation(internal.ai.recordAiFallback, {
-          day: turn.day,
-          count: 1,
-        });
-        log.warn('AI fallback used', {
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logError('generateLineForRound failed', err, { roomId, gameId, round });
+      await ctx
+        .runAction(internal.errors.reportBackendErrorToCanary, {
+          errorName: err.name || 'Error',
+          errorMessage: err.message,
+          errorStack: err.stack,
+          operation: 'generateLineForRound',
           roomId,
           gameId,
           round,
-          poemId: cell.poemId,
-        });
-      }
+        })
+        .catch(() => {});
+      throw error;
     }
   },
 });
@@ -768,63 +829,86 @@ export const generateGhostLine = internalAction({
     forUserId: v.id('users'),
   },
   handler: async (ctx, { roomId, gameId, round, poemId, forUserId }) => {
-    const game = await ctx.runQuery(internal.ai.getGameState, { gameId });
-    if (!game || game.status !== 'IN_PROGRESS') return;
-    if (game.currentRound !== round) return;
+    try {
+      const game = await ctx.runQuery(internal.ai.getGameState, { gameId });
+      if (!game || game.status !== 'IN_PROGRESS') return;
+      if (game.currentRound !== round) return;
 
-    const alreadySubmitted = await ctx.runQuery(internal.ai.hasLineForRound, {
-      poemId,
-      round,
-    });
-    if (alreadySubmitted) return;
+      const alreadySubmitted = await ctx.runQuery(internal.ai.hasLineForRound, {
+        poemId,
+        round,
+      });
+      if (alreadySubmitted) return;
 
-    const previousLine =
-      round > 0
-        ? await ctx.runQuery(internal.ai.getPreviousLine, {
-            poemId,
-            round: round - 1,
-          })
-        : null;
+      const previousLine =
+        round > 0
+          ? await ctx.runQuery(internal.ai.getPreviousLine, {
+              poemId,
+              round: round - 1,
+            })
+          : null;
 
-    const targetWordCount = WORD_COUNTS[round];
-    const apiKey = initialOpenRouterApiKey;
-    const result = await (async () => {
-      if (!apiKey) {
-        return {
-          text: getFallbackLine(targetWordCount, fallbackSeed(poemId, round)),
-          fallbackUsed: true,
-          attemptsUsed: 0,
+      const targetWordCount = WORD_COUNTS[round];
+      const apiKey = initialOpenRouterApiKey;
+      const result = await (async () => {
+        if (!apiKey) {
+          return {
+            text: getFallbackLine(targetWordCount, fallbackSeed(poemId, round)),
+            fallbackUsed: true,
+            attemptsUsed: 0,
+          };
+        }
+
+        const config: LLMConfig = {
+          provider: 'openrouter',
+          model: getAiModel(),
+          apiKey,
+          timeoutMs: 10000,
+          maxRetries: 2,
         };
-      }
 
-      const config: LLMConfig = {
-        provider: 'openrouter',
-        model: getAiModel(),
-        apiKey,
-        timeoutMs: 10000,
-        maxRetries: 2,
-      };
+        return generateLine(
+          {
+            persona: GHOSTWRITER_PERSONA,
+            previousLineText: previousLine?.text,
+            targetWordCount,
+          },
+          config
+        );
+      })();
 
-      return generateLine(
-        {
-          persona: GHOSTWRITER_PERSONA,
-          previousLineText: previousLine?.text,
-          targetWordCount,
-        },
-        config
-      );
-    })();
+      await ctx.runMutation(internal.ai.commitGhostLine, {
+        roomId,
+        gameId,
+        poemId,
+        lineIndex: round,
+        text: result.text,
+        forUserId,
+      });
 
-    await ctx.runMutation(internal.ai.commitGhostLine, {
-      roomId,
-      gameId,
-      poemId,
-      lineIndex: round,
-      text: result.text,
-      forUserId,
-    });
-
-    log.warn('Ghostwriter covered a stalled turn', { roomId, gameId, round });
+      log.warn('Ghostwriter covered a stalled turn', { roomId, gameId, round });
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logError('generateGhostLine failed', err, {
+        roomId,
+        gameId,
+        round,
+        poemId,
+      });
+      await ctx
+        .runAction(internal.errors.reportBackendErrorToCanary, {
+          errorName: err.name || 'Error',
+          errorMessage: err.message,
+          errorStack: err.stack,
+          operation: 'generateGhostLine',
+          roomId,
+          gameId,
+          poemId,
+          round,
+        })
+        .catch(() => {});
+      throw error;
+    }
   },
 });
 

--- a/convex/errors.ts
+++ b/convex/errors.ts
@@ -1,0 +1,60 @@
+/**
+ * Backend error reporting to Canary.
+ *
+ * Provides a single internalAction that sends errors to Canary. For mutations,
+ * schedule it via ctx.scheduler.runAfter(0, ...). For actions, call via
+ * ctx.runAction(...).
+ */
+
+import { v } from 'convex/values';
+import { internalAction } from './_generated/server';
+import {
+  buildBackendCanaryPayload,
+  isBackendCanaryEnabled,
+  sendBackendCanaryPayload,
+} from './lib/canary';
+
+/**
+ * Report a backend error to Canary. The action is fire-and-forget — callers
+ * schedule it and move on so error reporting never blocks recovery.
+ */
+export const reportBackendErrorToCanary = internalAction({
+  args: {
+    errorName: v.string(),
+    errorMessage: v.string(),
+    errorStack: v.optional(v.string()),
+    operation: v.optional(v.string()),
+    roomId: v.optional(v.string()),
+    gameId: v.optional(v.string()),
+    poemId: v.optional(v.string()),
+    round: v.optional(v.number()),
+  },
+  handler: async (
+    _ctx,
+    {
+      errorName: _errorName,
+      errorMessage,
+      errorStack: _errorStack,
+      operation,
+      roomId,
+      gameId,
+      poemId,
+      round,
+    }
+  ) => {
+    void _errorName;
+    void _errorStack;
+    if (!isBackendCanaryEnabled()) return;
+
+    const context: Record<string, unknown> = {};
+    if (operation) context.operation = operation;
+    if (roomId) context.roomId = roomId;
+    if (gameId) context.gameId = gameId;
+    if (poemId) context.poemId = poemId;
+    if (round !== undefined) context.round = round;
+
+    await sendBackendCanaryPayload(
+      buildBackendCanaryPayload(new Error(errorMessage), context)
+    );
+  },
+});

--- a/convex/lib/canary.ts
+++ b/convex/lib/canary.ts
@@ -1,0 +1,142 @@
+/**
+ * Convex-side Canary error reporter.
+ *
+ * Reuses the same Canary API endpoint, payload shape, and context-scrubbing
+ * discipline as the client-side reporter (lib/canaryCore.ts) so backend
+ * failures land in the same incident system.
+ */
+
+const SERVICE = 'linejam';
+const DEFAULT_CANARY_ENDPOINT = 'https://canary-obs.fly.dev';
+const REQUEST_TIMEOUT_MS = 2_000;
+
+const SAFE_CONTEXT_KEYS = new Set([
+  'boundary',
+  'digest',
+  'method',
+  'operation',
+  'path',
+  'poemId',
+  'roomCode',
+  'roomId',
+  'route',
+  'routePath',
+  'source',
+  'status',
+  'durationMs',
+]);
+
+function normalizeError(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      errorClass: error.name || error.constructor.name || 'Error',
+      message: error.message || 'Unknown error',
+      stackTrace: error.stack,
+    };
+  }
+
+  if (typeof error === 'string') {
+    return { errorClass: 'StringError', message: error };
+  }
+
+  return { errorClass: 'UnknownError', message: String(error) };
+}
+
+function scrubContext(
+  context: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!context) return undefined;
+
+  const next: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(context)) {
+    if (SAFE_CONTEXT_KEYS.has(key)) {
+      next[key] = value;
+    }
+  }
+
+  return Object.keys(next).length > 0 ? next : undefined;
+}
+
+export interface BackendCanaryPayload {
+  errorClass: string;
+  message: string;
+  severity: 'error' | 'warning' | 'info';
+  stackTrace?: string;
+  context?: Record<string, unknown>;
+}
+
+export function buildBackendCanaryPayload(
+  error: unknown,
+  context?: Record<string, unknown>
+): BackendCanaryPayload {
+  const normalized = normalizeError(error);
+  const scrubbedContext = scrubContext(context);
+
+  return {
+    errorClass: normalized.errorClass,
+    message: normalized.message,
+    severity: 'error',
+    stackTrace: normalized.stackTrace,
+    context: scrubbedContext,
+  };
+}
+
+function config() {
+  const apiKey = process.env.CANARY_API_KEY?.trim();
+  const endpoint =
+    process.env.CANARY_ENDPOINT?.trim() || DEFAULT_CANARY_ENDPOINT;
+  return { apiKey, endpoint };
+}
+
+export function isBackendCanaryEnabled(): boolean {
+  const { apiKey } = config();
+  return (apiKey?.length ?? 0) > 0;
+}
+
+/**
+ * Send a payload to Canary. Must be called from an action (has fetch).
+ */
+export async function sendBackendCanaryPayload(
+  payload: BackendCanaryPayload
+): Promise<void> {
+  const { apiKey, endpoint } = config();
+  if (!apiKey) return;
+
+  try {
+    const response = await fetch(
+      `${endpoint.replace(/\/$/, '')}/api/v1/errors`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          service: SERVICE,
+          environment: process.env.CONVEX_CLOUD_URL?.includes('convex.cloud')
+            ? 'production'
+            : 'development',
+          error_class: payload.errorClass,
+          message: payload.message,
+          severity: payload.severity,
+          stack_trace: payload.stackTrace,
+          context: payload.context,
+        }),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Canary capture returned ${response.status} ${response.statusText}`.trim()
+      );
+    }
+  } catch (reportingError) {
+    console.error('Canary capture failed (backend):', reportingError, {
+      originalError: {
+        errorClass: payload.errorClass,
+        message: payload.message,
+      },
+    });
+  }
+}

--- a/tests/convex/lib/canary.test.ts
+++ b/tests/convex/lib/canary.test.ts
@@ -1,0 +1,277 @@
+/** @vitest-environment node */
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+const ORIGINAL_ENV = { ...process.env };
+
+function canaryModule() {
+  return import('../../../convex/lib/canary');
+}
+
+describe('Backend Canary reporter (convex/lib/canary)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.CANARY_API_KEY;
+    delete process.env.CANARY_ENDPOINT;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe('isBackendCanaryEnabled', () => {
+    it('returns false when CANARY_API_KEY is not set', async () => {
+      delete process.env.CANARY_API_KEY;
+      const mod = await canaryModule();
+      expect(mod.isBackendCanaryEnabled()).toBe(false);
+    });
+
+    it('returns false when CANARY_API_KEY is empty', async () => {
+      process.env.CANARY_API_KEY = '';
+      const mod = await canaryModule();
+      expect(mod.isBackendCanaryEnabled()).toBe(false);
+    });
+
+    it('returns true when CANARY_API_KEY is set', async () => {
+      process.env.CANARY_API_KEY = 'sk-test-canary-key';
+      const mod = await canaryModule();
+      expect(mod.isBackendCanaryEnabled()).toBe(true);
+    });
+  });
+
+  describe('buildBackendCanaryPayload', () => {
+    it('normalizes Error objects', async () => {
+      const mod = await canaryModule();
+      const error = new Error('Test backend failure');
+      const payload = mod.buildBackendCanaryPayload(error);
+
+      expect(payload.errorClass).toBe('Error');
+      expect(payload.message).toBe('Test backend failure');
+      expect(payload.severity).toBe('error');
+      expect(payload.stackTrace).toBeDefined();
+      expect(payload.context).toBeUndefined();
+    });
+
+    it('normalizes string errors', async () => {
+      const mod = await canaryModule();
+      const payload = mod.buildBackendCanaryPayload('Plain string error');
+
+      expect(payload.errorClass).toBe('StringError');
+      expect(payload.message).toBe('Plain string error');
+      expect(payload.severity).toBe('error');
+    });
+
+    it('normalizes unknown errors', async () => {
+      const mod = await canaryModule();
+      const payload = mod.buildBackendCanaryPayload({ weird: 'shape' });
+
+      expect(payload.errorClass).toBe('UnknownError');
+      expect(payload.message).toContain('[object Object]');
+      expect(payload.severity).toBe('error');
+    });
+
+    it('scrubs unsafe context keys', async () => {
+      const mod = await canaryModule();
+      const payload = mod.buildBackendCanaryPayload(new Error('test'), {
+        roomCode: 'ABCD',
+        guestToken: 'secret-token',
+        displayName: 'Alice',
+        rawPayload: { sensitive: true },
+        operation: 'sweepAbandonedGames',
+      });
+
+      expect(payload.context).toEqual({
+        roomCode: 'ABCD',
+        operation: 'sweepAbandonedGames',
+      });
+      expect(payload.context).not.toHaveProperty('guestToken');
+      expect(payload.context).not.toHaveProperty('displayName');
+      expect(payload.context).not.toHaveProperty('rawPayload');
+    });
+
+    it('allows safe context keys', async () => {
+      const mod = await canaryModule();
+      const payload = mod.buildBackendCanaryPayload(new Error('test'), {
+        roomCode: 'ABCD',
+        roomId: 'room_123',
+        operation: 'generateLineForRound',
+        poemId: 'poem_456',
+        source: 'convex/ai',
+        status: 500,
+        durationMs: 200,
+        round: 3,
+      });
+
+      expect(payload.context).toEqual({
+        roomCode: 'ABCD',
+        roomId: 'room_123',
+        operation: 'generateLineForRound',
+        poemId: 'poem_456',
+        source: 'convex/ai',
+        status: 500,
+        durationMs: 200,
+      });
+    });
+
+    it('returns undefined context when all keys are unsafe', async () => {
+      const mod = await canaryModule();
+      const payload = mod.buildBackendCanaryPayload(new Error('test'), {
+        displayName: 'Alice',
+        guestToken: 'abc',
+        rawData: {},
+      });
+
+      expect(payload.context).toBeUndefined();
+    });
+
+    it('returns undefined context when none provided', async () => {
+      const mod = await canaryModule();
+      const payload = mod.buildBackendCanaryPayload(new Error('test'));
+
+      expect(payload.context).toBeUndefined();
+    });
+  });
+
+  describe('sendBackendCanaryPayload', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+      });
+      vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('sends a correctly-structured POST to Canary', async () => {
+      process.env.CANARY_API_KEY = 'sk-test';
+      process.env.CANARY_ENDPOINT = 'https://canary.test';
+      process.env.CONVEX_CLOUD_URL = 'https://linejam.convex.cloud';
+
+      const mod = await canaryModule();
+      await mod.sendBackendCanaryPayload({
+        errorClass: 'Error',
+        message: 'test error',
+        severity: 'error',
+        stackTrace: 'Error: test error\n    at Object.<anonymous>',
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://canary.test/api/v1/errors');
+
+      const body = JSON.parse(init.body);
+      expect(body.service).toBe('linejam');
+      expect(body.environment).toBe('production');
+      expect(body.error_class).toBe('Error');
+      expect(body.message).toBe('test error');
+      expect(body.severity).toBe('error');
+      expect(body.stack_trace).toBeDefined();
+      expect(init.headers.Authorization).toBe('Bearer sk-test');
+    });
+
+    it('includes context in the payload', async () => {
+      process.env.CANARY_API_KEY = 'sk-test';
+
+      const mod = await canaryModule();
+      await mod.sendBackendCanaryPayload({
+        errorClass: 'Error',
+        message: 'test',
+        severity: 'warning',
+        context: { roomCode: 'ABCD', operation: 'test' },
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.context).toEqual({ roomCode: 'ABCD', operation: 'test' });
+    });
+
+    it('is silent when CANARY_API_KEY is not configured', async () => {
+      delete process.env.CANARY_API_KEY;
+
+      const mod = await canaryModule();
+      await mod.sendBackendCanaryPayload({
+        errorClass: 'Error',
+        message: 'test',
+        severity: 'error',
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when the Canary API call fails', async () => {
+      process.env.CANARY_API_KEY = 'sk-test';
+      fetchMock.mockRejectedValue(new Error('Network error'));
+
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      const mod = await canaryModule();
+      await expect(
+        mod.sendBackendCanaryPayload({
+          errorClass: 'Error',
+          message: 'test',
+          severity: 'error',
+        })
+      ).resolves.toBeUndefined();
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('does not throw when the Canary API returns a non-OK status', async () => {
+      process.env.CANARY_API_KEY = 'sk-test';
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+      });
+
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      const mod = await canaryModule();
+      await expect(
+        mod.sendBackendCanaryPayload({
+          errorClass: 'Error',
+          message: 'test',
+          severity: 'error',
+        })
+      ).resolves.toBeUndefined();
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('sends request with a 2-second timeout signal', async () => {
+      process.env.CANARY_API_KEY = 'sk-test';
+
+      const mod = await canaryModule();
+      await mod.sendBackendCanaryPayload({
+        errorClass: 'Error',
+        message: 'test',
+        severity: 'error',
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const init = fetchMock.mock.calls[0][1];
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Creates `convex/lib/canary.ts` — server-side Canary payload builder with same scrub/redaction discipline as client
- Creates `convex/errors.ts` — fire-and-forget `internalAction` for delivering errors to Canary
- Wires try/catch + Canary reporting into 6 critical backend paths:
  - `sweepAbandonedGames` (abandonment cron sweep)
  - `finishAbandonedGame` (per-game finisher)
  - `scheduleAiTurn`, `ensureAiLine` (AI scheduler/safety net)
  - `generateLineForRound`, `generateGhostLine` (AI generation/ghostwriter actions)
- 16 new tests (`tests/convex/lib/canary.test.ts`) covering payload building, context scrubbing, API delivery, error resilience

## Oracle
- [x] abandonment cron, ghost-fill worker, and AI persona calls report through Canary-reachable path
- [x] Reuses same scrub/redaction discipline as client `lib/canaryCore.ts` (no guest tokens, display names, raw payloads)
- [x] `pnpm ci:prepush` passes (typecheck + lint + 1064 tests)

Agent: opencode
Agent-Surface: OpenCode
Agent-Model: deepseek/deepseek-v4-pro
