### PR TITLE
feat(observability): report canary health check-ins

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,6 +1,10 @@
 import { ConvexHttpClient } from 'convex/browser';
 import { api } from '@/convex/_generated/api';
-import { captureCanaryException, isCanaryEnabled } from '@/lib/canaryServer';
+import {
+  captureCanaryException,
+  isCanaryEnabled,
+  reportCanaryCheckIn,
+} from '@/lib/canaryServer';
 import { log, logError, logRequest } from '@/lib/logger';
 
 const CONVEX_HEALTH_TIMEOUT_MS = 1_500;
@@ -39,6 +43,15 @@ export async function GET() {
       durationMs: elapsedMs(startedAt),
       convex: convexStatus,
       observabilityStatus: canaryReady ? 'ready' : 'degraded',
+    });
+
+    await reportHealthCheckIn({
+      status: serviceHealthy ? 'alive' : 'error',
+      summary: serviceHealthy
+        ? 'linejam health route ok'
+        : 'linejam health route degraded',
+      routeStatus: status,
+      startedAt,
     });
 
     return Response.json(body, {
@@ -121,6 +134,25 @@ async function logFailure(error: unknown, startedAt: number) {
   logError('Healthcheck failed', error, context);
 
   void captureCanaryException(error, context);
+}
+
+async function reportHealthCheckIn(input: {
+  status: 'alive' | 'error';
+  summary: string;
+  routeStatus: number;
+  startedAt: number;
+}) {
+  await reportCanaryCheckIn({
+    status: input.status,
+    summary: input.summary,
+    ttlMs: 300_000,
+    context: {
+      source: 'api.health',
+      route: ROUTE,
+      status: input.routeStatus,
+      durationMs: elapsedMs(input.startedAt),
+    },
+  });
 }
 
 function elapsedMs(startedAt: number) {

--- a/lib/canaryCore.ts
+++ b/lib/canaryCore.ts
@@ -33,6 +33,13 @@ export type CanaryPayload = {
   fingerprint?: string[];
 };
 
+export type CanaryCheckInPayload = {
+  status: 'alive' | 'in_progress' | 'ok' | 'error';
+  summary: string;
+  ttlMs: number;
+  context?: Record<string, unknown>;
+};
+
 export type CanaryConfig = {
   apiKey: string;
   endpoint: string;
@@ -205,5 +212,47 @@ export async function sendCanaryPayload(
       originalError: scrubErrorForLogs(originalError),
       context: payload.context,
     });
+  }
+}
+
+export async function sendCanaryCheckIn(
+  config: CanaryConfig,
+  payload: CanaryCheckInPayload
+): Promise<void> {
+  if (!config.apiKey) return;
+
+  try {
+    const response = await fetch(
+      `${config.endpoint.replace(/\/$/, '')}/api/v1/check-ins`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${config.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          monitor: SERVICE,
+          status: payload.status,
+          summary: payload.summary,
+          ttl_ms: payload.ttlMs,
+          context: scrubCanaryContext(payload.context),
+        }),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Canary check-in returned ${response.status} ${response.statusText}`.trim()
+      );
+    }
+  } catch (reportingError) {
+    console.error(
+      'Canary check-in failed:',
+      scrubErrorForLogs(reportingError),
+      {
+        context: scrubCanaryContext(payload.context),
+      }
+    );
   }
 }

--- a/lib/canaryServer.ts
+++ b/lib/canaryServer.ts
@@ -2,10 +2,12 @@ import 'server-only';
 
 import {
   DEFAULT_CANARY_ENDPOINT,
+  type CanaryCheckInPayload,
   captureCanaryExceptionWith,
   isCanaryConfigured,
   normalizeApiKey,
   scrubCanaryContext,
+  sendCanaryCheckIn,
 } from '@/lib/canaryCore';
 
 function getCanaryConfig() {
@@ -40,6 +42,12 @@ export async function captureCanaryException(
   context?: Record<string, unknown>
 ): Promise<void> {
   await captureCanaryExceptionWith(getCanaryConfig, error, context);
+}
+
+export async function reportCanaryCheckIn(
+  payload: CanaryCheckInPayload
+): Promise<void> {
+  await sendCanaryCheckIn(getCanaryConfig(), payload);
 }
 
 export { scrubCanaryContext };

--- a/tests/app/api/health.test.ts
+++ b/tests/app/api/health.test.ts
@@ -44,6 +44,8 @@ describe('/api/health', () => {
     beforeAll(async () => {
       vi.resetModules();
       process.env = { ...originalEnv };
+      delete process.env.CANARY_API_KEY;
+      delete process.env.CANARY_ENDPOINT;
       process.env.GUEST_TOKEN_SECRET = HEALTHY_ENV.GUEST_TOKEN_SECRET;
       process.env.NEXT_PUBLIC_CONVEX_URL = HEALTHY_ENV.NEXT_PUBLIC_CONVEX_URL;
       process.env.NEXT_PUBLIC_CANARY_API_KEY =
@@ -53,6 +55,8 @@ describe('/api/health', () => {
         ConvexHttpClient: MockConvexHttpClient,
       }));
       mockQuery.mockResolvedValue({ ok: true });
+      vi.stubGlobal('fetch', fetchMock);
+      fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
 
       const mod = await import('@/app/api/health/route');
       GET = mod.GET;
@@ -61,6 +65,8 @@ describe('/api/health', () => {
     afterEach(() => {
       mockQuery.mockReset();
       mockQuery.mockResolvedValue({ ok: true });
+      fetchMock.mockClear();
+      fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
       vi.useRealTimers();
     });
 
@@ -99,6 +105,16 @@ describe('/api/health', () => {
           durationMs: expect.any(Number),
           convex: 'connected',
           observabilityStatus: 'ready',
+        })
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/\/api\/v1\/check-ins$/),
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer sk_test_canary',
+          }),
         })
       );
     });

--- a/tests/app/poem-detail.test.tsx
+++ b/tests/app/poem-detail.test.tsx
@@ -8,6 +8,7 @@ const mockApiRefs = vi.hoisted(() => ({
   isFavorited: {},
   toggleFavorite: {},
 }));
+const mockPoemDisplay = vi.hoisted(() => vi.fn());
 
 vi.mock('@/convex/_generated/api', () => ({
   api: {
@@ -32,12 +33,24 @@ vi.mock('next/link', () => ({
   }) => <a href={href}>{children}</a>,
 }));
 
+vi.mock('@/components/PoemDisplay', () => ({
+  PoemDisplay: (
+    props: Record<string, unknown> & { metadata: { backLabel: string } }
+  ) => {
+    mockPoemDisplay(props);
+    return (
+      <section data-testid="poem-display">{props.metadata.backLabel}</section>
+    );
+  },
+}));
+
 const mockQueryResults = {
   poemDetail: undefined as unknown,
   publicPoem: undefined as unknown,
   isFavorited: undefined as unknown,
 };
 const mockToggleFavorite = vi.fn();
+let mockGuestToken: string | null = null;
 
 vi.mock('convex/react', () => ({
   useMutation: () => mockToggleFavorite,
@@ -56,7 +69,7 @@ vi.mock('convex/react', () => ({
 }));
 
 vi.mock('@/lib/auth', () => ({
-  useUser: () => ({ guestToken: null }),
+  useUser: () => ({ guestToken: mockGuestToken }),
 }));
 
 import { PoemDetail } from '@/app/poem/[id]/PoemDetail';
@@ -68,6 +81,7 @@ describe('PoemDetail', () => {
     mockQueryResults.poemDetail = undefined;
     mockQueryResults.publicPoem = undefined;
     mockQueryResults.isFavorited = undefined;
+    mockGuestToken = null;
   });
 
   it('shows loading while poem queries are unresolved', () => {
@@ -89,5 +103,134 @@ describe('PoemDetail', () => {
     expect(
       screen.getByRole('link', { name: /Return to Linejam/i })
     ).toHaveAttribute('href', '/');
+  });
+
+  it('renders participant poem details with archive metadata', async () => {
+    mockGuestToken = 'guest-token';
+    mockQueryResults.poemDetail = {
+      poem: { createdAt: 1234 },
+      lines: [
+        {
+          text: 'first line',
+          authorName: 'Ada',
+          authorStableId: 'user-ada',
+          isBot: false,
+        },
+        {
+          text: 'second line',
+          authorName: 'Bot',
+          authorStableId: null,
+          isBot: true,
+        },
+      ],
+    };
+    mockQueryResults.publicPoem = null;
+    mockQueryResults.isFavorited = true;
+
+    render(<PoemDetail poemId={'poem1' as Id<'poems'>} />);
+
+    expect(screen.getByTestId('poem-display')).toHaveTextContent('Archive');
+    expect(mockPoemDisplay).toHaveBeenCalledWith(
+      expect.objectContaining({
+        poemId: 'poem1',
+        guestToken: 'guest-token',
+        alreadyRevealed: true,
+        allStableIds: ['user-ada'],
+        lines: [
+          {
+            text: 'first line',
+            authorName: 'Ada',
+            authorStableId: 'user-ada',
+            isBot: false,
+          },
+          {
+            text: 'second line',
+            authorName: 'Bot',
+            authorStableId: null,
+            isBot: true,
+          },
+        ],
+        metadata: expect.objectContaining({
+          backHref: '/me/poems',
+          backLabel: '← Archive',
+          createdAt: 1234,
+          firstLine: 'first line',
+          isFavorited: true,
+          isParticipant: true,
+          uniquePoets: 2,
+        }),
+      })
+    );
+
+    await mockPoemDisplay.mock.calls[0][0].metadata.onToggleFavorite();
+
+    expect(mockToggleFavorite).toHaveBeenCalledWith({
+      poemId: 'poem1',
+      guestToken: 'guest-token',
+    });
+  });
+
+  it('renders public poem fallback with Linejam metadata', () => {
+    mockQueryResults.poemDetail = null;
+    mockQueryResults.publicPoem = {
+      poem: { createdAt: 5678 },
+      lines: [
+        {
+          text: 'public first line',
+          authorName: 'Ada',
+          authorStableId: 'public-ada',
+          isBot: false,
+        },
+      ],
+    };
+
+    render(<PoemDetail poemId={'poem2' as Id<'poems'>} />);
+
+    expect(screen.getByTestId('poem-display')).toHaveTextContent('Linejam');
+    expect(mockPoemDisplay).toHaveBeenCalledWith(
+      expect.objectContaining({
+        poemId: 'poem2',
+        guestToken: undefined,
+        allStableIds: ['public-ada'],
+        metadata: expect.objectContaining({
+          backHref: '/',
+          backLabel: '← Linejam',
+          firstLine: 'public first line',
+          isFavorited: false,
+          isParticipant: false,
+          uniquePoets: 1,
+        }),
+      })
+    );
+  });
+
+  it('renders participant poem metadata without a guest token or lines', async () => {
+    mockQueryResults.poemDetail = {
+      poem: { createdAt: 9012 },
+      lines: [],
+    };
+    mockQueryResults.publicPoem = null;
+
+    render(<PoemDetail poemId={'poem3' as Id<'poems'>} />);
+
+    expect(mockPoemDisplay).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guestToken: undefined,
+        allStableIds: [],
+        lines: [],
+        metadata: expect.objectContaining({
+          firstLine: '',
+          isFavorited: false,
+          isParticipant: true,
+        }),
+      })
+    );
+
+    await mockPoemDisplay.mock.calls[0][0].metadata.onToggleFavorite();
+
+    expect(mockToggleFavorite).toHaveBeenCalledWith({
+      poemId: 'poem3',
+      guestToken: undefined,
+    });
   });
 });

--- a/tests/e2e/support/guestFlow.ts
+++ b/tests/e2e/support/guestFlow.ts
@@ -337,7 +337,10 @@ export class GuestFlowSession {
   async openHelpModal() {
     // Help / Theme / archive now live behind the overflow ("More options") menu.
     await this.hostPage.getByRole('button', { name: /More options/i }).click();
-    await this.hostPage.getByRole('button', { name: /How to play/i }).click();
+    await this.hostPage
+      .getByRole('button', { name: /How to play/i })
+      .last()
+      .click();
     await ensureVisible(
       this.hostPage.getByRole('heading', { name: /How to Play/i }),
       'help modal'

--- a/tests/lib/canary.test.ts
+++ b/tests/lib/canary.test.ts
@@ -87,6 +87,37 @@ describe('canary helpers', () => {
     });
   });
 
+  it('uses Error constructor names before the generic fallback', async () => {
+    const { normalizeError } = await import('@/lib/canaryCore');
+
+    class CustomCanaryError extends Error {}
+    const namedByConstructor = new CustomCanaryError('constructor name');
+    Object.defineProperty(namedByConstructor, 'name', {
+      configurable: true,
+      value: '',
+    });
+
+    expect(normalizeError(namedByConstructor)).toMatchObject({
+      errorClass: 'CustomCanaryError',
+      message: 'constructor name',
+    });
+
+    const genericFallback = new Error('generic name');
+    Object.defineProperty(genericFallback, 'name', {
+      configurable: true,
+      value: '',
+    });
+    Object.defineProperty(genericFallback, 'constructor', {
+      configurable: true,
+      value: { name: '' },
+    });
+
+    expect(normalizeError(genericFallback)).toMatchObject({
+      errorClass: 'Error',
+      message: 'generic name',
+    });
+  });
+
   it('drops empty scrubbed collections and non-string structured stack traces', async () => {
     const { scrubCanaryContext, scrubErrorForLogs } =
       await import('@/lib/canaryCore');
@@ -95,8 +126,11 @@ describe('canary helpers', () => {
       scrubCanaryContext({
         path: [{ userId: 'x' }],
         route: { userId: 'y' },
+        status: { route: '/api/health', authorization: 'secret' },
       })
-    ).toBeUndefined();
+    ).toEqual({
+      status: { route: '/api/health' },
+    });
     expect(
       scrubErrorForLogs({
         errorClass: 'ManualError',

--- a/tests/lib/canaryServer.test.ts
+++ b/tests/lib/canaryServer.test.ts
@@ -102,4 +102,116 @@ describe('captureCanaryException (server)', () => {
     const body = JSON.parse(String(request?.body)) as { environment: string };
     expect(body.environment).toBe('staging');
   });
+
+  it('posts server-side health check-ins', async () => {
+    vi.stubEnv('CANARY_API_KEY', 'sk_server_canary');
+    vi.stubEnv('CANARY_ENDPOINT', 'https://server-canary.test/');
+    fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
+
+    const { reportCanaryCheckIn } = await import('@/lib/canaryServer');
+    await reportCanaryCheckIn({
+      status: 'alive',
+      summary: 'linejam health route ok',
+      ttlMs: 300_000,
+      context: {
+        source: 'api.health',
+        route: '/api/health',
+        status: 200,
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://server-canary.test/api/v1/check-ins',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer sk_server_canary',
+        }),
+      })
+    );
+
+    const [, request] = fetchMock.mock.calls[0];
+    const body = JSON.parse(String(request?.body));
+    expect(body).toEqual({
+      monitor: 'linejam',
+      status: 'alive',
+      summary: 'linejam health route ok',
+      ttl_ms: 300_000,
+      context: {
+        source: 'api.health',
+        route: '/api/health',
+        status: 200,
+      },
+    });
+  });
+
+  it('does not post check-ins without an api key', async () => {
+    const { sendCanaryCheckIn } = await import('@/lib/canaryCore');
+
+    await sendCanaryCheckIn(
+      {
+        apiKey: '',
+        endpoint: 'https://server-canary.test/',
+        environment: 'test',
+      },
+      {
+        status: 'alive',
+        summary: 'linejam health route ok',
+        ttlMs: 300_000,
+      }
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('logs non-OK check-in responses with scrubbed context', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    fetchMock.mockResolvedValue(new Response(null, { status: 503 }));
+
+    const { sendCanaryCheckIn } = await import('@/lib/canaryCore');
+    await sendCanaryCheckIn(
+      {
+        apiKey: 'sk_server_canary',
+        endpoint: 'https://server-canary.test/',
+        environment: 'test',
+      },
+      {
+        status: 'error',
+        summary: 'linejam worker degraded',
+        ttlMs: 120_000,
+        context: {
+          source: 'worker',
+          route: '/jobs/sync',
+          authorization: 'secret',
+        },
+      }
+    );
+
+    const [, request] = fetchMock.mock.calls[0];
+    const body = JSON.parse(String(request?.body));
+    expect(body).toEqual({
+      monitor: 'linejam',
+      status: 'error',
+      summary: 'linejam worker degraded',
+      ttl_ms: 120_000,
+      context: {
+        source: 'worker',
+        route: '/jobs/sync',
+      },
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      'Canary check-in failed:',
+      expect.objectContaining({
+        errorClass: 'Error',
+        message: 'Canary check-in returned 503',
+      }),
+      {
+        context: {
+          source: 'worker',
+          route: '/jobs/sync',
+        },
+      }
+    );
+  });
 });

--- a/tests/lib/logger.test.ts
+++ b/tests/lib/logger.test.ts
@@ -48,6 +48,39 @@ describe('logger', () => {
     });
   });
 
+  it('describes non-Error timestamp failures', () => {
+    vi.spyOn(Date.prototype, 'toISOString').mockImplementation(() => {
+      throw 'clock failed';
+    });
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    log.info('clock checked');
+
+    expect(parseJsonCall(consoleLogSpy)).toMatchObject({
+      level: 'info',
+      message: 'clock checked',
+      timestamp: 'timestamp-unavailable',
+      timestampErrorName: 'UnknownError',
+      timestampErrorMessage: 'clock failed',
+    });
+  });
+
+  it('serializes Error values embedded in structured context', () => {
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    log.warn('recoverable failure', { cause: new TypeError('bad input') });
+
+    expect(parseJsonCall(consoleLogSpy)).toMatchObject({
+      level: 'warn',
+      message: 'recoverable failure',
+      cause: {
+        name: 'TypeError',
+        message: 'bad input',
+        stack: expect.stringContaining('TypeError: bad input'),
+      },
+    });
+  });
+
   it('serializes Error objects and protects against circular context', () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
@@ -63,6 +96,21 @@ describe('logger', () => {
       errorName: 'Error',
       errorMessage: 'boom',
       circular: '[Non-serializable]',
+    });
+  });
+
+  it('logs non-Error failures with a string fallback', () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    logError('request failed', 'boom', { route: '/api/health' });
+
+    expect(parseJsonCall(consoleErrorSpy)).toMatchObject({
+      level: 'error',
+      message: 'request failed',
+      errorValue: 'boom',
+      route: '/api/health',
     });
   });
 });


### PR DESCRIPTION
## Summary
- report Canary monitor check-ins from /api/health
- keep existing server-side Canary error capture behavior intact
- use existing Vercel production CANARY_* secrets; no secrets committed

## Verification
- pnpm test --run tests/lib/canaryServer.test.ts tests/app/api/health.test.ts
- pnpm ci:prepush
- pre-push: typecheck, lint, test

Agent: codex
Agent-Surface: Codex CLI
Agent-Model: GPT-5
Agent-Task: canary-906