### PR TITLE
fix(convex): bound launch reads and live game failures

### DIFF
--- a/app/room/[code]/page.tsx
+++ b/app/room/[code]/page.tsx
@@ -8,6 +8,7 @@ import type { Doc } from '@/convex/_generated/dataModel';
 import { AuthErrorState } from '@/components/AuthErrorState';
 import { Lobby } from '@/components/Lobby';
 import { RevealPhase } from '@/components/RevealPhase';
+import { RoomPanelErrorBoundary } from '@/components/RoomPanelErrorBoundary';
 import { RoomChrome } from '@/components/RoomChrome';
 import { Button } from '@/components/ui/Button';
 import { WritingScreen } from '@/components/WritingScreen';
@@ -83,7 +84,11 @@ function ResolvedRoomPage({
 
   if (room.status === 'LOBBY') {
     return (
-      <>
+      <RoomPanelErrorBoundary
+        key={`${code}:lobby`}
+        roomCode={code}
+        panel="lobby"
+      >
         <RoomChrome
           roomCode={code}
           {...buildLobbyChromeCopy({
@@ -92,23 +97,38 @@ function ResolvedRoomPage({
           })}
         />
         <Lobby room={room} players={players} isHost={isHost} />
-      </>
+      </RoomPanelErrorBoundary>
     );
   }
 
   if (room.status === 'IN_PROGRESS') {
-    return <WritingScreen roomCode={code} showChrome />;
+    return (
+      <RoomPanelErrorBoundary
+        key={`${code}:writing`}
+        roomCode={code}
+        panel="writing"
+      >
+        <WritingScreen roomCode={code} showChrome />
+      </RoomPanelErrorBoundary>
+    );
   }
 
   if (room.status === 'COMPLETED') {
-    return <RevealPhase roomCode={code} showChrome />;
+    return (
+      <RoomPanelErrorBoundary
+        key={`${code}:reveal`}
+        roomCode={code}
+        panel="reveal"
+      >
+        <RevealPhase roomCode={code} showChrome />
+      </RoomPanelErrorBoundary>
+    );
   }
 
   return <UnexpectedRoomState code={code} status={String(room.status)} />;
 }
 
-export default function RoomPage({ params }: RoomPageProps) {
-  const { code } = use(params);
+function RoomPageContent({ code }: { code: string }) {
   const { isLoading, guestToken, authError, retryAuth } = useUser();
   const roomState = useQuery(api.rooms.getRoomState, {
     code,
@@ -144,4 +164,14 @@ export default function RoomPage({ params }: RoomPageProps) {
   }
 
   return <ResolvedRoomPage code={code} roomState={roomState} />;
+}
+
+export default function RoomPage({ params }: RoomPageProps) {
+  const { code } = use(params);
+
+  return (
+    <RoomPanelErrorBoundary roomCode={code} panel="room">
+      <RoomPageContent code={code} />
+    </RoomPanelErrorBoundary>
+  );
 }

--- a/components/RoomPanelErrorBoundary.tsx
+++ b/components/RoomPanelErrorBoundary.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { Button } from './ui/Button';
+import { captureError } from '../lib/error';
+
+type RoomPanelErrorBoundaryProps = {
+  roomCode: string;
+  panel: string;
+  children: ReactNode;
+};
+
+type RoomPanelErrorBoundaryState = {
+  error: Error | null;
+};
+
+export class RoomPanelErrorBoundary extends Component<
+  RoomPanelErrorBoundaryProps,
+  RoomPanelErrorBoundaryState
+> {
+  state: RoomPanelErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): RoomPanelErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    captureError(error, {
+      operation: 'renderRoomPanel',
+      roomCode: this.props.roomCode,
+      panel: this.props.panel,
+      componentStack: info.componentStack ?? undefined,
+    });
+  }
+
+  componentDidUpdate(previousProps: RoomPanelErrorBoundaryProps) {
+    if (
+      this.state.error &&
+      (previousProps.roomCode !== this.props.roomCode ||
+        previousProps.panel !== this.props.panel)
+    ) {
+      this.setState({ error: null });
+    }
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children;
+
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--color-background)] gap-4 p-6 text-center">
+        <span className="text-[var(--color-text-primary)] text-xl">
+          This room panel needs a refresh
+        </span>
+        <span className="text-[var(--color-text-muted)] text-sm max-w-xl">
+          The room is still open, but this panel failed while syncing live data.
+          Refresh the panel to rejoin the current state.
+        </span>
+        <Button variant="secondary" onClick={() => window.location.reload()}>
+          Refresh
+        </Button>
+      </div>
+    );
+  }
+}

--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -513,6 +513,71 @@ export const scheduleAiTurn = internalMutation({
 
 /** How long the LLM path gets before the fallback line lands. */
 const AI_SAFETY_NET_MS = 25_000;
+const AI_ROUND_GENERATION_LOCK_STALE_MS = 60_000;
+
+export const claimAiRoundGeneration = internalMutation({
+  args: {
+    roomId: v.id('rooms'),
+    gameId: v.id('games'),
+    round: v.number(),
+  },
+  handler: async (ctx, { roomId, gameId, round }) => {
+    const now = Date.now();
+    const owner = crypto.randomUUID();
+    const existing = await ctx.db
+      .query('aiRoundLocks')
+      .withIndex('by_game_round', (q) =>
+        q.eq('gameId', gameId).eq('round', round)
+      )
+      .first();
+
+    if (
+      existing?.status === 'running' &&
+      now - existing.updatedAt < AI_ROUND_GENERATION_LOCK_STALE_MS
+    ) {
+      return { claimed: false as const };
+    }
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        roomId,
+        owner,
+        status: 'running',
+        claimedAt: now,
+        updatedAt: now,
+      });
+      return { claimed: true as const, lockId: existing._id, owner };
+    }
+
+    const lockId = await ctx.db.insert('aiRoundLocks', {
+      roomId,
+      gameId,
+      round,
+      owner,
+      status: 'running',
+      claimedAt: now,
+      updatedAt: now,
+    });
+
+    return { claimed: true as const, lockId, owner };
+  },
+});
+
+export const finishAiRoundGeneration = internalMutation({
+  args: {
+    lockId: v.id('aiRoundLocks'),
+    owner: v.string(),
+  },
+  handler: async (ctx, { lockId, owner }) => {
+    const existing = await ctx.db.get(lockId);
+    if (!existing) return;
+    if (existing.owner !== owner) return;
+    await ctx.db.patch(lockId, {
+      status: 'finished',
+      updatedAt: Date.now(),
+    });
+  },
+});
 
 /**
  * Last-resort committer for an AI turn. Idempotent: does nothing when the
@@ -592,7 +657,17 @@ export const generateLineForRound = internalAction({
     round: v.number(),
   },
   handler: async (ctx, { roomId, gameId, round }) => {
+    let generationLock: { lockId: Id<'aiRoundLocks'>; owner: string } | null =
+      null;
     try {
+      const claim = await ctx.runMutation(internal.ai.claimAiRoundGeneration, {
+        roomId,
+        gameId,
+        round,
+      });
+      if (!claim.claimed) return;
+      generationLock = { lockId: claim.lockId, owner: claim.owner };
+
       // Load game state directly (not through room.currentGameId which is race-prone)
       const game = await ctx.runQuery(internal.ai.getGameState, { gameId });
       if (!game) return;
@@ -737,6 +812,12 @@ export const generateLineForRound = internalAction({
         })
         .catch(() => {});
       throw error;
+    } finally {
+      if (generationLock) {
+        await ctx
+          .runMutation(internal.ai.finishAiRoundGeneration, generationLock)
+          .catch(() => {});
+      }
     }
   },
 });

--- a/convex/archive.ts
+++ b/convex/archive.ts
@@ -44,6 +44,26 @@ export interface ArchiveStats {
   totalLinesWritten: number;
 }
 
+const DEFAULT_ARCHIVE_LIMIT = 24;
+const MAX_ARCHIVE_LIMIT = 48;
+const DEFAULT_RECENT_PUBLIC_LIMIT = 5;
+const MAX_RECENT_PUBLIC_LIMIT = 10;
+const MAX_LINES_PER_POEM = 9;
+const PUBLIC_POEMS_PER_ROOM = 2;
+const RECENT_PUBLIC_ROOM_WINDOW_FACTOR = 4;
+const MAX_RECENT_PUBLIC_ROOM_WINDOW = 40;
+
+function boundedLimit(
+  value: number | undefined,
+  fallback: number,
+  max: number
+) {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  const rounded = Math.floor(value);
+  if (rounded <= 0) return fallback;
+  return Math.min(rounded, max);
+}
+
 /**
  * Get all poems for the user's archive with enriched metadata.
  *
@@ -59,18 +79,27 @@ export interface ArchiveStats {
 export const getArchiveData = query({
   args: {
     guestToken: v.optional(v.string()),
+    limit: v.optional(v.number()),
   },
-  handler: async (ctx, { guestToken }) => {
+  handler: async (ctx, { guestToken, limit }) => {
     const user = await getUser(ctx, guestToken);
     if (!user) {
       return { poems: [] as ArchivePoem[], stats: null };
     }
 
-    // Step 1: Find all lines written by user
+    const poemLimit = boundedLimit(
+      limit,
+      DEFAULT_ARCHIVE_LIMIT,
+      MAX_ARCHIVE_LIMIT
+    );
+    const authorLineWindow = poemLimit * MAX_LINES_PER_POEM;
+
+    // Step 1: Find a bounded window of latest lines written by user.
     const userLines = await ctx.db
       .query('lines')
-      .withIndex('by_author', (q) => q.eq('authorUserId', user._id))
-      .collect();
+      .withIndex('by_author_created', (q) => q.eq('authorUserId', user._id))
+      .order('desc')
+      .take(authorLineWindow);
 
     // No poems yet
     if (userLines.length === 0) {
@@ -85,30 +114,49 @@ export const getArchiveData = query({
       };
     }
 
-    // Step 2: Get unique poem IDs and fetch poems + favorites in parallel
-    const poemIds = [...new Set(userLines.map((l) => l.poemId))];
+    // Step 2: Get unique poem IDs from the bounded line window.
+    const poemIds: Id<'poems'>[] = [];
+    const seenPoemIds = new Set<Id<'poems'>>();
+    for (const line of userLines) {
+      if (seenPoemIds.has(line.poemId)) continue;
+      seenPoemIds.add(line.poemId);
+      poemIds.push(line.poemId);
+      if (poemIds.length >= poemLimit) break;
+    }
 
-    const [poemsRaw, favorites] = await Promise.all([
+    const [poemsRaw, favoriteRows] = await Promise.all([
       Promise.all(poemIds.map((id) => ctx.db.get(id))),
-      ctx.db
-        .query('favorites')
-        .withIndex('by_user', (q) => q.eq('userId', user._id))
-        .collect(),
+      Promise.all(
+        poemIds.map((poemId) =>
+          ctx.db
+            .query('favorites')
+            .withIndex('by_user_poem', (q) =>
+              q.eq('userId', user._id).eq('poemId', poemId)
+            )
+            .first()
+        )
+      ),
     ]);
 
     // Filter out null poems and create lookup
     const poems = poemsRaw.filter(
       (p): p is NonNullable<typeof p> => p !== null
     );
-    const favoriteMap = new Map(favorites.map((f) => [f.poemId, f.createdAt]));
+    poems.sort((a, b) => b.createdAt - a.createdAt);
+    const favoriteMap = new Map(
+      favoriteRows
+        .filter((f): f is NonNullable<typeof f> => f !== null)
+        .map((f) => [f.poemId, f.createdAt])
+    );
 
-    // Step 3: Fetch all lines for all poems in parallel
+    // Step 3: Fetch bounded poem lines in parallel. Classic poems have 9 lines.
     const allPoemLines = await Promise.all(
       poems.map((poem) =>
         ctx.db
           .query('lines')
-          .withIndex('by_poem', (q) => q.eq('poemId', poem._id))
-          .collect()
+          .withIndex('by_poem_index', (q) => q.eq('poemId', poem._id))
+          .order('asc')
+          .take(MAX_LINES_PER_POEM)
       )
     );
 
@@ -144,9 +192,7 @@ export const getArchiveData = query({
 
     // Step 7: Build enriched poem objects
     const enrichedPoems: ArchivePoem[] = poems.map((poem, poemIndex) => {
-      const lines = allPoemLines[poemIndex].sort(
-        (a, b) => a.indexInPoem - b.indexInPoem
-      );
+      const lines = allPoemLines[poemIndex];
       const uniqueAuthors = new Set(lines.map((l) => l.authorUserId));
       const favoritedAt = favoriteMap.get(poem._id) || null;
 
@@ -179,9 +225,6 @@ export const getArchiveData = query({
       };
     });
 
-    // Sort by creation date descending (most recent first)
-    enrichedPoems.sort((a, b) => b.createdAt - a.createdAt);
-
     // Step 8: Calculate stats
     const allCollaboratorIds = new Set<string>();
     for (const poem of enrichedPoems) {
@@ -195,11 +238,16 @@ export const getArchiveData = query({
       }
     }
 
+    const returnedPoemIds = new Set(enrichedPoems.map((poem) => poem._id));
+    const returnedUserLineCount = userLines.filter((line) =>
+      returnedPoemIds.has(line.poemId)
+    ).length;
+
     const stats: ArchiveStats = {
       totalPoems: enrichedPoems.length,
       totalFavorites: enrichedPoems.filter((p) => p.isFavorited).length,
       uniqueCollaborators: allCollaboratorIds.size,
-      totalLinesWritten: userLines.length,
+      totalLinesWritten: returnedUserLineCount,
     };
 
     return { poems: enrichedPoems, stats };
@@ -215,63 +263,57 @@ export const getRecentPublicPoems = query({
     limit: v.optional(v.number()),
   },
   handler: async (ctx, { limit = 5 }) => {
-    // Get recent poems from rooms that are completed
+    const poemLimit = boundedLimit(
+      limit,
+      DEFAULT_RECENT_PUBLIC_LIMIT,
+      MAX_RECENT_PUBLIC_LIMIT
+    );
+    const roomWindow = Math.min(
+      MAX_RECENT_PUBLIC_ROOM_WINDOW,
+      Math.max(poemLimit * RECENT_PUBLIC_ROOM_WINDOW_FACTOR, poemLimit)
+    );
+
+    // Get a bounded, indexed window of recently created completed rooms.
     const rooms = await ctx.db
       .query('rooms')
-      .filter((q) => q.eq(q.field('status'), 'COMPLETED'))
+      .withIndex('by_status_created', (q) => q.eq('status', 'COMPLETED'))
       .order('desc')
-      .take(20);
+      .take(roomWindow);
 
     if (rooms.length === 0) {
       return [];
     }
 
-    // Batch fetch all poems for these rooms in a single query
-    const roomIdSet = new Set(rooms.map((r) => r._id));
-    const allRoomPoems = await ctx.db
-      .query('poems')
-      .filter((q) =>
-        q.or(...rooms.map((room) => q.eq(q.field('roomId'), room._id)))
+    const poemsByRoom = await Promise.all(
+      rooms.map((room) =>
+        ctx.db
+          .query('poems')
+          .withIndex('by_room', (q) => q.eq('roomId', room._id))
+          .order('desc')
+          .take(PUBLIC_POEMS_PER_ROOM)
       )
-      .collect();
-
-    // Group poems by room and take up to 2 per room
-    const poemsByRoom = new Map<Id<'rooms'>, typeof allRoomPoems>();
-    for (const poem of allRoomPoems) {
-      if (!roomIdSet.has(poem.roomId)) continue;
-      const existing = poemsByRoom.get(poem.roomId) || [];
-      if (existing.length < 2) {
-        poemsByRoom.set(poem.roomId, [...existing, poem]);
-      }
-    }
-    const poems = [...poemsByRoom.values()].flat().slice(0, limit * 2);
+    );
+    const poems = poemsByRoom
+      .flat()
+      .slice(0, poemLimit * PUBLIC_POEMS_PER_ROOM);
 
     if (poems.length === 0) {
       return [];
     }
 
-    // Batch fetch all lines for all poems in a single query
-    const poemIdSet = new Set(poems.map((p) => p._id));
-    const allLines = await ctx.db
-      .query('lines')
-      .filter((q) =>
-        q.or(...poems.map((poem) => q.eq(q.field('poemId'), poem._id)))
+    const linesByPoem = await Promise.all(
+      poems.map((poem) =>
+        ctx.db
+          .query('lines')
+          .withIndex('by_poem_index', (q) => q.eq('poemId', poem._id))
+          .order('asc')
+          .take(MAX_LINES_PER_POEM)
       )
-      .collect();
-
-    // Group lines by poemId for O(1) lookup
-    const linesByPoemId = new Map<Id<'poems'>, typeof allLines>();
-    for (const line of allLines) {
-      if (!poemIdSet.has(line.poemId)) continue;
-      const existing = linesByPoemId.get(line.poemId) || [];
-      linesByPoemId.set(line.poemId, [...existing, line]);
-    }
+    );
 
     // Build poemsWithLines without additional database calls
-    const poemsWithLines = poems.map((poem) => {
-      const lines = (linesByPoemId.get(poem._id) || []).sort(
-        (a, b) => a.indexInPoem - b.indexInPoem
-      );
+    const poemsWithLines = poems.map((poem, index) => {
+      const lines = linesByPoem[index];
       const uniqueAuthors = new Set(lines.map((l) => l.authorUserId));
 
       return {
@@ -282,9 +324,14 @@ export const getRecentPublicPoems = query({
       };
     });
 
-    // Filter to only poems with at least 3 lines (looks better in showcase)
-    const qualityPoems = poemsWithLines.filter((p) => p.lines.length >= 3);
+    // Keep only poems with at least 3 lines (looks better in showcase).
+    const qualityPoems = [];
+    for (const poem of poemsWithLines) {
+      if (poem.lines.length < 3) continue;
+      qualityPoems.push(poem);
+      if (qualityPoems.length >= poemLimit) break;
+    }
 
-    return qualityPoems.slice(0, limit);
+    return qualityPoems;
   },
 });

--- a/convex/poems.ts
+++ b/convex/poems.ts
@@ -16,6 +16,21 @@ function isPublicSessionRecapEnabled(
   return game?.publicRecapEnabled === true;
 }
 
+const DEFAULT_MY_POEMS_LIMIT = 24;
+const MAX_MY_POEMS_LIMIT = 48;
+const MAX_LINES_PER_POEM = 9;
+
+function boundedLimit(
+  value: number | undefined,
+  fallback: number,
+  max: number
+) {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  const rounded = Math.floor(value);
+  if (rounded <= 0) return fallback;
+  return Math.min(rounded, max);
+}
+
 export const getPoemsForRoom = query({
   args: {
     roomCode: v.string(),
@@ -115,19 +130,35 @@ export const getPoemDetail = query({
 export const getMyPoems = query({
   args: {
     guestToken: v.optional(v.string()),
+    limit: v.optional(v.number()),
   },
-  handler: async (ctx, { guestToken }) => {
+  handler: async (ctx, { guestToken, limit }) => {
     const user = await getUser(ctx, guestToken);
     if (!user) return [];
 
-    // Find all lines written by user
+    const poemLimit = boundedLimit(
+      limit,
+      DEFAULT_MY_POEMS_LIMIT,
+      MAX_MY_POEMS_LIMIT
+    );
+    const authorLineWindow = poemLimit * MAX_LINES_PER_POEM;
+
+    // Find a bounded window of latest lines written by user.
     const lines = await ctx.db
       .query('lines')
-      .withIndex('by_author', (q) => q.eq('authorUserId', user._id))
-      .collect();
+      .withIndex('by_author_created', (q) => q.eq('authorUserId', user._id))
+      .order('desc')
+      .take(authorLineWindow);
 
     // Get unique poem IDs
-    const poemIds = [...new Set(lines.map((l) => l.poemId))];
+    const poemIds: Id<'poems'>[] = [];
+    const seenPoemIds = new Set<Id<'poems'>>();
+    for (const line of lines) {
+      if (seenPoemIds.has(line.poemId)) continue;
+      seenPoemIds.add(line.poemId);
+      poemIds.push(line.poemId);
+      if (poemIds.length >= poemLimit) break;
+    }
     if (poemIds.length === 0) return [];
 
     // Batch fetch all poems in parallel
@@ -135,6 +166,7 @@ export const getMyPoems = query({
     const poems = poemsRaw.filter(
       (p): p is NonNullable<typeof p> => p !== null
     );
+    poems.sort((a, b) => b.createdAt - a.createdAt);
 
     // Batch fetch all rooms and first lines in parallel
     const uniqueRoomIds = [...new Set(poems.map((p) => p.roomId))];

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -38,7 +38,8 @@ export default defineSchema({
     selectedMode: v.optional(v.string()),
   })
     .index('by_code', ['code'])
-    .index('by_host', ['hostUserId']),
+    .index('by_host', ['hostUserId'])
+    .index('by_status_created', ['status', 'createdAt']),
 
   roomPlayers: defineTable({
     roomId: v.id('rooms'),
@@ -111,7 +112,8 @@ export default defineSchema({
   })
     .index('by_poem', ['poemId'])
     .index('by_poem_index', ['poemId', 'indexInPoem'])
-    .index('by_author', ['authorUserId']),
+    .index('by_author', ['authorUserId'])
+    .index('by_author_created', ['authorUserId', 'createdAt']),
 
   aiTurns: defineTable({
     roomId: v.id('rooms'),
@@ -140,6 +142,16 @@ export default defineSchema({
     estimatedCostMicros: v.optional(v.number()),
     updatedAt: v.number(),
   }).index('by_day', ['day']),
+
+  aiRoundLocks: defineTable({
+    roomId: v.id('rooms'),
+    gameId: v.id('games'),
+    round: v.number(),
+    owner: v.string(),
+    status: v.union(v.literal('running'), v.literal('finished')),
+    claimedAt: v.number(),
+    updatedAt: v.number(),
+  }).index('by_game_round', ['gameId', 'round']),
 
   favorites: defineTable({
     userId: v.id('users'),

--- a/docs/evidence/linejam-021/after-scan.md
+++ b/docs/evidence/linejam-021/after-scan.md
@@ -1,0 +1,44 @@
+# linejam-021 after scan
+
+Captured after implementation on branch `perf/linejam-021-index-resilience`.
+
+## Static source scan
+
+Command:
+
+```bash
+rg -n "\.filter\(\(q\)|getArchiveData|getRecentPublicPoems|getMyPoems|by_status_created|by_author_created|aiRoundLocks" convex/archive.ts convex/poems.ts convex/schema.ts convex/ai.ts
+```
+
+Output:
+
+```text
+convex/ai.ts:526:    const owner = crypto.randomUUID();
+convex/ai.ts:528:      .query('aiRoundLocks')
+convex/ai.ts:544:        owner,
+convex/ai.ts:549:      return { claimed: true as const, lockId: existing._id, owner };
+convex/ai.ts:552:    const lockId = await ctx.db.insert('aiRoundLocks', {
+convex/ai.ts:556:      owner,
+convex/ai.ts:562:    return { claimed: true as const, lockId, owner };
+convex/ai.ts:568:    lockId: v.id('aiRoundLocks'),
+convex/ai.ts:569:    owner: v.string(),
+convex/ai.ts:571:  handler: async (ctx, { lockId, owner }) => {
+convex/ai.ts:574:    if (existing.owner !== owner) return;
+convex/ai.ts:660:    let generationLock: { lockId: Id<'aiRoundLocks'>; owner: string } | null =
+convex/ai.ts:669:      generationLock = { lockId: claim.lockId, owner: claim.owner };
+convex/schema.ts:42:    .index('by_status_created', ['status', 'createdAt']),
+convex/schema.ts:116:    .index('by_author_created', ['authorUserId', 'createdAt']),
+convex/schema.ts:146:  aiRoundLocks: defineTable({
+convex/schema.ts:150:    owner: v.string(),
+convex/poems.ts:130:export const getMyPoems = query({
+convex/poems.ts:149:      .withIndex('by_author_created', (q) => q.eq('authorUserId', user._id))
+convex/archive.ts:79:export const getArchiveData = query({
+convex/archive.ts:100:      .withIndex('by_author_created', (q) => q.eq('authorUserId', user._id))
+convex/archive.ts:261:export const getRecentPublicPoems = query({
+convex/archive.ts:279:      .withIndex('by_status_created', (q) => q.eq('status', 'COMPLETED'))
+```
+
+After verdict: the pre-implementation `getRecentPublicPoems` `.filter((q)` scans
+over `rooms`, `poems`, and `lines` are gone. Launch reads now use bounded
+windows over declared indexes, and AI generation has a persisted `(game, round)`
+lock table.

--- a/docs/evidence/linejam-021/baseline-scan.md
+++ b/docs/evidence/linejam-021/baseline-scan.md
@@ -1,0 +1,21 @@
+# linejam-021 baseline scan
+
+Captured before implementation on branch `perf/linejam-021-index-resilience`.
+
+## Static source scan
+
+Command:
+
+```bash
+rg -n "\.filter\(\(q\)|getArchiveData|getRecentPublicPoems|getMyPoems" convex/archive.ts convex/poems.ts
+```
+
+Findings:
+
+- `convex/archive.ts:71` - `getArchiveData` collects every line by author without an explicit page window.
+- `convex/archive.ts:220-221` - `getRecentPublicPoems` scans `rooms` with `filter(status === COMPLETED)`.
+- `convex/archive.ts:232-235` - `getRecentPublicPoems` scans `poems` with an `or(roomId...)` filter.
+- `convex/archive.ts:256-259` - `getRecentPublicPoems` scans `lines` with an `or(poemId...)` filter.
+- `convex/poems.ts:115-128` - `getMyPoems` collects every author line before deduping poems.
+
+Baseline verdict: launch/history read paths are not yet fully index-backed or page-windowed.

--- a/docs/evidence/linejam-021/plan.html
+++ b/docs/evidence/linejam-021/plan.html
@@ -1,0 +1,196 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Linejam 021 Plan</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #fbfaf6;
+        --paper: #ffffff;
+        --ink: #17130f;
+        --muted: #6e665e;
+        --line: #ddd6cc;
+        --accent: #b63422;
+      }
+      body {
+        margin: 0;
+        font-family:
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
+        background: var(--bg);
+        color: var(--ink);
+      }
+      main {
+        width: min(1120px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 32px 0 56px;
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+        gap: 24px;
+        align-items: end;
+        min-height: 48vh;
+        border-bottom: 1px solid var(--line);
+        padding-bottom: 28px;
+      }
+      h1 {
+        font-family: Georgia, serif;
+        font-size: clamp(44px, 7vw, 88px);
+        line-height: 0.94;
+        margin: 0;
+        letter-spacing: 0;
+      }
+      h2 {
+        font-size: 13px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        margin: 0 0 12px;
+        color: var(--accent);
+      }
+      p {
+        line-height: 1.55;
+        margin: 0 0 12px;
+      }
+      code {
+        font-family: 'SFMono-Regular', Consolas, monospace;
+        font-size: 0.92em;
+      }
+      .panel,
+      .cell {
+        background: var(--paper);
+        border: 1px solid var(--line);
+        padding: 18px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 1px;
+        background: var(--line);
+        margin-top: 24px;
+        border: 1px solid var(--line);
+      }
+      .grid .cell {
+        border: 0;
+      }
+      ul {
+        padding-left: 18px;
+        margin: 0;
+      }
+      li {
+        margin: 7px 0;
+        line-height: 1.45;
+      }
+      .muted {
+        color: var(--muted);
+      }
+      @media (max-width: 820px) {
+        .hero,
+        .grid {
+          grid-template-columns: 1fr;
+        }
+        .hero {
+          min-height: auto;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="hero">
+        <div>
+          <p class="muted">linejam-021 / Powder run run-zYLl93nnskic</p>
+          <h1>Index the launch reads and isolate live-game query failures.</h1>
+          <p class="muted">
+            Chosen design: additive Convex indexes and bounded query windows,
+            plus a small room phase error boundary and a database-backed AI
+            round lock. No destructive schema migration; active rooms keep their
+            existing documents.
+          </p>
+        </div>
+        <aside class="panel">
+          <h2>Quality System</h2>
+          <p>
+            <strong>Outcome:</strong> landing/auth archive reads and live room
+            panels stay within Convex limits under busy public use.
+          </p>
+          <p>
+            <strong>Proof:</strong> focused Convex/component tests, static
+            scan-count evidence before/after, `pnpm ci:prepush`, and
+            artifact-only critic review.
+          </p>
+          <p>
+            <strong>Stop:</strong> any required production Convex sync,
+            schema-destructive migration, or failing fast gate blocks closeout.
+          </p>
+        </aside>
+      </section>
+
+      <section class="grid" aria-label="Execution contract">
+        <article class="cell">
+          <h2>Acceptance</h2>
+          <ul>
+            <li>
+              `getRecentPublicPoems` uses indexed room/poem/line reads, not
+              filtered table scans.
+            </li>
+            <li>
+              Personal and community history reads have explicit page windows.
+            </li>
+            <li>
+              One failed room phase query degrades that panel instead of
+              white-screening the whole room.
+            </li>
+            <li>
+              AI generation holds at most one in-flight OpenRouter action per
+              `(game, round)`.
+            </li>
+            <li>Evidence records before/after scan counts or timings.</li>
+          </ul>
+        </article>
+        <article class="cell">
+          <h2>Repo Anchors</h2>
+          <ul>
+            <li>`convex/schema.ts`: additive indexes only.</li>
+            <li>
+              `convex/archive.ts`, `convex/poems.ts`: launch/archive read paths.
+            </li>
+            <li>`convex/ai.ts`: AI action scheduling and safety net.</li>
+            <li>
+              `app/room/[code]/page.tsx`: phase-level degradation boundary.
+            </li>
+            <li>
+              `tests/convex/*`, `tests/app/room-page.test.tsx`: TDD surfaces.
+            </li>
+          </ul>
+        </article>
+        <article class="cell">
+          <h2>Verification System</h2>
+          <p>
+            <strong>Claim:</strong> launch/history reads are bounded and
+            indexed; room phase failures stay local.
+          </p>
+          <p>
+            <strong>Falsifier:</strong> `convex/archive.ts` still has unindexed
+            `filter` scans or a child query throw blanks the room shell.
+          </p>
+          <p>
+            <strong>Driver:</strong> focused Vitest files, source scan script,
+            `pnpm ci:prepush`.
+          </p>
+          <p>
+            <strong>Evidence packet:</strong> `docs/evidence/linejam-021/` plus
+            lane report.
+          </p>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/evidence/linejam-021/verification.md
+++ b/docs/evidence/linejam-021/verification.md
@@ -1,0 +1,64 @@
+# linejam-021 verification
+
+## Red tests
+
+Before implementation, focused tests failed for the expected reasons:
+
+- `tests/convex/archive.test.ts` and `tests/convex/poems.test.ts`: `limit` was
+  not accepted by archive/history queries.
+- `tests/convex/readPathGuards.test.ts`: `getRecentPublicPoems` still contained
+  `.filter((q)` scans and history queries had no explicit `.take(...)` window.
+- `tests/convex/aiLifecycle.test.ts`: no `claimAiRoundGeneration` /
+  `finishAiRoundGeneration` lock API existed.
+- `tests/app/room-page.test.tsx`: a thrown writing panel rendered an empty body
+  instead of a panel fallback.
+
+## Focused proof
+
+```bash
+pnpm vitest run tests/convex/readPathGuards.test.ts tests/convex/archive.test.ts tests/convex/poems.test.ts
+```
+
+Result: 3 files passed, 79 tests passed.
+
+```bash
+pnpm vitest run tests/convex/aiLifecycle.test.ts tests/app/room-page.test.tsx
+```
+
+Result: 2 files passed, 37 tests passed.
+
+## Repo gate
+
+```bash
+pnpm ci:prepush
+```
+
+Final result after critic fixes:
+
+```text
+Test Files  104 passed (104)
+Tests  1153 passed | 1 skipped (1154)
+Duration  74.37s
+```
+
+The command also completed `pnpm typecheck` and `pnpm lint` before Vitest.
+
+Known non-failing warning: existing Canary responder tests emit Vitest warnings
+about nested `vi.unmock(...)` hoisting. This lane did not modify those tests.
+
+## Fresh critic
+
+Fresh-context critic initially returned `BLOCKING: yes`:
+
+- stale AI lock reclaims were unfenced;
+- room panel error boundaries did not reset across panel/status changes.
+
+Fixes applied:
+
+- `aiRoundLocks` now carries an owner token, and `finishAiRoundGeneration` only
+  releases the current owner.
+- The regression test now covers stale reclaim plus old-owner finish.
+- `RoomPanelErrorBoundary` resets on `roomCode`/`panel` changes, and room status
+  panels are keyed by `roomCode:panel`.
+- The room page test now covers recovery from a failed writing panel after the
+  room moves to reveal.

--- a/tests/app/room-page.test.tsx
+++ b/tests/app/room-page.test.tsx
@@ -7,6 +7,10 @@ const mockReactUse = vi.fn();
 const mockUseClerkUser = vi.fn();
 const mockUseQuery = vi.fn();
 const mockPush = vi.fn();
+const mockPhaseFailure = vi.hoisted(() => ({
+  writing: false,
+  reveal: false,
+}));
 
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react');
@@ -46,11 +50,17 @@ vi.mock('@/components/WritingScreen', () => ({
   }: {
     roomCode: string;
     showChrome?: boolean;
-  }) => (
-    <div>
-      Writing view {roomCode} {showChrome ? 'chrome on' : 'chrome off'}
-    </div>
-  ),
+  }) => {
+    if (mockPhaseFailure.writing) {
+      throw new Error('assignment query failed');
+    }
+
+    return (
+      <div>
+        Writing view {roomCode} {showChrome ? 'chrome on' : 'chrome off'}
+      </div>
+    );
+  },
 }));
 
 vi.mock('@/components/RevealPhase', () => ({
@@ -60,11 +70,17 @@ vi.mock('@/components/RevealPhase', () => ({
   }: {
     roomCode: string;
     showChrome?: boolean;
-  }) => (
-    <div>
-      Reveal view {roomCode} {showChrome ? 'chrome on' : 'chrome off'}
-    </div>
-  ),
+  }) => {
+    if (mockPhaseFailure.reveal) {
+      throw new Error('reveal query failed');
+    }
+
+    return (
+      <div>
+        Reveal view {roomCode} {showChrome ? 'chrome on' : 'chrome off'}
+      </div>
+    );
+  },
 }));
 
 import RoomPage from '@/app/room/[code]/page';
@@ -80,6 +96,8 @@ describe('RoomPage', () => {
     vi.clearAllMocks();
     localStorage.clear();
     process.env.NEXT_PUBLIC_CANARY_API_KEY = '';
+    mockPhaseFailure.writing = false;
+    mockPhaseFailure.reveal = false;
     mockReactUse.mockReturnValue({ code: 'ABCD' });
     mockUseClerkUser.mockReturnValue({
       user: null,
@@ -247,6 +265,90 @@ describe('RoomPage', () => {
     expect(
       await screen.findByText(/Writing view ABCD chrome on/i)
     ).toBeInTheDocument();
+  });
+
+  it('keeps a writing query failure inside the room panel fallback', async () => {
+    mockPhaseFailure.writing = true;
+    mockUseQuery.mockImplementation((query) => {
+      const functionName = getFunctionName(
+        query as Parameters<typeof getFunctionName>[0]
+      );
+
+      if (functionName === 'rooms:getRoomState') {
+        return {
+          room: {
+            _id: 'room_1',
+            _creationTime: Date.now(),
+            code: 'ABCD',
+            hostUserId: 'user_1',
+            createdAt: Date.now(),
+            status: 'IN_PROGRESS',
+          },
+          players: [],
+          isHost: true,
+        };
+      }
+
+      return null;
+    });
+
+    renderRoomPage();
+
+    expect(
+      await screen.findByText(/this room panel needs a refresh/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/failed while syncing live data/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Writing view ABCD chrome on/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('recovers from a failed writing panel when the room moves to reveal', async () => {
+    let status: 'IN_PROGRESS' | 'COMPLETED' = 'IN_PROGRESS';
+    mockPhaseFailure.writing = true;
+    mockUseQuery.mockImplementation((query) => {
+      const functionName = getFunctionName(
+        query as Parameters<typeof getFunctionName>[0]
+      );
+
+      if (functionName === 'rooms:getRoomState') {
+        return {
+          room: {
+            _id: 'room_1',
+            _creationTime: Date.now(),
+            code: 'ABCD',
+            hostUserId: 'user_1',
+            createdAt: Date.now(),
+            status,
+          },
+          players: [],
+          isHost: true,
+        };
+      }
+
+      return null;
+    });
+
+    const { rerender } = renderRoomPage();
+    expect(
+      await screen.findByText(/this room panel needs a refresh/i)
+    ).toBeInTheDocument();
+
+    status = 'COMPLETED';
+    rerender(
+      <ThemeProvider>
+        <RoomPage params={Promise.resolve({ code: 'ABCD' })} />
+      </ThemeProvider>
+    );
+
+    expect(
+      await screen.findByText(/Reveal view ABCD chrome on/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/this room panel needs a refresh/i)
+    ).not.toBeInTheDocument();
   });
 
   it('routes completed rooms through the reveal phase with shared chrome enabled', async () => {

--- a/tests/convex/aiLifecycle.test.ts
+++ b/tests/convex/aiLifecycle.test.ts
@@ -1136,6 +1136,106 @@ describe('multi-bot scheduling (solo play)', () => {
     }
   });
 
+  it('allows only one running AI generation action per game round', async () => {
+    const t = setupConvexTest();
+    const { gameId, roomId } = await seedClassicGame(t, {
+      players: SOLO_PLAYERS,
+      currentRound: 0,
+    });
+
+    const first = await t.mutation(internal.ai.claimAiRoundGeneration, {
+      roomId,
+      gameId,
+      round: 0,
+    });
+    const second = await t.mutation(internal.ai.claimAiRoundGeneration, {
+      roomId,
+      gameId,
+      round: 0,
+    });
+
+    expect(first.claimed).toBe(true);
+    expect(first.lockId).toBeTruthy();
+    expect(second).toEqual({ claimed: false });
+
+    if (!first.lockId || !first.owner) {
+      throw new Error('expected the first AI round claim to return a lock id');
+    }
+
+    await t.mutation(internal.ai.finishAiRoundGeneration, {
+      lockId: first.lockId,
+      owner: first.owner,
+    });
+    const afterRelease = await t.mutation(internal.ai.claimAiRoundGeneration, {
+      roomId,
+      gameId,
+      round: 0,
+    });
+
+    expect(afterRelease.claimed).toBe(true);
+  });
+
+  it('does not let an old stale-lock owner finish a newer running claim', async () => {
+    const t = setupConvexTest();
+    const { gameId, roomId } = await seedClassicGame(t, {
+      players: SOLO_PLAYERS,
+      currentRound: 0,
+    });
+
+    const first = await t.mutation(internal.ai.claimAiRoundGeneration, {
+      roomId,
+      gameId,
+      round: 0,
+    });
+    if (!first.claimed || !first.lockId) {
+      throw new Error('expected first claim to succeed');
+    }
+
+    await t.run((ctx) =>
+      ctx.db.patch(first.lockId, {
+        updatedAt: Date.now() - 120_000,
+      })
+    );
+
+    const second = await t.mutation(internal.ai.claimAiRoundGeneration, {
+      roomId,
+      gameId,
+      round: 0,
+    });
+    expect(second.claimed).toBe(true);
+    if (!second.claimed || !second.lockId) {
+      throw new Error('expected stale reclaim to return a lock id');
+    }
+    expect(second.lockId).toBe(first.lockId);
+    expect(second.owner).not.toBe(first.owner);
+
+    await t.mutation(internal.ai.finishAiRoundGeneration, {
+      lockId: first.lockId,
+      owner: first.owner,
+    });
+    const third = await t.mutation(internal.ai.claimAiRoundGeneration, {
+      roomId,
+      gameId,
+      round: 0,
+    });
+
+    expect(third).toEqual({ claimed: false });
+
+    await t.mutation(internal.ai.finishAiRoundGeneration, {
+      lockId: second.lockId,
+      owner: second.owner,
+    });
+    const afterCurrentOwnerFinishes = await t.mutation(
+      internal.ai.claimAiRoundGeneration,
+      {
+        roomId,
+        gameId,
+        round: 0,
+      }
+    );
+    expect(afterCurrentOwnerFinishes.claimed).toBe(true);
+  });
+
   it('a round whose bots all strand still completes via the safety net (no cron)', async () => {
     // The critical solo invariant: the abandonment cron never fires while the
     // human is present, so ensureAiLine alone must clear every bot cell so the

--- a/tests/convex/archive.test.ts
+++ b/tests/convex/archive.test.ts
@@ -84,10 +84,14 @@ async function seedFavorite(
 }
 
 /** Helper: call getArchiveData as the given Clerk user. */
