### PR TITLE
docs(truth-sweep): retire orphaned vision.md, drop stale sections, add rollback runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,15 +368,6 @@ pnpm test:e2e:ui      # Playwright interactive mode
 - Playwright: `PLAYWRIGHT_BASE_URL`, `PLAYWRIGHT_CLERK_TEST_EMAIL`, `PLAYWRIGHT_REQUIRE_AUTH_E2E`, `PLAYWRIGHT_REQUIRE_AUTH_SMOKE`
 - Smoke: `LINEJAM_SMOKE_RUNNER`
 
-## Recent Features (Dec 2025)
-
-- **AI Players**: Add AI players to games via OpenRouter/Gemini
-- **Premium Themes**: 4 visual themes (kenya, mono, vintage-paper, hyper)
-- **Poem Sharing**: Copy poem URLs to clipboard with analytics
-- **Help Modal**: Floating "?" button explains gameplay
-- **WordSlots**: Genkoyoushi-inspired word count indicator
-- **Pen Names**: Author display name captured at write-time
-
 ## Code Patterns
 
 ### Parallel Database Operations

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -361,16 +361,70 @@ Before deploying to production:
 
 If deployment issues occur:
 
+### Release pipeline gotcha
+
+The Landmark release action runs semantic-release in its own runtime, which
+has Node but **no `pnpm` on PATH**. Do not add a `pnpm`-shelling step (e.g.
+`@semantic-release/exec` with a `pnpm ...` `prepareCmd`) to `.releaserc.js` —
+it will fail with exit 127 and silently abort the release before it tags a
+version (see #276 / commit `d431210`, which dropped exactly this step and
+excluded `CHANGELOG.md` from `format:check` instead). If a generated artifact
+needs formatting, exclude it from the gate rather than shelling out to pnpm
+from inside the release action.
+
 ### Vercel Rollback
 
-Promote the last known-good deployment with your standard `vercel` CLI workflow.
+Promote the last known-good deployment:
+
+```bash
+vercel rollback [deployment-url-or-id]
+# or, with no argument, roll back to the previous production deployment:
+vercel rollback
+```
+
+Check `vercel rollback status` if a rollback is already in flight.
 
 ### Convex Rollback
 
-Convex doesn't support rollback of environment variables. If needed:
+Convex has no built-in "rollback" — there is no equivalent of `vercel
+rollback` for Convex functions or schema. Two drills exist depending on what
+broke:
 
-1. Update environment variables to previous values
-2. Redeploy Vercel (environment variables take effect immediately in Convex)
+**Env var rollback** (a bad env var change):
+
+1. Update the environment variable(s) back to previous values:
+   `pnpm exec convex env set <KEY> "<previous-value>" production`
+2. Redeploy Vercel (`vercel --prod`) — env vars take effect immediately in
+   Convex, no separate Convex deploy needed.
+
+**Forward-redeploy-of-prior-SHA** (a bad function/schema change):
+
+Convex deploys are forward-only, so "rolling back" means redeploying the
+last-known-good code, not reverting Convex state:
+
+1. Identify the last good commit SHA (the one before the breaking deploy).
+2. `git checkout <prior-sha> -- convex/` to stage the prior Convex source
+   (or work from a branch/worktree at that SHA if the app code also needs to
+   match).
+3. `pnpm exec convex deploy` to push that prior version forward as the new
+   current deployment.
+4. Once the underlying bug is fixed, forward-deploy the fixed version the
+   same way — don't leave the deployment pinned to the old SHA.
+
+**Data export/restore drill** (recover from bad data, not bad code):
+
+```bash
+# Before a risky migration or mutation, export a safety snapshot:
+pnpm exec convex export --path backup-$(date +%Y%m%d).zip
+
+# To restore from a snapshot (overwrites current deployment data — confirm
+# target deployment with `pnpm exec convex env list` first):
+pnpm exec convex import backup-<date>.zip
+```
+
+`convex import` replaces data in the target deployment; always verify
+`CONVEX_DEPLOYMENT` / the `--prod`/`--preview` flag points at the intended
+deployment before running it against anything with real player data.
 
 ## Additional Resources
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,86 +1,13 @@
 # Linejam Vision
 
-Status: canonical · Last revised 2026-06-17 (first draft, from /groom mega-sweep)
+This file is retired. `VISION.md` (repo root) is the canonical north star —
+read that one first. `project.md` is the deeper product brief (current focus,
+glossary, quality bar, patterns, anti-goals).
 
