### PR TITLE
feat: make reveal shareable and teach first writers

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -231,6 +231,65 @@ h6 {
   }
 }
 
+@keyframes final-line-settle {
+  0% {
+    opacity: 0.88;
+    transform: translateY(0.35rem);
+  }
+  70% {
+    opacity: 1;
+    transform: translateY(-0.08rem);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-final-line-settle {
+  animation:
+    wipe-reveal 800ms ease-out forwards,
+    final-line-settle 700ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@keyframes heart-burst {
+  0% {
+    opacity: 0;
+    transform: scale(0.55);
+  }
+  34% {
+    opacity: 0.28;
+    transform: scale(1.15);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.75);
+  }
+}
+
+.animate-heart-burst {
+  animation: heart-burst 900ms ease-out both;
+}
+
+@keyframes crown-settle {
+  0% {
+    opacity: 0;
+    transform: translateY(-0.7rem) scale(0.86) rotate(-8deg);
+  }
+  58% {
+    opacity: 1;
+    transform: translateY(0.1rem) scale(1.04) rotate(3deg);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1) rotate(0deg);
+  }
+}
+
+.animate-crown-settle {
+  animation: crown-settle 760ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
 /* Custom Caret - Theme color for ceremonial typing */
 textarea:focus {
   caret-color: var(--color-primary);

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -76,6 +76,10 @@ function JoinForm() {
       </h1>
 
       <div className="p-8 border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-lg)]">
+        <p className="mb-8 text-base leading-relaxed text-[var(--color-text-secondary)]">
+          You&apos;ll add one hidden line at a time, then everyone reads the
+          finished poems together.
+        </p>
         <form onSubmit={handleJoin} className="space-y-8">
           <div className="space-y-3">
             <label

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,10 @@ export default function Home() {
             <br />
             One line at a time.
           </p>
+          <p className="max-w-md text-base md:text-lg leading-relaxed text-[var(--color-text-secondary)]">
+            Pass the phone around a room-code game, then read the surprise poems
+            aloud.
+          </p>
 
           {/* Action Buttons */}
           <div className="space-y-4 max-w-md">

--- a/app/recap/[code]/opengraph-image.tsx
+++ b/app/recap/[code]/opengraph-image.tsx
@@ -130,7 +130,7 @@ export default async function Image({
                     textTransform: 'uppercase',
                   }}
                 >
-                  Poem {poem.number} / {poem.readerName}
+                  {`Poem ${poem.number} / ${poem.readerName}`}
                 </div>
                 <div
                   style={{
@@ -139,7 +139,7 @@ export default async function Image({
                     lineHeight: 1.18,
                   }}
                 >
-                  &ldquo;{poem.preview}&rdquo;
+                  {`“${poem.preview}”`}
                 </div>
               </div>
             ))}

--- a/app/recap/[code]/opengraph-image.tsx
+++ b/app/recap/[code]/opengraph-image.tsx
@@ -21,14 +21,23 @@ export default async function Image({
   const subtitle = recap
     ? `${recap.poemCount} poems by ${recap.playerCount} poets`
     : 'Session recap';
-  const lines = recap?.poems
-    .slice(0, 3)
-    .map((poem) =>
-      poem.preview.length > 70
-        ? `${poem.preview.slice(0, 67)}...`
-        : poem.preview
-    )
-    .filter(Boolean);
+  const poemPreviews =
+    recap?.poems
+      .map((poem) => ({
+        key: String(poem._id),
+        number: (poem.indexInRoom + 1).toString().padStart(2, '0'),
+        readerName: poem.readerName,
+        preview:
+          poem.preview.length > 58
+            ? `${poem.preview.slice(0, 55).trimEnd()}...`
+            : poem.preview,
+      }))
+      .filter((poem) => poem.preview.length > 0) ?? [];
+  const midpoint = Math.ceil(poemPreviews.length / 2);
+  const previewColumns = [
+    poemPreviews.slice(0, midpoint),
+    poemPreviews.slice(midpoint),
+  ].filter((column) => column.length > 0);
 
   return new ImageResponse(
     <div
@@ -48,7 +57,7 @@ export default async function Image({
           fontSize: 30,
           color: tokens.colors.primary,
           fontFamily: 'sans-serif',
-          letterSpacing: '0.18em',
+          letterSpacing: 0,
           textTransform: 'uppercase',
         }}
       >
@@ -76,18 +85,65 @@ export default async function Image({
       <div
         style={{
           display: 'flex',
-          flexDirection: 'column',
-          gap: 14,
+          gap: 26,
           marginTop: 44,
-          fontSize: 30,
-          lineHeight: 1.25,
         }}
       >
-        {(lines && lines.length > 0
-          ? lines
-          : ['Write poems together, one line at a time.']
-        ).map((line) => (
-          <div key={line}>&ldquo;{line}&rdquo;</div>
+        {(previewColumns.length > 0
+          ? previewColumns
+          : [
+              [
+                {
+                  key: 'fallback',
+                  number: '01',
+                  readerName: 'Linejam',
+                  preview: 'Write poems together, one line at a time.',
+                },
+              ],
+            ]
+        ).map((column, columnIndex) => (
+          <div
+            key={`column-${columnIndex}`}
+            style={{
+              display: 'flex',
+              flex: 1,
+              flexDirection: 'column',
+              gap: 12,
+            }}
+          >
+            {column.map((poem) => (
+              <div
+                key={poem.key}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  borderLeft: `3px solid ${tokens.colors.primary}`,
+                  paddingLeft: 16,
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 16,
+                    color: tokens.colors.textMuted,
+                    fontFamily: 'sans-serif',
+                    letterSpacing: 0,
+                    textTransform: 'uppercase',
+                  }}
+                >
+                  Poem {poem.number} / {poem.readerName}
+                </div>
+                <div
+                  style={{
+                    marginTop: 5,
+                    fontSize: 26,
+                    lineHeight: 1.18,
+                  }}
+                >
+                  &ldquo;{poem.preview}&rdquo;
+                </div>
+              </div>
+            ))}
+          </div>
         ))}
       </div>
       <div

--- a/backlog.d/023-reveal-ceremony-and-shareable-artifact.md
+++ b/backlog.d/023-reveal-ceremony-and-shareable-artifact.md
@@ -1,6 +1,6 @@
 # Make the reveal a ceremony and a one-tap shareable group artifact
 
-Priority: P1 · Status: pending · Estimate: L
+Priority: P1 · Status: done · Estimate: L
 
 Milestone: aesthetic polish + growth loop (sequence after the launch-readiness
 items 020–022).
@@ -13,17 +13,17 @@ the funniest minute of game night into the acquisition channel.
 
 ## Oracle
 
-- [ ] Reveal pacing follows the poem's own 1,2,3,4,5,4,3,2,1 word-shape with a
+- [x] Reveal pacing follows the poem's own 1,2,3,4,5,4,3,2,1 word-shape with a
       crescendo into the final line (not a flat 1000ms/line metronome),
       respecting `prefers-reduced-motion`.
-- [ ] The room-favorite "crown" is a distinct ceremonial moment (heart-burst →
+- [x] The room-favorite "crown" is a distinct ceremonial moment (heart-burst →
       crown settle), not a static badge.
-- [ ] Optional sound + haptic punctuation on reveal/crown (mobile-first,
+- [x] Optional sound + haptic punctuation on reveal/crown (mobile-first,
       default-on with a mute) — zero exists today.
-- [ ] At session end the group gets ONE "Share the whole set" action backed by a
+- [x] At session end the group gets ONE "Share the whole set" action backed by a
       typeset session OG image at `/recap/[code]/opengraph-image`; the two
       near-identical recap share buttons collapse to one.
-- [ ] Per-poem share text is seeded with the poem's actual opening line (not the
+- [x] Per-poem share text is seeded with the poem's actual opening line (not the
       generic "Read this poem from our Linejam session").
 
 ## Verification System

--- a/backlog.d/024-zero-friction-join-and-onboarding.md
+++ b/backlog.d/024-zero-friction-join-and-onboarding.md
@@ -1,6 +1,6 @@
 # Zero-friction join (QR + tap-copy) and teach-by-doing onboarding
 
-Priority: P1 · Status: pending · Estimate: L
+Priority: P1 · Status: done · Estimate: L
 
 Milestone: spans launch-readiness (join friction) and aesthetic polish
 (onboarding feel).
@@ -13,17 +13,17 @@ scanning/tapping the code, not retyping it.
 
 ## Oracle
 
-- [ ] The lobby shows a scannable QR that drops a phone straight into
+- [x] The lobby shows a scannable QR that drops a phone straight into
       `/join?code=…`; tapping the room code copies the bare 4-char code (distinct
       from the invite URL) — closes the long-standing issue #170 properly.
-- [ ] A first-run inline coachmark on the writing screen teaches the
+- [x] A first-run inline coachmark on the writing screen teaches the
       partial-visibility + word-count mechanic, shown once per device, without
       opening the help modal.
-- [ ] A late/mid-game arrival sees an explanatory "game in progress — you're in
+- [x] A late/mid-game arrival sees an explanatory "game in progress — you're in
       for the next round" state instead of an empty waiting screen.
-- [ ] The landing/join page has a one-sentence "what happens" beat before a
+- [x] The landing/join page has a one-sentence "what happens" beat before a
       cold-linked friend commits a name.
-- [ ] The submit-failure path routes through `errorToFeedback` (not the hardcoded
+- [x] The submit-failure path routes through `errorToFeedback` (not the hardcoded
       English string), matching the rest of the app.
 
 ## Verification System

--- a/components/PoemDisplay.tsx
+++ b/components/PoemDisplay.tsx
@@ -2,13 +2,14 @@
 
 import { Fragment, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Heart } from 'lucide-react';
+import { Heart, Volume2, VolumeX } from 'lucide-react';
 import { Button } from './ui/Button';
 import { Alert } from './ui/Alert';
 import { HeartButton } from './ui/HeartButton';
 import { cn } from '@/lib/utils';
 import { Id } from '@/convex/_generated/dataModel';
 import { useSharePoem } from '@/hooks/useSharePoem';
+import { useCeremonyEffects } from '@/hooks/useCeremonyEffects';
 import { getUserColor, getUniqueColor } from '@/lib/avatarColor';
 
 /**
@@ -24,9 +25,15 @@ import { getUserColor, getUniqueColor } from '@/lib/avatarColor';
  * - 'archive': Regular page flow for archive viewing
  */
 
-const BASE_REVEAL_DELAY = 1000;
-const PAUSE_AFTER_LINE = 4;
-const PAUSE_DURATION = 1200;
+const REVEAL_DELAYS_MS = [560, 680, 800, 940, 1120, 900, 720, 520, 360];
+
+function getRevealDelay(lineIndex: number, totalLines: number) {
+  if (totalLines <= 1) return REVEAL_DELAYS_MS[0];
+  const shapeIndex = Math.round(
+    (lineIndex / Math.max(totalLines - 1, 1)) * (REVEAL_DELAYS_MS.length - 1)
+  );
+  return REVEAL_DELAYS_MS[shapeIndex] ?? REVEAL_DELAYS_MS.at(-1)!;
+}
 
 export interface PoemLine {
   text: string;
@@ -77,18 +84,21 @@ export function PoemDisplay({
 
   // Archive variant is always fully revealed
   const effectiveAlreadyRevealed = isArchive ? true : alreadyRevealed;
+  const normalizedLines: PoemLine[] = lines.map((line) =>
+    typeof line === 'string' ? { text: line } : line
+  );
+  const firstLineText = normalizedLines[0]?.text ?? metadata?.firstLine ?? '';
+  const { isMuted, prefersReducedMotion, punctuate, toggleMuted } =
+    useCeremonyEffects();
 
   const [revealedCount, setRevealedCount] = useState(
-    effectiveAlreadyRevealed ? lines.length : 0
+    effectiveAlreadyRevealed || prefersReducedMotion ? lines.length : 0
   );
   const [selectedLine, setSelectedLine] = useState<number | null>(null);
   const { handleShare, copied, shared, shareError } = useSharePoem(
     poemId,
-    guestToken
-  );
-
-  const normalizedLines: PoemLine[] = lines.map((line) =>
-    typeof line === 'string' ? { text: line } : line
+    guestToken,
+    firstLineText
   );
 
   // Get unique authors for legend (preserves order of first appearance)
@@ -107,19 +117,35 @@ export function PoemDisplay({
       }));
   }, [normalizedLines]);
 
-  // Staggered reveal with rhythmic pause after line 4
+  // Staggered reveal follows the 1,2,3,4,5,4,3,2,1 poem shape, then
+  // accelerates into the final one-word line.
   useEffect(() => {
-    if (!effectiveAlreadyRevealed && revealedCount < lines.length) {
-      const extraDelay =
-        revealedCount === PAUSE_AFTER_LINE + 1 ? PAUSE_DURATION : 0;
-      const delay = BASE_REVEAL_DELAY + extraDelay;
+    if (effectiveAlreadyRevealed || prefersReducedMotion) {
+      if (revealedCount < lines.length) {
+        const timer = setTimeout(() => {
+          setRevealedCount(lines.length);
+        }, 0);
+        return () => clearTimeout(timer);
+      }
+      return;
+    }
 
+    if (revealedCount < lines.length) {
+      const delay = getRevealDelay(revealedCount, lines.length);
       const timer = setTimeout(() => {
-        setRevealedCount((prev) => prev + 1);
+        const nextCount = revealedCount + 1;
+        punctuate(nextCount >= lines.length ? 'final-line' : 'line');
+        setRevealedCount(nextCount);
       }, delay);
       return () => clearTimeout(timer);
     }
-  }, [revealedCount, lines.length, effectiveAlreadyRevealed]);
+  }, [
+    revealedCount,
+    lines.length,
+    effectiveAlreadyRevealed,
+    prefersReducedMotion,
+    punctuate,
+  ]);
 
   // Clear selected line after 2s
   useEffect(() => {
@@ -131,16 +157,34 @@ export function PoemDisplay({
 
   const allRevealed = revealedCount >= lines.length;
 
-  // Get first line for preview (use metadata or extract from lines)
-  const firstLineText = metadata?.firstLine ?? normalizedLines[0]?.text ?? '';
-
   // Container classes based on variant
   const containerClasses = isArchive
     ? 'min-h-screen bg-background flex flex-col'
     : 'fixed inset-0 bg-background z-50 flex flex-col overflow-y-auto';
 
+  const ceremonyMuteButton = !isArchive ? (
+    <button
+      type="button"
+      onClick={toggleMuted}
+      className="inline-flex h-9 items-center gap-2 rounded-full border border-border-subtle bg-background/80 px-3 text-xs font-mono uppercase tracking-wider text-text-muted backdrop-blur-sm transition-colors hover:border-primary hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring"
+      aria-label={isMuted ? 'Turn ceremony sound on' : 'Mute ceremony sound'}
+      title={isMuted ? 'Turn ceremony sound on' : 'Mute ceremony'}
+    >
+      {isMuted ? (
+        <VolumeX className="h-4 w-4" aria-hidden="true" />
+      ) : (
+        <Volume2 className="h-4 w-4" aria-hidden="true" />
+      )}
+      <span>{isMuted ? 'Muted' : 'Sound'}</span>
+    </button>
+  ) : null;
+
   return (
     <div className={containerClasses}>
+      {!metadata && ceremonyMuteButton && (
+        <div className="fixed right-4 top-4 z-10">{ceremonyMuteButton}</div>
+      )}
+
       {/* Poem Content */}
       <div className="flex-1 px-6 md:px-12 lg:px-24 py-12 md:py-16 lg:py-24 max-w-3xl mx-auto w-full">
         {/* Header: Poem Identity + Controls */}
@@ -163,6 +207,7 @@ export function PoemDisplay({
               <span className="text-sm font-mono text-text-muted uppercase tracking-wider">
                 {formatDate(metadata.createdAt)}
               </span>
+              {!isArchive && ceremonyMuteButton}
               {isArchive &&
                 metadata.isParticipant &&
                 metadata.onToggleFavorite && (
@@ -228,6 +273,13 @@ export function PoemDisplay({
           {normalizedLines.map((line, index) => {
             const isVisible = index < revealedCount;
             const isSelected = selectedLine === index;
+            const isFinalLine = index === normalizedLines.length - 1;
+            const revealAnimation =
+              isVisible && !prefersReducedMotion
+                ? isFinalLine
+                  ? 'wipe-reveal 800ms ease-out forwards, final-line-settle 700ms cubic-bezier(0.22, 1, 0.36, 1) forwards'
+                  : 'wipe-reveal 800ms ease-out forwards'
+                : 'none';
             const dotColor = line.authorStableId
               ? allStableIds
                 ? getUniqueColor(line.authorStableId, allStableIds)
@@ -264,12 +316,14 @@ export function PoemDisplay({
                       className={cn(
                         'font-[var(--font-display)] leading-relaxed',
                         'text-lg md:text-xl lg:text-2xl',
-                        'text-text-primary'
+                        'text-text-primary',
+                        isVisible &&
+                          isFinalLine &&
+                          !prefersReducedMotion &&
+                          'animate-final-line-settle'
                       )}
                       style={{
-                        animation: isVisible
-                          ? `wipe-reveal 800ms ease-out forwards`
-                          : 'none',
+                        animation: revealAnimation,
                         clipPath: isVisible ? undefined : 'inset(0 100% 0 0)',
                       }}
                     >

--- a/components/SessionRecapHub.tsx
+++ b/components/SessionRecapHub.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { MouseEvent, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useMutation, useQuery } from 'convex/react';
-import { Heart, Share2 } from 'lucide-react';
+import { Crown, Heart, Share2, Volume2, VolumeX } from 'lucide-react';
 import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
 import { trackRoomInviteShared } from '@/lib/analytics';
 import { useShareLink } from '@/hooks/useShareLink';
+import { useCeremonyEffects } from '@/hooks/useCeremonyEffects';
 import { Alert } from './ui/Alert';
 import { Button } from './ui/Button';
 import { Label } from './ui/Label';
@@ -46,7 +47,8 @@ export function SessionRecapHub({
   onBackToLobby,
 }: SessionRecapHubProps) {
   const sortedPoems = [...poems].sort((a, b) => a.indexInRoom - b.indexInRoom);
-  const [openError, setOpenError] = useState<string | null>(null);
+  const lastCrownedPoemId = useRef<Id<'poems'> | null>(null);
+  const { isMuted, punctuate, toggleMuted } = useCeremonyEffects();
 
   // Live tally — the crown can still change as late hearts land.
   const sessionFavorites = useQuery(api.favorites.getSessionFavorites, {
@@ -60,7 +62,6 @@ export function SessionRecapHub({
   const enablePublicSessionRecapShare = useMutation(
     api.shares.enablePublicSessionRecapShare
   );
-  const recapHref = `/recap/${roomCode}`;
   const enablePublicRecap = async () => {
     await enablePublicSessionRecapShare({
       roomCode,
@@ -72,7 +73,7 @@ export function SessionRecapHub({
     getShareData: () => ({
       url: sessionRecapUrl(roomCode),
       title: 'Linejam session recap',
-      text: `Replay every poem from our Linejam session in room ${roomCode}.`,
+      text: `Share the whole set from Linejam room ${roomCode}.`,
     }),
     onShared: (method) => {
       trackRoomInviteShared({ method, roomCode });
@@ -80,19 +81,13 @@ export function SessionRecapHub({
     failureMessage: 'Failed to share recap. Please try again.',
   });
 
-  const handleOpenSharedRecap = async (
-    event: MouseEvent<HTMLAnchorElement>
-  ) => {
-    event.preventDefault();
-    setOpenError(null);
+  useEffect(() => {
+    if (!favoritePoem || sessionFavorites?.leaderCount === 0) return;
+    if (lastCrownedPoemId.current === favoritePoem._id) return;
 
-    try {
-      await enablePublicRecap();
-      window.location.assign(recapHref);
-    } catch {
-      setOpenError('Failed to publish recap. Please try again.');
-    }
-  };
+    lastCrownedPoemId.current = favoritePoem._id;
+    punctuate('crown');
+  }, [favoritePoem, punctuate, sessionFavorites?.leaderCount]);
 
   return (
     <section
@@ -122,15 +117,24 @@ export function SessionRecapHub({
         </div>
       </div>
 
-      {(error || shareError || openError) && (
-        <Alert variant="error">{error || shareError || openError}</Alert>
+      {(error || shareError) && (
+        <Alert variant="error">{error || shareError}</Alert>
       )}
 
       {/* Room favorite — only crowned when the room actually gave hearts */}
       {favoritePoem && sessionFavorites && (
-        <div className="border border-primary bg-surface p-5 shadow-sm">
-          <div className="flex items-center gap-2 text-primary">
+        <div className="relative overflow-hidden border border-primary bg-surface p-5 shadow-sm">
+          <div
+            aria-hidden="true"
+            className="animate-heart-burst absolute right-5 top-5 h-16 w-16 rounded-full bg-primary/20"
+          />
+          <div className="relative flex items-center gap-2 text-primary">
             <Heart className="h-4 w-4" fill="currentColor" />
+            <Crown
+              data-testid="room-favorite-crown"
+              className="animate-crown-settle h-5 w-5"
+              aria-hidden="true"
+            />
             <p className="text-[10px] font-mono uppercase tracking-widest">
               Room favorite · {sessionFavorites.leaderCount} heart
               {sessionFavorites.leaderCount === 1 ? '' : 's'}
@@ -181,25 +185,33 @@ export function SessionRecapHub({
         })}
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className="grid gap-3">
         <Button type="button" onClick={handleShare} size="lg" className="h-14">
           <Share2 className="mr-2 h-4 w-4" />
-          {shared ? 'Shared!' : copied ? 'Copied!' : 'Share Session'}
+          {shared ? 'Shared!' : copied ? 'Copied!' : 'Share the whole set'}
         </Button>
-
-        <Link
-          href={recapHref}
-          prefetch={false}
-          onClick={handleOpenSharedRecap}
-          className="inline-flex h-14 w-full items-center justify-center rounded-md border border-border bg-surface px-8 text-lg font-medium text-text-primary shadow-sm transition-all duration-[var(--duration-normal)] hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2 active:scale-[0.96]"
-        >
-          Open Shared Recap
-        </Link>
       </div>
 
-      <p className="text-sm text-text-muted text-center">
-        Sharing makes the full session recap public to anyone with the link.
-      </p>
+      <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:justify-between sm:text-left">
+        <p className="text-sm text-text-muted">
+          Sharing makes the full session recap public to anyone with the link.
+        </p>
+        <button
+          type="button"
+          onClick={toggleMuted}
+          className="inline-flex h-10 items-center gap-2 rounded-full border border-border-subtle px-3 text-xs font-mono uppercase tracking-wider text-text-muted transition-colors hover:border-primary hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring"
+          aria-label={
+            isMuted ? 'Turn ceremony sound on' : 'Mute ceremony sound'
+          }
+        >
+          {isMuted ? (
+            <VolumeX className="h-4 w-4" aria-hidden="true" />
+          ) : (
+            <Volume2 className="h-4 w-4" aria-hidden="true" />
+          )}
+          <span>{isMuted ? 'Muted' : 'Sound'}</span>
+        </button>
+      </div>
 
       {/* Anyone in the room can keep it moving — a vanished host never strands the recap. */}
       <div className="grid grid-cols-2 gap-3">

--- a/components/WritingScreen.tsx
+++ b/components/WritingScreen.tsx
@@ -25,6 +25,8 @@ interface WritingScreenProps {
 
 type RoomQueryArgs = ReturnType<typeof useRoomQueryArgs>['queryArgs'];
 
+const WRITING_COACHMARK_STORAGE_KEY = 'linejam:writing-coachmark-seen';
+
 interface WritingAssignment {
   poemId: Id<'poems'>;
   lineIndex: number;
@@ -45,6 +47,26 @@ interface WritingComposerProps {
 function numberToWord(n: number): string {
   const words = ['zero', 'one', 'two', 'three', 'four', 'five'];
   return words[n] ?? String(n);
+}
+
+function shouldShowWritingCoachmark() {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    return window.localStorage.getItem(WRITING_COACHMARK_STORAGE_KEY) !== '1';
+  } catch {
+    return true;
+  }
+}
+
+function markWritingCoachmarkSeen() {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(WRITING_COACHMARK_STORAGE_KEY, '1');
+  } catch {
+    // The coachmark is still visible for this render if storage is unavailable.
+  }
 }
 
 function WritingComposer({
@@ -71,6 +93,7 @@ function WritingComposer({
   const [error, setError] = useState<string | null>(null);
   const [liveRegionMessage, setLiveRegionMessage] = useState('');
   const [hasFocus, setHasFocus] = useState(false);
+  const [showCoachmark] = useState(shouldShowWritingCoachmark);
   const submitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -125,6 +148,12 @@ function WritingComposer({
     window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
   }, [assignment.poemId, assignment.lineIndex]);
 
+  useEffect(() => {
+    if (showCoachmark) {
+      markWritingCoachmarkSeen();
+    }
+  }, [showCoachmark]);
+
   if (showWaitingScreen) {
     return <WaitingScreen roomCode={roomCode} guestToken={guestToken} />;
   }
@@ -174,6 +203,15 @@ function WritingComposer({
       </div>
 
       <div className="w-full max-w-3xl space-y-6 md:space-y-16">
+        {showCoachmark && (
+          <div className="border-l-2 border-primary py-1 pl-4 text-sm leading-relaxed text-text-secondary animate-fade-in-up">
+            <p className="font-medium text-text-primary">
+              You only see one carried line.
+            </p>
+            <p>Match the word slots, then pass it on.</p>
+          </div>
+        )}
+
         {/* The Memory - No container */}
         {assignment.previousLineText && (
           <div className="mb-4 md:mb-16 animate-fade-in-up">

--- a/hooks/useCeremonyEffects.ts
+++ b/hooks/useCeremonyEffects.ts
@@ -1,0 +1,137 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+type CeremonyEffect = 'line' | 'final-line' | 'crown';
+
+const CEREMONY_MUTED_KEY = 'linejam:ceremony-muted';
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+const HAPTIC_PATTERNS: Record<CeremonyEffect, VibratePattern> = {
+  line: 8,
+  'final-line': [14, 30, 18],
+  crown: [16, 40, 22],
+};
+
+const TONE_FREQUENCIES: Record<CeremonyEffect, number> = {
+  line: 440,
+  'final-line': 660,
+  crown: 740,
+};
+
+function readMutedPreference() {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    return window.localStorage.getItem(CEREMONY_MUTED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function writeMutedPreference(isMuted: boolean) {
+  if (typeof window === 'undefined') return;
+
+  try {
+    if (isMuted) {
+      window.localStorage.setItem(CEREMONY_MUTED_KEY, '1');
+    } else {
+      window.localStorage.removeItem(CEREMONY_MUTED_KEY);
+    }
+  } catch {
+    // Storage is a convenience; the in-memory toggle still works.
+  }
+}
+
+function readReducedMotionPreference() {
+  if (typeof window === 'undefined' || !window.matchMedia) return false;
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function playTone(effect: CeremonyEffect) {
+  if (typeof window === 'undefined') return;
+
+  type AudioWindow = Window &
+    typeof globalThis & {
+      webkitAudioContext?: typeof AudioContext;
+    };
+  const AudioContextCtor =
+    window.AudioContext ?? (window as AudioWindow).webkitAudioContext;
+  if (!AudioContextCtor) return;
+
+  try {
+    const context = new AudioContextCtor();
+    const oscillator = context.createOscillator();
+    const gain = context.createGain();
+    const now = context.currentTime;
+
+    oscillator.type = effect === 'crown' ? 'triangle' : 'sine';
+    oscillator.frequency.setValueAtTime(TONE_FREQUENCIES[effect], now);
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.035, now + 0.012);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.11);
+
+    oscillator.connect(gain);
+    gain.connect(context.destination);
+    oscillator.start(now);
+    oscillator.stop(now + 0.12);
+
+    window.setTimeout(() => {
+      void context.close().catch(() => {});
+    }, 160);
+  } catch {
+    // Audio is best-effort; haptics and visual ceremony still carry the beat.
+  }
+}
+
+export function useCeremonyEffects() {
+  const [isMuted, setIsMuted] = useState(readMutedPreference);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+    readReducedMotionPreference
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+
+    const media = window.matchMedia(REDUCED_MOTION_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    media.addEventListener('change', handleChange);
+    return () => media.removeEventListener('change', handleChange);
+  }, []);
+
+  const setMuted = useCallback((nextMuted: boolean) => {
+    setIsMuted(nextMuted);
+    writeMutedPreference(nextMuted);
+  }, []);
+
+  const toggleMuted = useCallback(() => {
+    setIsMuted((current) => {
+      const next = !current;
+      writeMutedPreference(next);
+      return next;
+    });
+  }, []);
+
+  const punctuate = useCallback(
+    (effect: CeremonyEffect) => {
+      if (isMuted || prefersReducedMotion) return;
+
+      if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+        navigator.vibrate(HAPTIC_PATTERNS[effect]);
+      }
+      playTone(effect);
+    },
+    [isMuted, prefersReducedMotion]
+  );
+
+  return {
+    isMuted,
+    prefersReducedMotion,
+    punctuate,
+    setMuted,
+    toggleMuted,
+  };
+}

--- a/hooks/useSharePoem.ts
+++ b/hooks/useSharePoem.ts
@@ -7,7 +7,20 @@ import { captureError } from '@/lib/error';
 import { trackPoemShared } from '@/lib/analytics';
 import { useShareLink } from '@/hooks/useShareLink';
 
-export function useSharePoem(poemId: Id<'poems'>, guestToken?: string) {
+function buildPoemShareText(openingLine?: string) {
+  const trimmed = openingLine?.trim();
+  if (!trimmed) return 'Read this poem from our Linejam session.';
+
+  const preview =
+    trimmed.length > 80 ? `${trimmed.slice(0, 77).trimEnd()}...` : trimmed;
+  return `Read "${preview}" from our Linejam session.`;
+}
+
+export function useSharePoem(
+  poemId: Id<'poems'>,
+  guestToken?: string,
+  openingLine?: string
+) {
   const enablePublicPoemShare = useMutation(api.shares.enablePublicPoemShare);
   const logShare = useMutation(api.shares.logShare);
 
@@ -21,7 +34,7 @@ export function useSharePoem(poemId: Id<'poems'>, guestToken?: string) {
     getShareData: () => ({
       url: `${window.location.origin}/poem/${poemId}`,
       title: 'Linejam poem',
-      text: 'Read this poem from our Linejam session.',
+      text: buildPoemShareText(openingLine),
     }),
     onShared: (method) => {
       logShare({ poemId }).catch(() => {});

--- a/tests/app/onboarding-copy.test.tsx
+++ b/tests/app/onboarding-copy.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const mockUseSearchParams = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => mockUseSearchParams(),
+}));
+
+vi.mock('convex/react', () => ({
+  useMutation: () => vi.fn().mockResolvedValue(undefined),
+  useConvexAuth: () => ({ isLoading: false, isAuthenticated: false }),
+}));
+
+vi.mock('@clerk/nextjs', () => ({
+  useUser: () => ({ user: null, isLoaded: true }),
+}));
+
+import Home from '@/app/page';
+import JoinPage from '@/app/join/page';
+
+describe('onboarding copy', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSearchParams.mockReturnValue(new URLSearchParams('code=ABCD'));
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ guestId: 'guest-123', token: 'guest-token' }),
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('sets the party-loop expectation on the landing page', () => {
+    render(<Home />);
+
+    expect(
+      screen.getByText(
+        /pass the phone around a room-code game, then read the surprise poems aloud/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('sets the party-loop expectation before a cold-linked friend enters a name', async () => {
+    render(<JoinPage />);
+
+    expect(
+      await screen.findByText(
+        /you'll add one hidden line at a time, then everyone reads the finished poems together/i
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/components/PoemDisplay.test.tsx
+++ b/tests/components/PoemDisplay.test.tsx
@@ -498,6 +498,168 @@ describe('PoemDisplay component', () => {
     });
   });
 
+  describe('archive variant metadata header', () => {
+    // Noon UTC keeps the calendar day stable across the local test-runner's
+    // timezone, unlike a bare date string parsed at UTC midnight.
+    const testCreatedAt = Date.UTC(2026, 0, 15, 12);
+    const expectedDateText = new Date(testCreatedAt).toLocaleDateString(
+      'en-US',
+      { month: 'short', day: 'numeric' }
+    );
+    const archiveMetadata = {
+      createdAt: testCreatedAt,
+      backHref: '/archive',
+      backLabel: 'Back to archive',
+      isParticipant: true,
+      isFavorited: false,
+      onToggleFavorite: vi.fn(),
+    };
+
+    it('shows the back link and lets a participant toggle the room-favorite heart', () => {
+      const onToggleFavorite = vi.fn();
+      const { rerender } = render(
+        <PoemDisplay
+          poemId={mockPoemId}
+          lines={mockLines}
+          variant="archive"
+          metadata={{
+            ...archiveMetadata,
+            onToggleFavorite,
+            isFavorited: false,
+          }}
+        />
+      );
+
+      expect(
+        screen.getByRole('link', { name: 'Back to archive' })
+      ).toHaveAttribute('href', '/archive');
+
+      const heartButton = screen.getByRole('button', {
+        name: 'Add to favorites',
+      });
+      fireEvent.click(heartButton);
+      expect(onToggleFavorite).toHaveBeenCalledTimes(1);
+
+      rerender(
+        <PoemDisplay
+          poemId={mockPoemId}
+          lines={mockLines}
+          variant="archive"
+          metadata={{ ...archiveMetadata, onToggleFavorite, isFavorited: true }}
+        />
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'Remove from favorites' })
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to the default back label when none is provided', () => {
+      render(
+        <PoemDisplay
+          poemId={mockPoemId}
+          lines={mockLines}
+          variant="archive"
+          metadata={{ createdAt: testCreatedAt, backHref: '/archive' }}
+        />
+      );
+
+      expect(screen.getByRole('link', { name: '← Back' })).toBeInTheDocument();
+    });
+
+    it('does not offer favorite controls to a non-participant viewer', () => {
+      render(
+        <PoemDisplay
+          poemId={mockPoemId}
+          lines={mockLines}
+          variant="archive"
+          metadata={{
+            createdAt: testCreatedAt,
+            isParticipant: false,
+            onToggleFavorite: vi.fn(),
+          }}
+        />
+      );
+
+      expect(
+        screen.queryByRole('button', { name: /favorites/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('truncates a long first line in the header title', () => {
+      const longLine =
+        'A remarkably long opening line that easily exceeds forty characters';
+      const linesWithLongFirst: PoemLine[] = [
+        { text: longLine, authorName: 'Alice', authorStableId: 'stable_alice' },
+        ...mockLines.slice(1),
+      ];
+
+      render(
+        <PoemDisplay
+          poemId={mockPoemId}
+          lines={linesWithLongFirst}
+          variant="archive"
+          metadata={{ createdAt: testCreatedAt }}
+        />
+      );
+
+      expect(
+        screen.getByText(`${longLine.slice(0, 40)}...`, { exact: false })
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to the metadata first line when there are no poem lines yet', () => {
+      render(
+        <PoemDisplay
+          poemId={mockPoemId}
+          lines={[]}
+          variant="archive"
+          metadata={{
+            createdAt: testCreatedAt,
+            firstLine: 'Fallback title from metadata',
+          }}
+        />
+      );
+
+      expect(
+        screen.getByText(/Fallback title from metadata/)
+      ).toBeInTheDocument();
+      // A zero-line poem is trivially "fully revealed" the instant it mounts.
+      expect(screen.getByTestId('poem-actions')).toHaveClass('opacity-100');
+    });
+
+    it('shows an empty title when there is no line text and no metadata fallback', () => {
+      render(
+        <PoemDisplay
+          poemId={mockPoemId}
+          lines={[]}
+          variant="archive"
+          metadata={{ createdAt: testCreatedAt }}
+        />
+      );
+
+      // The header still renders (date is present) even with nothing to quote.
+      expect(screen.getByText(expectedDateText)).toBeInTheDocument();
+    });
+
+    it('labels a contributor as Unknown when no author name is recorded', () => {
+      const linesWithMysteryAuthor: PoemLine[] = [
+        { text: 'A quiet line', authorStableId: 'stable_mystery' },
+      ];
+
+      render(
+        <PoemDisplay
+          poemId={mockPoemId}
+          lines={linesWithMysteryAuthor}
+          variant="archive"
+          metadata={{ createdAt: testCreatedAt }}
+        />
+      );
+
+      expect(screen.getByText('Unknown')).toBeInTheDocument();
+    });
+  });
+
   describe('string line normalization', () => {
     it('handles plain string lines array', () => {
       const stringLines = ['One', 'Two words', 'Three simple words'];

--- a/tests/components/PoemDisplay.test.tsx
+++ b/tests/components/PoemDisplay.test.tsx
@@ -21,6 +21,7 @@ Object.defineProperty(navigator, 'clipboard', {
 import { PoemDisplay, type PoemLine } from '@/components/PoemDisplay';
 import { Id } from '@/convex/_generated/dataModel';
 import { getUserColor, getUniqueColor } from '@/lib/avatarColor';
+import { installMatchMedia } from '@/tests/helpers/matchMedia';
 
 describe('PoemDisplay component', () => {
   const mockPoemId = 'poem_test_123' as Id<'poems'>;
@@ -62,12 +63,19 @@ describe('PoemDisplay component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     mockClipboard.writeText.mockClear();
+    installMatchMedia(false);
+    Object.defineProperty(navigator, 'vibrate', {
+      value: vi.fn(),
+      configurable: true,
+    });
     vi.useFakeTimers();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    localStorage.clear();
   });
 
   describe('reveal animation', () => {
@@ -103,7 +111,7 @@ describe('PoemDisplay component', () => {
       });
     });
 
-    it('reveals lines progressively with staggered timing', async () => {
+    it('reveals lines with the poem-shaped ceremony cadence', async () => {
       render(
         <PoemDisplay
           poemId={mockPoemId}
@@ -118,21 +126,27 @@ describe('PoemDisplay component', () => {
       // Initially no lines revealed
       expect(lineDots[0]).toHaveClass('opacity-0');
 
-      // After 1000ms (BASE_REVEAL_DELAY), first line should reveal
+      // The reveal is not a flat metronome: it follows the poem diamond,
+      // swelling toward the five-word line before accelerating to the end.
       await act(async () => {
-        vi.advanceTimersByTime(1000);
+        vi.advanceTimersByTime(559);
+      });
+      expect(lineDots[0]).toHaveClass('opacity-0');
+
+      await act(async () => {
+        vi.advanceTimersByTime(1);
       });
       expect(lineDots[0]).toHaveClass('opacity-100');
       expect(lineDots[1]).toHaveClass('opacity-0');
+      expect(navigator.vibrate).toHaveBeenCalledWith(8);
 
-      // After another 1000ms, second line reveals
       await act(async () => {
-        vi.advanceTimersByTime(1000);
+        vi.advanceTimersByTime(680);
       });
       expect(lineDots[1]).toHaveClass('opacity-100');
     });
 
-    it('pauses after line 4 with extra delay', async () => {
+    it('crescendoes into the final line instead of pausing at a fixed beat', async () => {
       render(
         <PoemDisplay
           poemId={mockPoemId}
@@ -142,29 +156,87 @@ describe('PoemDisplay component', () => {
         />
       );
 
-      // Advance timers to reveal first 5 lines (0-4)
-      for (let i = 0; i < 5; i++) {
+      const lineDots = screen.getAllByRole('button', { name: /Show author/i });
+      const delays = [560, 680, 800, 940, 1120, 900, 720, 520, 360];
+
+      for (const delay of delays.slice(0, 5)) {
         await act(async () => {
-          vi.advanceTimersByTime(1000);
+          vi.advanceTimersByTime(delay);
         });
       }
 
-      const lineDots = screen.getAllByRole('button', { name: /Show author/i });
-
-      // Lines 0-4 should be revealed
       expect(lineDots[4]).toHaveClass('opacity-100');
       expect(lineDots[5]).toHaveClass('opacity-0');
 
-      // Line 5 (after pause point at PAUSE_AFTER_LINE=4) needs extra PAUSE_DURATION
       await act(async () => {
-        vi.advanceTimersByTime(1000); // Normal delay - not enough
+        vi.advanceTimersByTime(899);
       });
       expect(lineDots[5]).toHaveClass('opacity-0');
 
       await act(async () => {
-        vi.advanceTimersByTime(1200); // Extra pause delay
+        vi.advanceTimersByTime(1);
       });
       expect(lineDots[5]).toHaveClass('opacity-100');
+
+      for (const delay of delays.slice(6, 8)) {
+        await act(async () => {
+          vi.advanceTimersByTime(delay);
+        });
+      }
+
+      expect(lineDots[7]).toHaveClass('opacity-100');
+      expect(lineDots[8]).toHaveClass('opacity-0');
+
+      await act(async () => {
+        vi.advanceTimersByTime(359);
+      });
+      expect(lineDots[8]).toHaveClass('opacity-0');
+
+      await act(async () => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(lineDots[8]).toHaveClass('opacity-100');
+      expect(navigator.vibrate).toHaveBeenLastCalledWith([14, 30, 18]);
+    });
+
+    it('reveals immediately and skips haptics for reduced motion', async () => {
+      installMatchMedia(true);
+
+      render(
+        <PoemDisplay
+          poemId={mockPoemId}
+          lines={mockLines}
+          onDone={mockOnDone}
+          alreadyRevealed={false}
+        />
+      );
+
+      const lineDots = screen.getAllByRole('button', { name: /Show author/i });
+      lineDots.forEach((dot) => {
+        expect(dot).toHaveClass('opacity-100');
+      });
+      expect(navigator.vibrate).not.toHaveBeenCalled();
+    });
+
+    it('lets the reader mute reveal punctuation before the first line', async () => {
+      render(
+        <PoemDisplay
+          poemId={mockPoemId}
+          lines={mockLines}
+          onDone={mockOnDone}
+          alreadyRevealed={false}
+        />
+      );
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /Mute ceremony sound/i })
+      );
+
+      await act(async () => {
+        vi.advanceTimersByTime(560);
+      });
+
+      expect(navigator.vibrate).not.toHaveBeenCalled();
     });
 
     it('shows Share and Close buttons only after all lines revealed', async () => {
@@ -181,8 +253,7 @@ describe('PoemDisplay component', () => {
       expect(screen.getByTestId('poem-actions')).toHaveClass('opacity-0');
 
       // Reveal all 9 lines one by one (with extra pause after line 4)
-      for (let i = 0; i < 9; i++) {
-        const delay = i === 5 ? 2200 : 1000; // Extra delay after pause point
+      for (const delay of [560, 680, 800, 940, 1120, 900, 720, 520, 360]) {
         await act(async () => {
           vi.advanceTimersByTime(delay);
         });

--- a/tests/components/RevealPhase.test.tsx
+++ b/tests/components/RevealPhase.test.tsx
@@ -328,11 +328,11 @@ describe('RevealPhase component', () => {
     expect(screen.getByText(/2 poems/i)).toBeInTheDocument();
     expect(screen.getByText(/2 poets/i)).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /Share Session/i })
+      screen.getByRole('button', { name: /Share the whole set/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: /Open Shared Recap/i })
-    ).toHaveAttribute('href', '/recap/ABCD');
+      screen.queryByRole('link', { name: /Open Shared Recap/i })
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole('link', {
         name: /Replay poem 1: The stars align above/i,
@@ -399,14 +399,17 @@ describe('RevealPhase component', () => {
     });
   });
 
-  it('disables recap prefetch on the session-complete screen', () => {
+  it('collapses the old second recap link on the session-complete screen', () => {
     mockUseQuery.mockReturnValue(mockStateAllRevealed);
 
     render(<RevealPhase roomCode="ABCD" />);
 
     expect(
-      screen.getByRole('link', { name: /Open Shared Recap/i })
-    ).toHaveAttribute('data-prefetch', 'false');
+      screen.queryByRole('link', { name: /Open Shared Recap/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Share the whole set/i })
+    ).toBeInTheDocument();
   });
 
   it('gives non-hosts replay and share actions after completion', () => {
@@ -415,11 +418,11 @@ describe('RevealPhase component', () => {
     render(<RevealPhase roomCode="ABCD" />);
 
     expect(
-      screen.getByRole('button', { name: /Share Session/i })
+      screen.getByRole('button', { name: /Share the whole set/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: /Open Shared Recap/i })
-    ).toHaveAttribute('href', '/recap/ABCD');
+      screen.queryByRole('link', { name: /Open Shared Recap/i })
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: /Replay poem 1/i })
     ).toHaveAttribute('href', '/poem/poem_123');

--- a/tests/components/SessionRecapHub.test.tsx
+++ b/tests/components/SessionRecapHub.test.tsx
@@ -246,6 +246,69 @@ describe('SessionRecapHub', () => {
     expect(screen.queryByText(/Room favorite/i)).not.toBeInTheDocument();
   });
 
+  it('does not re-punctuate the crown ceremony on an unrelated re-render', () => {
+    mockSessionFavorites.mockReturnValue({
+      counts: [{ poemId: 'poem_1', indexInRoom: 0, count: 3 }],
+      totalHearts: 3,
+      leaderPoemId: 'poem_1',
+      leaderCount: 3,
+    });
+
+    const { rerender } = render(<SessionRecapHub {...defaultProps} />);
+    expect(navigator.vibrate).toHaveBeenCalledTimes(1);
+
+    // Same crowned poem, same leader count — a later re-render (e.g. from an
+    // unrelated prop change) must not replay the crown ceremony.
+    rerender(<SessionRecapHub {...defaultProps} playerCount={3} />);
+    expect(navigator.vibrate).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the singular "heart" label when exactly one heart was given', () => {
+    mockSessionFavorites.mockReturnValue({
+      counts: [{ poemId: 'poem_1', indexInRoom: 0, count: 1 }],
+      totalHearts: 1,
+      leaderPoemId: 'poem_1',
+      leaderCount: 1,
+    });
+
+    render(<SessionRecapHub {...defaultProps} />);
+
+    expect(screen.getByText(/1 heart\b/i)).toBeInTheDocument();
+    expect(screen.queryByText(/1 hearts/i)).not.toBeInTheDocument();
+  });
+
+  it('falls back to "Untitled poem" when the crowned poem has no preview', () => {
+    mockSessionFavorites.mockReturnValue({
+      counts: [{ poemId: 'poem_2', indexInRoom: 1, count: 2 }],
+      totalHearts: 2,
+      leaderPoemId: 'poem_2',
+      leaderCount: 2,
+    });
+
+    render(<SessionRecapHub {...defaultProps} />);
+
+    const crown = screen.getByText(/Room favorite/i).closest('.border-primary');
+    expect(crown).toHaveTextContent(/Untitled poem/i);
+  });
+
+  it('shows the share error alone when there is no separate room error', async () => {
+    mockEnablePublicSessionRecapShare.mockRejectedValueOnce(
+      new Error('Network down')
+    );
+    const user = userEvent.setup();
+    render(<SessionRecapHub {...defaultProps} />);
+
+    await user.click(
+      screen.getByRole('button', { name: /Share the whole set/i })
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Failed to share recap. Please try again.')
+      ).toBeInTheDocument();
+    });
+  });
+
   it('toggles ceremony sound and persists the preference across mount', async () => {
     const user = userEvent.setup();
     const { unmount } = render(<SessionRecapHub {...defaultProps} />);

--- a/tests/components/SessionRecapHub.test.tsx
+++ b/tests/components/SessionRecapHub.test.tsx
@@ -68,6 +68,7 @@ describe('SessionRecapHub', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     mockEnablePublicSessionRecapShare.mockResolvedValue(undefined);
     // Default: no hearts given → no room-favorite crown
     mockSessionFavorites.mockReturnValue(null);
@@ -86,6 +87,10 @@ describe('SessionRecapHub', () => {
     Object.defineProperty(navigator, 'share', {
       value: undefined,
       writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'vibrate', {
+      value: vi.fn(),
       configurable: true,
     });
 
@@ -111,6 +116,7 @@ describe('SessionRecapHub', () => {
       value: originalShare,
       configurable: true,
     });
+    localStorage.clear();
   });
 
   it('renders sorted poem replay links and host controls', async () => {
@@ -128,8 +134,8 @@ describe('SessionRecapHub', () => {
       screen.getByRole('link', { name: /Replay poem 2: Untitled poem/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: /Open Shared Recap/i })
-    ).toHaveAttribute('href', '/recap/ABCD');
+      screen.queryByRole('link', { name: /Open Shared Recap/i })
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Start Next Round' }));
     await user.click(screen.getByRole('button', { name: 'Back to Lobby' }));
@@ -142,7 +148,9 @@ describe('SessionRecapHub', () => {
     const user = userEvent.setup();
     render(<SessionRecapHub {...defaultProps} playerCount={1} />);
 
-    await user.click(screen.getByRole('button', { name: /Share Session/i }));
+    await user.click(
+      screen.getByRole('button', { name: /Share the whole set/i })
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Copied!')).toBeInTheDocument();
@@ -180,12 +188,14 @@ describe('SessionRecapHub', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Starting...' })).toBeDisabled();
 
-    await user.click(screen.getByRole('button', { name: /Share Session/i }));
+    await user.click(
+      screen.getByRole('button', { name: /Share the whole set/i })
+    );
 
     await waitFor(() => {
       expect(nativeShare).toHaveBeenCalledWith({
         title: 'Linejam session recap',
-        text: 'Replay every poem from our Linejam session in room ABCD.',
+        text: 'Share the whole set from Linejam room ABCD.',
         url: 'https://example.com/recap/ABCD',
       });
       expect(mockEnablePublicSessionRecapShare).toHaveBeenCalledWith({
@@ -215,6 +225,9 @@ describe('SessionRecapHub', () => {
 
     const crown = screen.getByText(/Room favorite/i).closest('.border-primary');
     expect(crown).toBeInTheDocument();
+    expect(screen.getByTestId('room-favorite-crown')).toHaveClass(
+      'animate-crown-settle'
+    );
     expect(screen.getByText(/3 hearts/i)).toBeInTheDocument();
     // The crowned poem's preview appears inside the crown card
     expect(crown).toHaveTextContent(/The moon hums/i);

--- a/tests/components/SessionRecapHub.test.tsx
+++ b/tests/components/SessionRecapHub.test.tsx
@@ -246,6 +246,42 @@ describe('SessionRecapHub', () => {
     expect(screen.queryByText(/Room favorite/i)).not.toBeInTheDocument();
   });
 
+  it('toggles ceremony sound and persists the preference across mount', async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<SessionRecapHub {...defaultProps} />);
+
+    const muteButton = screen.getByRole('button', {
+      name: 'Mute ceremony sound',
+    });
+    expect(screen.getByText('Sound')).toBeInTheDocument();
+
+    await user.click(muteButton);
+
+    expect(
+      screen.getByRole('button', { name: 'Turn ceremony sound on' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Muted')).toBeInTheDocument();
+    expect(localStorage.getItem('linejam:ceremony-muted')).toBe('1');
+
+    unmount();
+
+    // A remount should read the persisted preference back as muted.
+    render(<SessionRecapHub {...defaultProps} />);
+    expect(
+      screen.getByRole('button', { name: 'Turn ceremony sound on' })
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Turn ceremony sound on' })
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Mute ceremony sound' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Sound')).toBeInTheDocument();
+    expect(localStorage.getItem('linejam:ceremony-muted')).toBeNull();
+  });
+
   it('lets anyone in the room continue (no host gating)', async () => {
     // A vanished host must never strand the recap: every participant gets
     // the continuation controls.

--- a/tests/components/WritingScreen.test.tsx
+++ b/tests/components/WritingScreen.test.tsx
@@ -74,6 +74,7 @@ describe('WritingScreen component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     mockUseQuery.mockReset();
     mockSubmitLineMutation.mockReset();
 
@@ -100,6 +101,7 @@ describe('WritingScreen component', () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
+    localStorage.clear();
   });
 
   it('keeps the word counter visible in the composer flow', () => {
@@ -108,6 +110,26 @@ describe('WritingScreen component', () => {
 
     const wordSlots = document.getElementById('word-slots');
     expect(wordSlots).toBeInTheDocument();
+  });
+
+  it('shows the first-run writing coachmark inline without opening help', () => {
+    render(<WritingScreen roomCode="ABCD" />);
+
+    expect(
+      screen.getByText(/you only see one carried line/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/match the word slots/i)).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('does not repeat the writing coachmark after this device has seen it', () => {
+    localStorage.setItem('linejam:writing-coachmark-seen', '1');
+
+    render(<WritingScreen roomCode="ABCD" />);
+
+    expect(
+      screen.queryByText(/you only see one carried line/i)
+    ).not.toBeInTheDocument();
   });
 
   it('resets scroll when the active assignment changes', () => {

--- a/tests/components/WritingScreen.test.tsx
+++ b/tests/components/WritingScreen.test.tsx
@@ -23,16 +23,26 @@ vi.mock('@clerk/nextjs', () => ({
   useUser: () => ({ user: null, isLoaded: true }),
 }));
 
-// Mock useUser hook to return pre-loaded state with guestToken
+// Mock useUser hook to return pre-loaded state with guestToken. A plain
+// mutable object (rather than a fixed literal) lets individual tests flip
+// guestToken to a falsy value without re-mocking the module.
+const mockUseUserReturn: {
+  clerkUser: null;
+  guestId: string;
+  guestToken: string | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  displayName: string;
+} = {
+  clerkUser: null,
+  guestId: 'guest_123',
+  guestToken: 'mock-token',
+  isLoading: false,
+  isAuthenticated: false,
+  displayName: 'Guest',
+};
 vi.mock('@/lib/auth', () => ({
-  useUser: () => ({
-    clerkUser: null,
-    guestId: 'guest_123',
-    guestToken: 'mock-token',
-    isLoading: false,
-    isAuthenticated: false,
-    displayName: 'Guest',
-  }),
+  useUser: () => mockUseUserReturn,
 }));
 
 // Mock fetch for guest session API (external boundary)
@@ -77,6 +87,7 @@ describe('WritingScreen component', () => {
     localStorage.clear();
     mockUseQuery.mockReset();
     mockSubmitLineMutation.mockReset();
+    mockUseUserReturn.guestToken = 'mock-token';
 
     // Default: return assignment for all queries
     // WritingScreen calls useQuery twice but only uses first result for rendering
@@ -310,6 +321,27 @@ describe('WritingScreen component', () => {
     await flushSubmitTransition();
   });
 
+  it('submits guestToken as undefined when no guest session is established yet', async () => {
+    mockUseUserReturn.guestToken = null;
+    mockSubmitLineMutation.mockResolvedValue(undefined);
+    const user = setupUser();
+    render(<WritingScreen roomCode="ABCD" />);
+    const textarea = screen.getByRole('textbox');
+
+    await user.type(textarea, 'Poetry');
+    await user.click(screen.getByRole('button', { name: /^Submit$/i }));
+
+    await waitFor(() => {
+      expect(mockSubmitLineMutation).toHaveBeenCalledWith({
+        poemId: 'poem_123',
+        lineIndex: 0,
+        text: 'Poetry',
+        guestToken: undefined,
+      });
+    });
+    await flushSubmitTransition();
+  });
+
   it('shows "Submitting…" during submission', async () => {
     // Arrange - Make mutation take time
     mockSubmitLineMutation.mockImplementation(
@@ -504,6 +536,21 @@ describe('WritingScreen component', () => {
       // Assert
       expect(textarea).toHaveAttribute('placeholder', 'write four words…');
     });
+
+    it('falls back to the numeral when target word count exceeds the known number words', () => {
+      // numberToWord only spells out zero through five; anything beyond that
+      // is a defensive fallback that should still render a sane placeholder.
+      mockUseQuery.mockReturnValue({
+        ...mockAssignment,
+        lineIndex: 5,
+        targetWordCount: 6,
+      });
+
+      render(<WritingScreen roomCode="ABCD" />);
+      const textarea = screen.getByRole('textbox');
+
+      expect(textarea).toHaveAttribute('placeholder', 'write 6 words…');
+    });
   });
 
   describe('live region announcements', () => {
@@ -573,6 +620,22 @@ describe('WritingScreen component', () => {
       expect(liveRegion).toHaveTextContent('Add 3 words');
     });
 
+    it('announces "Add 1 word" (singular) when exactly one word under target', async () => {
+      // Arrange - Round 5 requires 5 words
+      mockUseQuery.mockReturnValue(mockAssignmentRound5);
+      const user = setupUser();
+      const { container } = render(<WritingScreen roomCode="ABCD" />);
+      const textarea = screen.getByRole('textbox');
+
+      // Act - Type 4 words (1 under the target of 5)
+      await user.type(textarea, 'One two three four');
+      await flushDebounce();
+
+      // Assert - singular "word", not "words"
+      const liveRegion = getLiveRegion(container);
+      expect(liveRegion).toHaveTextContent(/^Add 1 word$/);
+    });
+
     it('keeps the live region silent before the player starts typing', async () => {
       const { container } = render(<WritingScreen roomCode="ABCD" />);
 
@@ -617,6 +680,47 @@ describe('WritingScreen component', () => {
           ''
         );
       });
+    });
+  });
+
+  describe('room chrome', () => {
+    it('shows the round chrome header above the composer when showChrome is set', () => {
+      mockUseQuery.mockImplementation((query) => {
+        const functionName = getFunctionName(
+          query as Parameters<typeof getFunctionName>[0]
+        );
+        if (functionName === 'game:getRoundProgress') {
+          return mockRoundProgress;
+        }
+        return mockAssignment;
+      });
+
+      render(<WritingScreen roomCode="ABCD" showChrome />);
+
+      expect(screen.getByText('Round 1 · 1 word')).toBeInTheDocument();
+    });
+
+    it('shows the round chrome above the late-joiner waiting screen when showChrome is set', () => {
+      mockUseQuery.mockImplementation((query) => {
+        const functionName = getFunctionName(
+          query as Parameters<typeof getFunctionName>[0]
+        );
+        if (functionName === 'game:getRoundProgress') {
+          return {
+            round: 2,
+            players: [
+              { stableId: 'stable_alice', submitted: true },
+              { stableId: 'stable_bob', submitted: false },
+            ],
+          };
+        }
+        return null; // no assignment yet — late joiner waiting for the round
+      });
+
+      render(<WritingScreen roomCode="ABCD" showChrome />);
+
+      expect(screen.getByText('Round 3 of 9')).toBeInTheDocument();
+      expect(screen.getByText('1 of 2 ready.')).toBeInTheDocument();
     });
   });
 });

--- a/tests/e2e/reveal-share.spec.ts
+++ b/tests/e2e/reveal-share.spec.ts
@@ -52,10 +52,10 @@ test('mobile reveal ceremony produces a one-tap shareable recap artifact', async
     await expect(
       session.hostPage.getByRole('button', { name: /Mute ceremony sound/i })
     ).toBeVisible();
-    await expect(session.hostPage.getByText('poetry')).toBeVisible({
+    await expect(session.hostPage.getByText('poetry').first()).toBeVisible({
       timeout: 10000,
     });
-    await expect(session.hostPage.getByText('end')).toBeVisible({
+    await expect(session.hostPage.getByText('end').first()).toBeVisible({
       timeout: 12000,
     });
     await session.capture('host', `${evidenceDir}/mobile-reveal-ceremony.png`);

--- a/tests/e2e/reveal-share.spec.ts
+++ b/tests/e2e/reveal-share.spec.ts
@@ -1,0 +1,114 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { test, expect } from '@playwright/test';
+
+import {
+  CANONICAL_GUEST_FLOW_LINES,
+  GuestFlowSession,
+} from '@/tests/e2e/support/guestFlow';
+
+const missingGuestTokenSecret =
+  !process.env.GUEST_TOKEN_SECRET && !process.env.E2E_BASE_URL;
+test.skip(
+  missingGuestTokenSecret,
+  'Set GUEST_TOKEN_SECRET for local E2E, or E2E_BASE_URL for a remote target'
+);
+
+test('mobile reveal ceremony produces a one-tap shareable recap artifact', async ({
+  browser,
+  request,
+}, testInfo) => {
+  const evidenceDir =
+    process.env.LINEJAM_PRODUCT_EVIDENCE_DIR ??
+    testInfo.outputPath('linejam-product-evidence');
+  await mkdir(evidenceDir, { recursive: true });
+
+  const session = await GuestFlowSession.create(browser, {
+    guestName: 'Guest Poet',
+    hostName: 'Host Poet',
+    recordHostVideoDir: evidenceDir,
+    viewport: { width: 390, height: 844 },
+  });
+
+  try {
+    await session.hostContext.grantPermissions(['clipboard-write']);
+
+    const roomCode = await session.createRoom();
+    await session.joinRoom();
+    await session.startGame();
+
+    await expect(
+      session.hostPage.getByText(/You only see one carried line/i)
+    ).toBeVisible();
+    await session.capture(
+      'host',
+      `${evidenceDir}/mobile-writing-coachmark.png`
+    );
+
+    await session.playCanonicalGame(CANONICAL_GUEST_FLOW_LINES);
+
+    await session.hostPage
+      .getByRole('button', { name: /Reveal & Read/i })
+      .click();
+    await expect(
+      session.hostPage.getByRole('button', { name: /Mute ceremony sound/i })
+    ).toBeVisible();
+    await expect(session.hostPage.getByText('poetry')).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(session.hostPage.getByText('end')).toBeVisible({
+      timeout: 12000,
+    });
+    await session.capture('host', `${evidenceDir}/mobile-reveal-ceremony.png`);
+    await session.hostPage
+      .getByRole('button', { name: /Favorite this poem/i })
+      .click();
+    await session.hostPage.getByRole('button', { name: /Close/i }).click();
+
+    await session.revealAssignedPoem('guest', CANONICAL_GUEST_FLOW_LINES);
+
+    await expect(
+      session.hostPage.getByRole('heading', { name: /Session complete/i })
+    ).toBeVisible({ timeout: 15000 });
+    await expect(
+      session.hostPage.getByTestId('room-favorite-crown')
+    ).toBeVisible();
+    await expect(
+      session.hostPage.getByRole('button', { name: /Share the whole set/i })
+    ).toHaveCount(1);
+    await expect(
+      session.hostPage.getByRole('link', { name: /Open Shared Recap/i })
+    ).toHaveCount(0);
+    await session.capture('host', `${evidenceDir}/mobile-session-recap.png`);
+
+    await session.hostPage
+      .getByRole('button', { name: /Share the whole set/i })
+      .click();
+    await expect(session.hostPage.getByText(/Copied!|Shared!/i)).toBeVisible({
+      timeout: 10000,
+    });
+
+    const baseUrl = new URL(session.hostPage.url()).origin;
+    const ogResponse = await request.get(
+      `${baseUrl}/recap/${roomCode}/opengraph-image`
+    );
+    expect(ogResponse.ok()).toBe(true);
+    expect(ogResponse.headers()['content-type']).toContain('image/png');
+
+    const ogImage = await ogResponse.body();
+    const ogPath = `${evidenceDir}/recap-opengraph-image.png`;
+    await writeFile(ogPath, ogImage);
+    await testInfo.attach('recap-opengraph-image', {
+      body: ogImage,
+      contentType: 'image/png',
+    });
+  } finally {
+    const video = session.recordedHostVideo;
+    await session.close();
+    if (video) {
+      await testInfo.attach('host-mobile-video', {
+        path: await video.path(),
+        contentType: 'video/webm',
+      });
+    }
+  }
+});

--- a/tests/e2e/support/guestFlow.ts
+++ b/tests/e2e/support/guestFlow.ts
@@ -528,7 +528,9 @@ export class GuestFlowSession {
 
     await page.getByRole('button', { name: /Reveal & Read/i }).click();
     await expect(page.getByText(lines[0])).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText(lines.at(-1) ?? '')).toBeVisible();
+    await expect(page.getByText(lines.at(-1) ?? '')).toBeVisible({
+      timeout: 12000,
+    });
     await page.getByRole('button', { name: /Close|Done|Back/i }).click();
   }
 

--- a/tests/hooks/useCeremonyEffects.test.ts
+++ b/tests/hooks/useCeremonyEffects.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useCeremonyEffects } from '@/hooks/useCeremonyEffects';
+import { installMatchMedia } from '@/tests/helpers/matchMedia';
+
+const CEREMONY_MUTED_KEY = 'linejam:ceremony-muted';
+
+// vi.fn().mockReturnValue() can't stand in for a `new`-able constructor, so
+// build a real constructor function that copies the fake context's members
+// onto `this` the way a real AudioContext instance would expose them.
+function createAudioContextCtor(audioContext: Record<string, unknown>) {
+  return vi.fn(function (this: Record<string, unknown>) {
+    Object.assign(this, audioContext);
+  });
+}
+
+describe('useCeremonyEffects', () => {
+  let originalVibrate: Navigator['vibrate'];
+  let originalAudioContext: typeof window.AudioContext | undefined;
+
+  beforeEach(() => {
+    localStorage.clear();
+    installMatchMedia(false);
+    originalVibrate = navigator.vibrate;
+    originalAudioContext = window.AudioContext;
+    Object.defineProperty(navigator, 'vibrate', {
+      value: vi.fn(),
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    Object.defineProperty(navigator, 'vibrate', {
+      value: originalVibrate,
+      configurable: true,
+    });
+    if (originalAudioContext) {
+      Object.defineProperty(window, 'AudioContext', {
+        value: originalAudioContext,
+        configurable: true,
+        writable: true,
+      });
+    } else {
+      Reflect.deleteProperty(window, 'AudioContext');
+    }
+  });
+
+  it('mutes and unmutes, persisting the preference to localStorage each way', () => {
+    const { result } = renderHook(() => useCeremonyEffects());
+
+    expect(result.current.isMuted).toBe(false);
+
+    act(() => {
+      result.current.toggleMuted();
+    });
+    expect(result.current.isMuted).toBe(true);
+    expect(localStorage.getItem(CEREMONY_MUTED_KEY)).toBe('1');
+
+    act(() => {
+      result.current.toggleMuted();
+    });
+    expect(result.current.isMuted).toBe(false);
+    expect(localStorage.getItem(CEREMONY_MUTED_KEY)).toBeNull();
+  });
+
+  it('setMuted writes the explicit value instead of toggling', () => {
+    const { result } = renderHook(() => useCeremonyEffects());
+
+    act(() => {
+      result.current.setMuted(true);
+    });
+    expect(result.current.isMuted).toBe(true);
+    expect(localStorage.getItem(CEREMONY_MUTED_KEY)).toBe('1');
+
+    act(() => {
+      result.current.setMuted(false);
+    });
+    expect(result.current.isMuted).toBe(false);
+    expect(localStorage.getItem(CEREMONY_MUTED_KEY)).toBeNull();
+  });
+
+  it('does not vibrate or play a tone while muted', () => {
+    const { result } = renderHook(() => useCeremonyEffects());
+
+    act(() => {
+      result.current.setMuted(true);
+    });
+    act(() => {
+      result.current.punctuate('line');
+    });
+
+    expect(navigator.vibrate).not.toHaveBeenCalled();
+  });
+
+  it('does not vibrate or play a tone when the reader prefers reduced motion', () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useCeremonyEffects());
+
+    expect(result.current.prefersReducedMotion).toBe(true);
+
+    act(() => {
+      result.current.punctuate('final-line');
+    });
+
+    expect(navigator.vibrate).not.toHaveBeenCalled();
+  });
+
+  it('plays a triangle tone and vibrates the crown pattern for the crown beat', () => {
+    const oscillator = {
+      type: '',
+      frequency: { setValueAtTime: vi.fn() },
+      connect: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+    };
+    const gain = {
+      gain: {
+        setValueAtTime: vi.fn(),
+        exponentialRampToValueAtTime: vi.fn(),
+      },
+      connect: vi.fn(),
+    };
+    const audioContext = {
+      currentTime: 0,
+      createOscillator: vi.fn().mockReturnValue(oscillator),
+      createGain: vi.fn().mockReturnValue(gain),
+      destination: {},
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const AudioContextCtor = createAudioContextCtor(audioContext);
+    Object.defineProperty(window, 'AudioContext', {
+      value: AudioContextCtor,
+      configurable: true,
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useCeremonyEffects());
+
+    act(() => {
+      result.current.punctuate('crown');
+    });
+
+    expect(AudioContextCtor).toHaveBeenCalledTimes(1);
+    expect(oscillator.type).toBe('triangle');
+    expect(oscillator.connect).toHaveBeenCalledWith(gain);
+    expect(gain.connect).toHaveBeenCalledWith(audioContext.destination);
+    expect(oscillator.start).toHaveBeenCalledWith(0);
+    expect(navigator.vibrate).toHaveBeenCalledWith([16, 40, 22]);
+  });
+
+  it('plays a sine tone for a regular line beat', () => {
+    const oscillator = {
+      type: '',
+      frequency: { setValueAtTime: vi.fn() },
+      connect: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+    };
+    const gain = {
+      gain: {
+        setValueAtTime: vi.fn(),
+        exponentialRampToValueAtTime: vi.fn(),
+      },
+      connect: vi.fn(),
+    };
+    const audioContext = {
+      currentTime: 0,
+      createOscillator: vi.fn().mockReturnValue(oscillator),
+      createGain: vi.fn().mockReturnValue(gain),
+      destination: {},
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    Object.defineProperty(window, 'AudioContext', {
+      value: createAudioContextCtor(audioContext),
+      configurable: true,
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useCeremonyEffects());
+
+    act(() => {
+      result.current.punctuate('line');
+    });
+
+    expect(oscillator.type).toBe('sine');
+    expect(navigator.vibrate).toHaveBeenCalledWith(8);
+  });
+});

--- a/tests/hooks/useCeremonyEffects.test.ts
+++ b/tests/hooks/useCeremonyEffects.test.ts
@@ -95,6 +95,19 @@ describe('useCeremonyEffects', () => {
     expect(navigator.vibrate).not.toHaveBeenCalled();
   });
 
+  it('skips haptics gracefully on a device with no vibrate API', () => {
+    Reflect.deleteProperty(navigator, 'vibrate');
+    expect('vibrate' in navigator).toBe(false);
+
+    const { result } = renderHook(() => useCeremonyEffects());
+
+    expect(() => {
+      act(() => {
+        result.current.punctuate('line');
+      });
+    }).not.toThrow();
+  });
+
   it('does not vibrate or play a tone when the reader prefers reduced motion', () => {
     installMatchMedia(true);
     const { result } = renderHook(() => useCeremonyEffects());

--- a/tests/hooks/useSharePoem.test.ts
+++ b/tests/hooks/useSharePoem.test.ts
@@ -303,6 +303,30 @@ describe('useSharePoem', () => {
     expect(mockCaptureError).not.toHaveBeenCalled();
   });
 
+  it('truncates a long opening line in the share text preview', async () => {
+    const nativeShare = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', {
+      value: nativeShare,
+      writable: true,
+      configurable: true,
+    });
+    const longOpeningLine =
+      'The moon hums a long forgotten tune while the tide pulls back from the shore, again and again, patient as ever';
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, longOpeningLine)
+    );
+
+    await act(async () => {
+      await result.current.handleShare();
+    });
+
+    expect(nativeShare).toHaveBeenCalledWith({
+      title: 'Linejam poem',
+      text: `Read "${longOpeningLine.slice(0, 77)}..." from our Linejam session.`,
+      url: 'https://example.com/poem/poem123',
+    });
+  });
+
   it('uses a generic fallback only when the opening line is unavailable', async () => {
     const nativeShare = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'share', {

--- a/tests/hooks/useSharePoem.test.ts
+++ b/tests/hooks/useSharePoem.test.ts
@@ -31,6 +31,7 @@ vi.mock('@/lib/analytics', () => ({
 
 describe('useSharePoem', () => {
   const testPoemId = 'poem123' as Id<'poems'>;
+  const openingLine = 'The moon hums';
   let originalClipboard: Clipboard;
   let originalLocation: Location;
   let originalShare: Navigator['share'];
@@ -90,14 +91,18 @@ describe('useSharePoem', () => {
   });
 
   it('returns initial state with copied=false', () => {
-    const { result } = renderHook(() => useSharePoem(testPoemId));
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, openingLine)
+    );
 
     expect(result.current.copied).toBe(false);
     expect(typeof result.current.handleShare).toBe('function');
   });
 
   it('copies URL to clipboard when handleShare is called', async () => {
-    const { result } = renderHook(() => useSharePoem(testPoemId));
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, openingLine)
+    );
 
     await act(async () => {
       await result.current.handleShare();
@@ -113,7 +118,9 @@ describe('useSharePoem', () => {
   });
 
   it('sets copied=true after successful copy', async () => {
-    const { result } = renderHook(() => useSharePoem(testPoemId));
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, openingLine)
+    );
 
     await act(async () => {
       await result.current.handleShare();
@@ -123,7 +130,9 @@ describe('useSharePoem', () => {
   });
 
   it('resets copied to false after 2000ms timeout', async () => {
-    const { result } = renderHook(() => useSharePoem(testPoemId));
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, openingLine)
+    );
 
     await act(async () => {
       await result.current.handleShare();
@@ -140,7 +149,9 @@ describe('useSharePoem', () => {
   });
 
   it('logs share via mutation (fire-and-forget)', async () => {
-    const { result } = renderHook(() => useSharePoem(testPoemId));
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, openingLine)
+    );
 
     await act(async () => {
       await result.current.handleShare();
@@ -152,7 +163,9 @@ describe('useSharePoem', () => {
 
   it('does not copy when public sharing cannot be enabled', async () => {
     mockEnablePublicPoemShare.mockRejectedValueOnce(new Error('Forbidden'));
-    const { result } = renderHook(() => useSharePoem(testPoemId));
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, openingLine)
+    );
 
     await act(async () => {
       await result.current.handleShare();
@@ -167,7 +180,9 @@ describe('useSharePoem', () => {
 
   it('handles logShare mutation failure gracefully', async () => {
     mockLogShare.mockRejectedValueOnce(new Error('Network error'));
-    const { result } = renderHook(() => useSharePoem(testPoemId));
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, openingLine)
+    );
 
     // Should not throw, mutation error is caught
     await act(async () => {
@@ -183,7 +198,9 @@ describe('useSharePoem', () => {
     (
       navigator.clipboard.writeText as ReturnType<typeof vi.fn>
     ).mockRejectedValueOnce(clipboardError);
-    const { result } = renderHook(() => useSharePoem(testPoemId));
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, openingLine)
+    );
 
     await act(async () => {
       await result.current.handleShare();
@@ -203,7 +220,9 @@ describe('useSharePoem', () => {
     (
       navigator.clipboard.writeText as ReturnType<typeof vi.fn>
     ).mockRejectedValueOnce(new Error('Clipboard denied'));
-    const { result } = renderHook(() => useSharePoem(testPoemId));
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, openingLine)
+    );
 
     await act(async () => {
       await result.current.handleShare();
@@ -220,7 +239,9 @@ describe('useSharePoem', () => {
       writable: true,
       configurable: true,
     });
-    const { result } = renderHook(() => useSharePoem(testPoemId));
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, openingLine)
+    );
 
     await act(async () => {
       await result.current.handleShare();
@@ -228,7 +249,7 @@ describe('useSharePoem', () => {
 
     expect(nativeShare).toHaveBeenCalledWith({
       title: 'Linejam poem',
-      text: 'Read this poem from our Linejam session.',
+      text: 'Read "The moon hums" from our Linejam session.',
       url: 'https://example.com/poem/poem123',
     });
     expect(mockEnablePublicPoemShare).toHaveBeenCalledWith({
@@ -248,7 +269,9 @@ describe('useSharePoem', () => {
       writable: true,
       configurable: true,
     });
-    const { result } = renderHook(() => useSharePoem(testPoemId));
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, openingLine)
+    );
 
     await act(async () => {
       await result.current.handleShare();
@@ -267,7 +290,9 @@ describe('useSharePoem', () => {
       writable: true,
       configurable: true,
     });
-    const { result } = renderHook(() => useSharePoem(testPoemId));
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, openingLine)
+    );
 
     await act(async () => {
       await result.current.handleShare();
@@ -276,5 +301,25 @@ describe('useSharePoem', () => {
     expect(result.current.shareError).toBeNull();
     expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
     expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+
+  it('uses a generic fallback only when the opening line is unavailable', async () => {
+    const nativeShare = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', {
+      value: nativeShare,
+      writable: true,
+      configurable: true,
+    });
+    const { result } = renderHook(() => useSharePoem(testPoemId));
+
+    await act(async () => {
+      await result.current.handleShare();
+    });
+
+    expect(nativeShare).toHaveBeenCalledWith({
+      title: 'Linejam poem',
+      text: 'Read this poem from our Linejam session.',
+      url: 'https://example.com/poem/poem123',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Make reveal pacing poem-shaped with reduced-motion handling, optional haptic/audio punctuation, and a room-favorite crown ceremony.
- Collapse session recap sharing to one "Share the whole set" action backed by the privacy-gated recap OG image.
- Seed per-poem share text with the actual opening line.
- Close the remaining linejam-024 gaps: first-run writing coachmark and one-sentence landing/join copy.

## Card verdicts
- linejam-023: Complete. All oracle boxes checked in `backlog.d/023-reveal-ceremony-and-shareable-artifact.md`.
- linejam-024: Complete. QR/tap-copy/help/late-join/error feedback came from 7f754ff; this PR adds the coachmark and landing/join copy, then checks the ticket honestly.

## Verification
- `pnpm test --run tests/components/PoemDisplay.test.tsx tests/hooks/useSharePoem.test.ts tests/components/SessionRecapHub.test.tsx tests/components/WritingScreen.test.tsx tests/app/onboarding-copy.test.tsx`
- `pnpm test --run tests/components/RevealPhase.test.tsx`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm ci:prepush` (green: 102 test files, 1120 passed, 1 skipped)
- pre-push hook during `git push` reran typecheck + lint + test green

## E2E / mobile evidence
- Added `tests/e2e/reveal-share.spec.ts` for the 390px reveal/share walkthrough and recap OG image artifact capture.
- Local Playwright was not run because no local app server was listening on 3000/3333 and repo invariant forbids agents from starting `pnpm dev`/server processes. Hosted merge-gate should exercise the committed spec.

## Fresh critic
- Fresh-context critic result: no blocking findings.
- Residual noted by critic: Playwright/mobile recording and live OG render were not run locally for the same server-boundary reason above.

## CSP / privacy
- No new external origins or dependencies.
- Recap page, metadata, and OG image still read through `api.poems.getPublicSessionRecap`, preserving the public-by-link sharing contract.

Agent: codex-implementer
Agent-Surface: Codex CLI
Agent-Task: linejam-023,linejam-024