-function queryArchive(t: T, clerkUserId: string, guestToken?: string) {
+function queryArchive(
+  t: T,
+  clerkUserId: string,
+  args: { guestToken?: string; limit?: number } = {}
+) {
   return t
     .withIdentity({ subject: clerkUserId })
-    .query(api.archive.getArchiveData, { guestToken });
+    .query(api.archive.getArchiveData, args);
 }
 
 // ---------------------------------------------------------------------------
@@ -118,6 +122,40 @@ describe('archive', () => {
         uniqueCollaborators: 0,
         totalLinesWritten: 0,
       });
+    });
+
+    it('windows archive poems by explicit limit instead of returning the whole history', async () => {
+      const t = setupConvexTest();
+      const userId = await seedUser(t, {
+        displayName: 'Windowed',
+        clerkUserId: 'clerk_windowed',
+        guestId: 'guest_windowed',
+      });
+
+      const seeded = [];
+      for (let i = 0; i < 4; i++) {
+        const room = await seedCompletedRoom(t, userId, {
+          createdAt: 1000 + i,
+          poemCreatedAt: 1000 + i,
+        });
+        await seedLine(t, {
+          poemId: room.poemId,
+          authorUserId: userId,
+          text: `Line ${i}`,
+          wordCount: 2,
+          indexInPoem: 0,
+        });
+        seeded.push(room.poemId);
+      }
+
+      const result = await queryArchive(t, 'clerk_windowed', { limit: 2 });
+
+      expect(result.poems.map((poem) => poem._id)).toEqual([
+        seeded[3],
+        seeded[2],
+      ]);
+      expect(result.stats?.totalPoems).toBe(2);
+      expect(result.stats?.totalLinesWritten).toBe(2);
     });
 
     it('returns enriched poem with all metadata for user with one line', async () => {

--- a/tests/convex/poems.test.ts
+++ b/tests/convex/poems.test.ts
@@ -558,6 +558,48 @@ describe('getMyPoems', () => {
     ]);
   });
 