-## Audience and job-to-be-done
-
-**Audience:** small groups of friends, coworkers, or strangers who want a
-low-friction creative icebreaker that leaves behind something worth sharing.
-Secondary: long-distance friend groups who want a slow, asynchronous creative
-ritual.
-
-**JTBD:** "Give us a shared creative moment that produces an artifact we'd
-actually re-read and share — without requiring anyone to be good at poetry."
-
-Linejam is a party game, not a poetry tool. The constraint (write the next
-line, see only the previous one) is the mechanic; the reveal ceremony and the
-shared recap are the product.
-
-## Category
-
-Synchronous-and-asynchronous collaborative party game with an AI co-author
-option. Nearest neighbors: Gartic Phone (reveal-driven party game), Jackbox
-(audience + party packs), Exquisite Corpse (the format's origin), Codenames
-Online (low-friction join).
-
-## Standards
-
-1. **The room never dies.** No group should lose their session because one
-   human closed a tab or the host left. (Backed by backlog 016.)
-2. **Joining is instant.** A friend with a phone should be in the game in
-   under 10 seconds — code, link, or QR.
-3. **AI is a collaborator, not filler.** AI lines should read as intentional
-   contributions; personas should be verifiably distinct; player text must
-   not be able to hijack the AI.
-4. **Sharing is the growth loop.** Every completed session produces a
-   beautiful, context-rich, shareable recap that makes outsiders want to
-   play — and gives the returning group a one-tap "play again."
-5. **The artifact persists.** Groups and poems accumulate into a collection
-   that rewards return visits.
-6. **Operationally boring.** A cold agent or operator can run, debug, and
-   recover the deployed surfaces from AGENTS.md + docs alone.
-
-## Non-goals
-
-- Not a creative-writing workshop or critique platform.
-- Not a competitive/ranked game. No leaderboards across rooms.
-- Not a mobile app — the web surface is the product.
-- No user-generated custom game modes in the near term; modes are curated.
-
-## Strategic bets
-
-1. **The reveal is the viral product.** Pass-the-poem is the input; the
-   ceremony, recap, and shareable artifact are the content. Invest
-   disproportionately in the reveal-and-share loop over the writing UI.
-   (ExemplarPremise + RevealVirality lanes.)
-2. **Groups are first-class.** Promote rooms into persistent groups with a
-   roster, anthology, and comeback cadence. The 4-letter code is a join
-   mechanic, not an identity. (ProductValue lane.)
-3. **Time-agnostic play.** Ship an async (turn-over-days) mode so the same
-   format serves a 10-minute live jam and a multi-day correspondence circle.
-   (ExemplarPremise lane; the reveal/recap stack already points here.)
-4. **AI as a dial.** Lift the one-AI-seat cap; let any seat count be filled
-   with distinct, evaluable personas; support solo/duo practice jams.
-   (AIPlayerQuality + ProductValue lanes.)
-
-## What excellent looks like in 6–12 months
-
-- A group plays a live Quick Jam in 10 minutes, shares the recap, and the
-  same group returns the next week to a persistent group hub with their
-  anthology and a new weekly prompt.
-- A long-distance friend group plays asynchronously over a week, gets a
-  turn notification, and finishes a poem together without scheduling a call.
-- A streamer's audience spectates a jam, hearts poems, and joins the next
-  room via QR.
-- AI co-authors are verifiably on-persona, can't be prompt-injected via poem
-  text, and fill any empty seat — and the team has an eval harness that
-  catches persona drift before players do.
-- No room has ever stranded in `IN_PROGRESS`; the abandonment cron is so
-  reliable that "stuck room" is a phrase no operator has used in months.
-
-## How to use this vision
-
-Every backlog item should name which standard it advances, which bet it
-de-risks, or which non-goal it enforces. A ticket that doesn't move any of
-these is a candidate for deletion. Revise this doc when live evidence
-contradicts it — do not bury direction changes in chat only.
+The standards, strategic bets, and "what excellent looks like" content this
+file used to carry are superseded by `VISION.md`'s "What Must Stay True" /
+"What Linejam Refuses" / "Current Bets" sections. Where they diverged (this
+file leaned toward expansion — groups as first-class, async play, lifting the
+AI-seat cap; `VISION.md` holds the line on one core mode until launch), treat
+`VISION.md` as authoritative. If you want to write a new product-vision doc,
+edit `VISION.md` instead of creating a competing one.

--- a/project.md
+++ b/project.md
@@ -42,35 +42,15 @@ A digital version of the paper-folding poetry game—casual multiplayer fun with
 
 ## Patterns to Follow
 
-### Parallel Convex Mutations
+Code patterns and snippets live in `AGENTS.md`, not here — one copy, not a
+triplicated one:
 
-```typescript
-// GOOD — parallelize independent operations
-await Promise.all(
-  items.map((item) => ctx.db.patch(item._id, { field: value }))
-);
-```
-
-### Auth Helper
-
-```typescript
-// convex/lib/auth.ts — always use this, never re-implement
-const user = await getUser(ctx, args.guestId);
-```
-
-### Error Capture (Frontend)
-
-```typescript
-import { captureError } from '@/lib/error';
-captureError(err, { userId, operation: 'submitLine' });
-```
-
-### Structured Logging (Convex)
-
-```typescript
-import { logError } from './lib/errors';
-logError('API call failed', error, { roomId, round });
-```
+- Parallel Convex mutations, N+1 batching, loop-safety guards: `AGENTS.md`
+  → "Code Patterns".
+- The auth helper (`convex/lib/auth.ts`, Clerk + guest-UUID fallback):
+  `AGENTS.md` → "Architecture" → "Auth Pattern".
+- Frontend error capture (`captureError`) and Convex structured logging
+  (`logError`): `AGENTS.md` → "Observability".
 
 ## Stretch Goal
 
@@ -95,5 +75,7 @@ them, small revenue cut per book.
 
 ---
 
-_Last updated: 2026-06-25_
-_Updated during: /groom session (absorbed vision.md, which is now removed)_
+_Last updated: 2026-07-04_
+_Updated during: doc-truth sweep (backlog 026). `docs/vision.md` was not_
+_removed — it's demoted to a pointer at root `VISION.md`, the actual north_
+_star. This section no longer restates AGENTS.md's code patterns._


### PR DESCRIPTION
## Summary

Addresses `backlog.d/026-doc-truth-and-runbook-sweep.md`: a cold agent should get one un-contradicted answer to "what is the north star, what runs when I push, and how do I roll back."

- **`docs/vision.md`** self-declared `Status: canonical` while diverging from the real north star. Demoted to a pointer instead of deleting it (non-destructive default per the ticket). **Deviation from the ticket's literal text:** the ticket says point it at `project.md`, but `project.md` has itself been demoted — `AGENTS.md`'s own "Ground-Truth Pointers" section (line 51) already names root `VISION.md` as the canonical north star. Pointing the retired file at `project.md` would send readers to the wrong doc and contradict `AGENTS.md`. Pointed at `VISION.md` instead, with `project.md` named as the deeper brief — matching the convention already in place.
- **`project.md`**'s footer claimed `vision.md` "is now removed" — false, it's demoted, not deleted. Fixed.
- **`AGENTS.md`**'s frozen "Recent Features (Dec 2025)" section removed — every feature it listed (AI Players, Themes, Poem Sharing, Help Modal, WordSlots, Pen Names) is already documented elsewhere (Stack & Boundaries, Theme System) and the list wasn't being kept current.
- **Patterns de-triplication:** `CLAUDE.md` is already a symlink to `AGENTS.md` (confirmed — not two files), so the "exists in exactly one file" half of the oracle was already true. Fixed the actual duplication: `project.md`'s "Patterns to Follow" section restated 4 code snippets that live in `AGENTS.md` (Code Patterns, Auth Pattern, Observability). Replaced with pointers.
- **Release/rollback runbook** added to `docs/deployment.md`'s Rollback section:
  - Landmark release action has no `pnpm` on PATH — don't add a pnpm-shelling `prepareCmd` to `.releaserc.js` (traced to the actual fix, #276 / commit `d431210`).
  - The real `vercel rollback` command (was previously "use your standard vercel CLI workflow" — no command given).
  - A forward-redeploy-of-prior-SHA drill for bad Convex function/schema deploys (Convex has no rollback primitive, only forward deploys).
  - A `convex export` / `convex import` data backup/restore drill (previously undocumented).

## Sweep inventory

**Fixed (mechanical + judgment calls above):**
- `docs/vision.md` retired to pointer
- `project.md` footer + Patterns section
- `AGENTS.md` stale Recent Features section
- `docs/deployment.md` Rollback section expanded

**Flagged, not touched (judgment calls for a human):**
- `AGENTS.md`'s "Known-Debt Map" section ("No open known-debt rows... No known issues currently tracked") — this appears to already be the fixed/renamed version of what the ticket calls "Known Issues (None currently tracked)" frozen boilerplate. It already derives from `backlog.d/_done/` per the oracle's intent. Left as-is; flagging in case there's a further staleness concern I'm not positioned to judge (e.g. whether "no known debt" is still true given #291's security hardening work).
- Did not do a full second-pass sweep of every doc under `docs/` for other self-contradicting "canonical" claims beyond the `grep -ri canonical docs/` check (see oracle verification below) — the other two hits (`docs/testing.md`, `docs/ops/canary-responder.md`) are non-competing uses of the word ("canonical guest flow", "canonical event taxonomy") and don't claim to be *the* product vision.

**Residuals:**
- The content divergence between old `docs/vision.md` (envisioned groups-as-first-class, async play, lifting the AI-seat cap) and current `VISION.md` (holds the line on one core mode until launch) is noted in the new pointer file but not reconciled — that's a product-direction call, not a doc-truth one.

## Verification

- `grep -ri "canonical" docs/` — only non-competing uses remain (confirmed).
- `pnpm typecheck` — clean.
- `pnpm lint` — clean.
- `pnpm format:check` — clean.
- Pre-push hook ran full local gate: typecheck, lint, and `vitest run` (101 test files, 1113 tests passed, 1 skipped) — all green.

## Test plan

- [x] Docs-only change; no runtime surface to exercise.
- [x] Local gates (typecheck/lint/format/test) all green via pre-push hook.
- [ ] Human ratification of the `docs/vision.md` → `VISION.md` pointer (vs. ticket's literal `project.md` wording) and the flagged Known-Debt Map item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)