+  it('windows personal history by explicit limit', async () => {
+    const t = setupConvexTest();
+    const aliceId = await seedClerkUser(t, 'alice');
+    const { gameId, roomId } = await seedRoom(t, {
+      userId: aliceId,
+      poemCount: 0,
+    });
+
+    const poemIds = await t.run(async (ctx) => {
+      const ids: Id<'poems'>[] = [];
+      for (let i = 0; i < 4; i++) {
+        ids.push(
+          await ctx.db.insert('poems', {
+            roomId,
+            gameId,
+            indexInRoom: i,
+            createdAt: 1000 + i,
+          })
+        );
+      }
+      return ids;
+    });
+
+    for (const [index, poemId] of poemIds.entries()) {
+      await seedLine(t, {
+        poemId,
+        authorUserId: aliceId,
+        indexInPoem: 0,
+        text: `Poem ${index}`,
+      });
+    }
+
+    const result = await asUser(t, 'alice').query(api.poems.getMyPoems, {
+      limit: 2,
+    });
+
+    expect(result.map((poem: { _id: Id<'poems'> }) => poem._id)).toEqual([
+      poemIds[3],
+      poemIds[2],
+    ]);
+  });
+
   it('includes roomDate from the room record', async () => {
     const t = setupConvexTest();
     const aliceId = await seedClerkUser(t, 'alice');

--- a/tests/convex/readPathGuards.test.ts
+++ b/tests/convex/readPathGuards.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function exportedFunctionBody(source: string, exportName: string): string {
+  const start = source.indexOf(`export const ${exportName}`);
+  if (start === -1) throw new Error(`Missing export ${exportName}`);
+
+  const nextExport = source.indexOf('\nexport const ', start + 1);
+  return nextExport === -1
+    ? source.slice(start)
+    : source.slice(start, nextExport);
+}
+
+describe('Convex launch read path guards', () => {
+  const archiveSource = readFileSync('convex/archive.ts', 'utf8');
+  const poemSource = readFileSync('convex/poems.ts', 'utf8');
+  const schemaSource = readFileSync('convex/schema.ts', 'utf8');
+
+  it('keeps getRecentPublicPoems on indexed reads instead of query filters', () => {
+    const body = exportedFunctionBody(archiveSource, 'getRecentPublicPoems');
+
+    expect(body).not.toContain('.filter(');
+    expect(body).toContain(".withIndex('by_status_created'");
+    expect(body).toContain(".withIndex('by_room'");
+    expect(body).toContain(".withIndex('by_poem_index'");
+    expect(schemaSource).toContain(".index('by_status_created'");
+  });
+
+  it('keeps user history reads explicitly windowed', () => {
+    const archiveBody = exportedFunctionBody(archiveSource, 'getArchiveData');
+    const myPoemsBody = exportedFunctionBody(poemSource, 'getMyPoems');
+
+    expect(archiveBody).toContain('limit: v.optional(v.number())');
+    expect(archiveBody).toContain('.take(');
+    expect(myPoemsBody).toContain('limit: v.optional(v.number())');
+    expect(myPoemsBody).toContain('.take(');
+    expect(schemaSource).toContain(".index('by_author_created'");
+  });
+});


### PR DESCRIPTION
## Summary
- index and window launch/archive reads so public surfaces avoid Convex table scans and unbounded history collections
- add owner-fenced AI round generation locks for one in-flight OpenRouter generation per `(game, round)`
- add keyed room-panel error boundaries so a child query/render failure degrades locally

## Evidence
- `pnpm vitest run tests/convex/readPathGuards.test.ts tests/convex/archive.test.ts tests/convex/poems.test.ts` -> 3 files passed, 79 tests passed
- `pnpm vitest run tests/convex/aiLifecycle.test.ts tests/app/room-page.test.tsx` -> 2 files passed, 37 tests passed
- `pnpm ci:prepush` -> typecheck, lint, 104 Vitest files passed; 1153 tests passed, 1 skipped
- scan proof: `docs/evidence/linejam-021/baseline-scan.md`, `docs/evidence/linejam-021/after-scan.md`
- verification receipt: `docs/evidence/linejam-021/verification.md`

## Review
Fresh-context critic found stale lock fencing and boundary reset gaps; both were fixed and covered before final gate.

## Deployment
No production Convex deploy run. Repo docs make hosted `merge-gate` authoritative and do not state that factory lanes should deploy after merge.

Agent: codex-linejam-021
Agent-Surface: Codex CLI
Agent-Runner: Codex
Agent-Model: GPT-5
Agent-Task: Powder linejam-021
Agent-Context: perf/linejam-021-index-resilience