### PR TITLE
test(e2e): freeze selector contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,51 @@ jobs:
       - name: Build check
         run: ./scripts/ci/dagger-call.sh build-check
 
+  early-smoke:
+    name: Early Selector Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [quality-gates]
+    env:
+      NEXT_PUBLIC_CONVEX_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CI_NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+      CLERK_JWT_ISSUER_DOMAIN: ${{ secrets.CI_CLERK_JWT_ISSUER_DOMAIN || secrets.CLERK_JWT_ISSUER_DOMAIN }}
+      GUEST_TOKEN_SECRET: ${{ secrets.GUEST_TOKEN_SECRET }}
+      LINEJAM_ALLOW_UNSYNCED_CONVEX_THROTTLE: '1'
+      CANARY_ENDPOINT: ${{ secrets.CANARY_ENDPOINT }}
+      NEXT_PUBLIC_CANARY_ENDPOINT: ${{ secrets.NEXT_PUBLIC_CANARY_ENDPOINT }}
+      NEXT_PUBLIC_CANARY_API_KEY: ${{ secrets.NEXT_PUBLIC_CANARY_API_KEY }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Set NEXT_PUBLIC_CONVEX_URL fallback
+        run: |
+          if [ -z "$NEXT_PUBLIC_CONVEX_URL" ]; then
+            echo "NEXT_PUBLIC_CONVEX_URL=http://localhost:8187" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build:check
+
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Run early selector smoke
+        run: pnpm test:e2e:early-smoke
+
   e2e:
     name: E2E Mirror
     runs-on: ubuntu-latest
@@ -257,7 +302,7 @@ jobs:
   merge-gate:
     name: merge-gate
     runs-on: ubuntu-latest
-    needs: [quality-gates, test-build, e2e, qa-evidence]
+    needs: [quality-gates, test-build, early-smoke, e2e, qa-evidence]
     if: always()
     steps:
       - name: Check all jobs passed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,7 @@ pnpm test             # vitest run
 pnpm test:watch       # vitest watch
 pnpm test:ci          # vitest run --coverage
 pnpm test:ui          # vitest interactive UI
+pnpm test:e2e:early-smoke # fast selector smoke to reveal phase
 ```
 
 For a non-destructive env bootstrap without installing dependencies:
@@ -237,6 +238,7 @@ Full-contract composition (hosted / on-demand):
 - `audit`
 - `unit-test` with 85% coverage floor (lines/branches/functions/statements)
 - `build-check`
+- `early-smoke` selector flow
 - `e2e`
 
 Local enforcement:
@@ -247,7 +249,7 @@ Local enforcement:
 
 Hosted workflows:
 
-- `.github/workflows/ci.yml` — authoritative `merge-gate`: `quality-gates`, `test-build`, `e2e`, advisory `qa-evidence`
+- `.github/workflows/ci.yml` — authoritative `merge-gate`: `quality-gates`, `test-build`, `early-smoke`, `e2e`, advisory `qa-evidence`
 - `.github/workflows/preview-smoke.yml` — preview smoke
 - `.github/workflows/prod-smoke.yml` — production smoke
 - `.github/workflows/release.yml` — semantic-release plus note synthesis
@@ -303,6 +305,7 @@ pnpm ci:dagger:{lint,typecheck,format-check,build-check,unit-test,e2e,audit,secr
 
 # E2E
 pnpm test:e2e
+pnpm test:e2e:early-smoke
 pnpm test:e2e:smoke
 pnpm test:e2e:evidence
 pnpm test:e2e:ui

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ pnpm ci:dagger:all
 
 # Browser suites
 pnpm test:e2e       # Local Playwright suite
+pnpm test:e2e:early-smoke # Fast selector smoke to reveal phase
 pnpm test:e2e:smoke # Remote preview/prod smoke via PLAYWRIGHT_BASE_URL
 pnpm test:e2e:ui    # Interactive UI mode
 
@@ -125,7 +126,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for system overview: domain mod
 - Critical route telemetry is structured JSON. `/api/health` and `/api/guest/session` log method, route, status, and duration without guest tokens, display names, or raw request payloads.
 - Completed rooms end in a shared recap hub. Players can replay every poem, share `/recap/<room-code>`, and keep the same group moving into the next round without relying on one-off archive links.
 - Use `pnpm ci:fast` for the fast host loop: typecheck, lint, and tests without Docker. `pnpm ci:prepush` is the same command under the pre-push hook.
-- GitHub Actions enforces the authoritative full contract through hosted `merge-gate`. Run `pnpm ci:dagger:all` on demand for full local parity when Docker and the required env are available.
+- GitHub Actions enforces the authoritative full contract through hosted `merge-gate`, including the non-draft-gated `early-smoke` selector flow. Run `pnpm ci:dagger:all` on demand for full local parity when Docker and the required env are available.
 - Local Dagger auto-hydrates `GUEST_TOKEN_SECRET` from the active Convex deployment when `NEXT_PUBLIC_CONVEX_URL` points at the same Convex dev or prod backend that the CLI resolves.
 - Local Dagger auto-syncs the active Convex dev deployment before `all` and `e2e` runs. It refuses to push production Convex code unless you explicitly set `LINEJAM_ALLOW_PROD_CONVEX_SYNC=1`.
 - Local Dagger ensures the Clerk `convex` JWT template exists before local auth-heavy browser coverage. Dev/test Clerk keys can be bootstrapped automatically; live-key mutation stays blocked unless you explicitly set `LINEJAM_ALLOW_LIVE_CLERK_TEMPLATE_CREATE=1`.

--- a/app/host/page.tsx
+++ b/app/host/page.tsx
@@ -8,6 +8,7 @@ import { useUser } from '../../lib/auth';
 import { captureError } from '../../lib/error';
 import { trackGameCreated } from '../../lib/analytics';
 import { errorToFeedback } from '../../lib/errorFeedback';
+import { E2E_TEST_IDS } from '../../lib/e2eTestIds';
 import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
 import { Alert } from '../../components/ui/Alert';
@@ -77,6 +78,7 @@ export default function HostPage() {
               </label>
               <Input
                 id="name"
+                data-testid={E2E_TEST_IDS.hostNameInput}
                 placeholder="Enter your name..."
                 value={name}
                 onChange={(e) => setName(e.target.value)}
@@ -95,6 +97,7 @@ export default function HostPage() {
             <div className="pt-4">
               <Button
                 type="submit"
+                data-testid={E2E_TEST_IDS.hostCreateRoomButton}
                 className="w-full text-lg h-14"
                 disabled={!name.trim() || isSubmitting}
               >

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -6,6 +6,7 @@ import { useMutation } from 'convex/react';
 import { api } from '../../convex/_generated/api';
 import { useUser } from '../../lib/auth';
 import { captureError } from '../../lib/error';
+import { E2E_TEST_IDS } from '../../lib/e2eTestIds';
 import { trackGameJoined } from '../../lib/analytics';
 import { errorToFeedback } from '../../lib/errorFeedback';
 import { Alert } from '../../components/ui/Alert';
@@ -90,6 +91,7 @@ function JoinForm() {
             </label>
             <Input
               id="code"
+              data-testid={E2E_TEST_IDS.joinRoomCodeInput}
               placeholder="ABCD"
               value={code}
               onChange={(e) => setCode(e.target.value.toUpperCase())}
@@ -114,6 +116,7 @@ function JoinForm() {
             </label>
             <Input
               id="name"
+              data-testid={E2E_TEST_IDS.joinNameInput}
               placeholder="Enter your name..."
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -134,6 +137,7 @@ function JoinForm() {
           <div className="pt-4">
             <Button
               type="submit"
+              data-testid={E2E_TEST_IDS.joinRoomButton}
               className="w-full text-lg h-14"
               disabled={!name.trim() || !code.trim() || isSubmitting}
             >

--- a/components/Lobby.tsx
+++ b/components/Lobby.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useMutation } from 'convex/react';
 import { api } from '../convex/_generated/api';
 import { useUser } from '../lib/auth';
+import { E2E_TEST_IDS } from '../lib/e2eTestIds';
 import { errorToFeedback } from '../lib/errorFeedback';
 import { Alert } from './ui/Alert';
 import { Avatar } from './ui/Avatar';
@@ -148,6 +149,7 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
         <div className="space-y-3">
           <Button
             onClick={handleStartGame}
+            data-testid={E2E_TEST_IDS.lobbyStartGameButton}
             size="lg"
             className={`w-full h-16 text-lg ${className || ''}`}
             disabled={!canStart}
@@ -173,6 +175,7 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
       <div className="space-y-3">
         <Button
           disabled
+          data-testid={E2E_TEST_IDS.lobbyWaitingForHostButton}
           size="lg"
           className={`w-full h-16 text-lg opacity-50 cursor-not-allowed ${className || ''}`}
           variant="secondary"

--- a/components/PoemDisplay.tsx
+++ b/components/PoemDisplay.tsx
@@ -6,6 +6,7 @@ import { Heart, Volume2, VolumeX } from 'lucide-react';
 import { Button } from './ui/Button';
 import { Alert } from './ui/Alert';
 import { HeartButton } from './ui/HeartButton';
+import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
 import { cn } from '@/lib/utils';
 import { Id } from '@/convex/_generated/dataModel';
 import { useSharePoem } from '@/hooks/useSharePoem';
@@ -360,7 +361,7 @@ export function PoemDisplay({
 
       {/* Footer / Actions - Fixed at bottom */}
       <div
-        data-testid="poem-actions"
+        data-testid={E2E_TEST_IDS.poemActions}
         className={cn(
           'px-6 md:px-12 lg:px-24 py-6 border-t border-border-subtle',
           'flex flex-col items-center gap-4',
@@ -397,6 +398,7 @@ export function PoemDisplay({
           {!isArchive && onDone && (
             <Button
               onClick={onDone}
+              data-testid={E2E_TEST_IDS.poemDoneButton}
               variant="ghost"
               size="lg"
               className="min-w-[100px] h-12 text-text-muted hover:text-text-primary"

--- a/components/RevealPhase.tsx
+++ b/components/RevealPhase.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation } from 'convex/react';
 import { api } from '../convex/_generated/api';
 import { useUser } from '../lib/auth';
 import { cn } from '../lib/utils';
+import { E2E_TEST_IDS } from '../lib/e2eTestIds';
 import { captureError } from '../lib/error';
 import { errorToFeedback } from '../lib/errorFeedback';
 import { Alert } from './ui/Alert';
@@ -167,7 +168,10 @@ export function RevealPhase({
   return (
     <>
       {chrome}
-      <div className="min-h-screen bg-background flex flex-col">
+      <div
+        data-testid={E2E_TEST_IDS.revealPhase}
+        className="min-h-screen bg-background flex flex-col"
+      >
         <main className="flex-1 max-w-3xl mx-auto w-full space-y-12 p-6 md:p-12 lg:px-24 lg:pb-24 lg:pt-16">
           {/* 2. HERO - Your Assignment (primary action) */}
           {myPoems && myPoems.length > 0 && (
@@ -196,6 +200,7 @@ export function RevealPhase({
                     {error && <Alert variant="error">{error}</Alert>}
                     <Button
                       onClick={() => handleReveal(poem._id)}
+                      data-testid={E2E_TEST_IDS.revealPoemButton}
                       size="lg"
                       className="w-full h-12"
                       disabled={isRevealingId === poem._id}

--- a/components/SessionRecapHub.tsx
+++ b/components/SessionRecapHub.tsx
@@ -7,6 +7,7 @@ import { Crown, Heart, Share2, Volume2, VolumeX } from 'lucide-react';
 import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
 import { trackRoomInviteShared } from '@/lib/analytics';
+import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
 import { useShareLink } from '@/hooks/useShareLink';
 import { useCeremonyEffects } from '@/hooks/useCeremonyEffects';
 import { Alert } from './ui/Alert';
@@ -91,6 +92,7 @@ export function SessionRecapHub({
 
   return (
     <section
+      data-testid={E2E_TEST_IDS.sessionComplete}
       aria-labelledby="session-recap-title"
       className="space-y-8 pt-8 border-t border-border"
     >
@@ -131,7 +133,7 @@ export function SessionRecapHub({
           <div className="relative flex items-center gap-2 text-primary">
             <Heart className="h-4 w-4" fill="currentColor" />
             <Crown
-              data-testid="room-favorite-crown"
+              data-testid={E2E_TEST_IDS.roomFavoriteCrown}
               className="animate-crown-settle h-5 w-5"
               aria-hidden="true"
             />
@@ -186,7 +188,13 @@ export function SessionRecapHub({
       </div>
 
       <div className="grid gap-3">
-        <Button type="button" onClick={handleShare} size="lg" className="h-14">
+        <Button
+          type="button"
+          onClick={handleShare}
+          data-testid={E2E_TEST_IDS.sessionRecapShareButton}
+          size="lg"
+          className="h-14"
+        >
           <Share2 className="mr-2 h-4 w-4" />
           {shared ? 'Shared!' : copied ? 'Copied!' : 'Share the whole set'}
         </Button>

--- a/components/WaitingScreen.tsx
+++ b/components/WaitingScreen.tsx
@@ -4,6 +4,7 @@ import { api } from '../convex/_generated/api';
 import { GHOSTWRITER_OVERTIME_MS } from '../convex/lib/gameRules';
 import { useRoomQueryArgs } from '../hooks/useRoomQueryArgs';
 import { captureError } from '../lib/error';
+import { E2E_TEST_IDS } from '../lib/e2eTestIds';
 import { errorToFeedback } from '../lib/errorFeedback';
 import { Alert } from './ui/Alert';
 import { Button } from './ui/Button';
@@ -116,7 +117,11 @@ export function WaitingScreen({
   const allStableIds = players.map((p) => p.stableId);
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-[var(--color-background)] p-8 md:p-12">
+    <div
+      data-testid={E2E_TEST_IDS.waitingPhase}
+      data-round={round + 1}
+      className="min-h-screen flex flex-col items-center justify-center bg-[var(--color-background)] p-8 md:p-12"
+    >
       {/* Floating vertical composition - massive breathing space */}
       <div
         className="w-full max-w-2xl flex flex-col items-center"

--- a/components/WritingScreen.tsx
+++ b/components/WritingScreen.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useRoomQueryArgs } from '@/hooks/useRoomQueryArgs';
+import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
 import { captureError } from '@/lib/error';
 import { errorToFeedback } from '@/lib/errorFeedback';
 import { cn } from '@/lib/utils';
@@ -186,7 +187,11 @@ function WritingComposer({
   };
 
   return (
-    <div className="relative min-h-screen bg-background flex flex-col items-center px-6 pb-6 pt-4 md:px-8 md:pb-8 md:pt-12">
+    <div
+      data-testid={E2E_TEST_IDS.writingPhase}
+      data-round={assignment.lineIndex + 1}
+      className="relative min-h-screen bg-background flex flex-col items-center px-6 pb-6 pt-4 md:px-8 md:pb-8 md:pt-12"
+    >
       {/* Screen reader live region for validation announcements */}
       <div
         className="sr-only"
@@ -242,6 +247,7 @@ function WritingComposer({
 
           <textarea
             ref={textareaRef}
+            data-testid={E2E_TEST_IDS.writingLineInput}
             className={cn(
               'w-full min-h-[110px] md:min-h-[320px] lg:min-h-[360px] field-sizing-content bg-transparent border-none outline-none resize-none',
               'text-3xl md:text-5xl lg:text-6xl font-[var(--font-display)] leading-tight',
@@ -280,6 +286,7 @@ function WritingComposer({
         <div className="mt-6 md:mt-16 flex justify-center">
           <Button
             onClick={handleSubmit}
+            data-testid={E2E_TEST_IDS.writingSubmitLineButton}
             size="lg"
             disabled={
               !isValid ||

--- a/components/ui/WordSlots.tsx
+++ b/components/ui/WordSlots.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { cn } from '@/lib/utils';
+import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
 
 interface WordSlotsProps {
   current: number;
@@ -26,6 +27,7 @@ export function WordSlots({ current, target, className }: WordSlotsProps) {
   return (
     <div
       id="word-slots"
+      data-testid={E2E_TEST_IDS.writingWordSlots}
       className={cn('flex items-center gap-1', className)}
       role="status"
       aria-label={`${current} of ${target} words`}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -11,6 +11,7 @@ pnpm test:ci       # CI mode with coverage
 pnpm ci:fast       # Fast local gate: typecheck, lint, tests
 pnpm ci:dagger:all # Full local Dagger parity for hosted merge-gate
 pnpm test:e2e      # Run deterministic E2E tests (excludes @evidence)
+pnpm test:e2e:early-smoke # Fast selector smoke to reveal phase
 pnpm test:e2e:smoke # Remote preview/prod smoke
 pnpm test:e2e:evidence # Run the tagged evidence capture spec
 pnpm test:e2e:ui   # Playwright UI mode
@@ -186,6 +187,7 @@ test('host creates room', async ({ page }) => {
 - Port: 3333 (avoids conflicts with dev server)
 - Browser base URL: `http://localhost:${PORT_E2E:-3333}`
 - `E2E_BASE_URL=https://...` targets a remote deployment and skips the local web server bootstrap
+- `early-smoke.spec.ts` runs the frozen selector contract through host/create/start/play-to-reveal and is wired as the non-draft-gated `early-smoke` merge-gate job
 - `prod-smoke.spec.ts` is excluded from the local suite and runs only through `playwright.smoke.config.ts`
 
 **Environment contract**:

--- a/lib/e2eTestIds.ts
+++ b/lib/e2eTestIds.ts
@@ -1,0 +1,23 @@
+export const E2E_TEST_IDS = {
+  hostNameInput: 'host-name-input',
+  hostCreateRoomButton: 'host-create-room-button',
+  joinRoomCodeInput: 'join-room-code-input',
+  joinNameInput: 'join-name-input',
+  joinRoomButton: 'join-room-button',
+  lobbyStartGameButton: 'lobby-start-game-button',
+  lobbyWaitingForHostButton: 'lobby-waiting-for-host-button',
+  writingPhase: 'writing-phase',
+  writingLineInput: 'writing-line-input',
+  writingWordSlots: 'writing-word-slots',
+  writingSubmitLineButton: 'writing-submit-line-button',
+  waitingPhase: 'waiting-phase',
+  revealPhase: 'reveal-phase',
+  revealPoemButton: 'reveal-poem-button',
+  poemActions: 'poem-actions',
+  poemDoneButton: 'poem-done-button',
+  sessionComplete: 'session-complete',
+  roomFavoriteCrown: 'room-favorite-crown',
+  sessionRecapShareButton: 'session-recap-share-button',
+} as const;
+
+export type E2ETestId = (typeof E2E_TEST_IDS)[keyof typeof E2E_TEST_IDS];

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:ci": "vitest run --coverage",
     "test:watch": "vitest --watch",
     "test:e2e": "playwright test --grep-invert \"@evidence|@slow\"",
+    "test:e2e:early-smoke": "playwright test tests/e2e/early-smoke.spec.ts --project=chromium --workers=1 --retries=0 --reporter=line",
     "test:e2e:smoke": "playwright test --config=playwright.smoke.config.ts",
     "test:e2e:evidence": "playwright test tests/e2e/guest-flow.evidence.spec.ts --project=chromium --workers=1 --retries=0 --reporter=line",
     "test:e2e:leaver": "playwright test mid-game-leaver --project=chromium --workers=1 --retries=0 --reporter=line",

--- a/tests/e2e/early-smoke.spec.ts
+++ b/tests/e2e/early-smoke.spec.ts
@@ -1,0 +1,34 @@
+import { test } from '@playwright/test';
+
+import {
+  CANONICAL_GUEST_FLOW_LINES,
+  GuestFlowSession,
+} from '@/tests/e2e/support/guestFlow';
+
+const missingGuestTokenSecret =
+  !process.env.GUEST_TOKEN_SECRET && !process.env.E2E_BASE_URL;
+test.skip(
+  missingGuestTokenSecret,
+  'Set GUEST_TOKEN_SECRET for local E2E, or E2E_BASE_URL for a remote target'
+);
+
+test('frozen selector smoke reaches the reveal phase @early-smoke', async ({
+  browser,
+}) => {
+  test.setTimeout(90_000);
+
+  const session = await GuestFlowSession.create(browser, {
+    guestName: 'Smoke Guest',
+    hostName: 'Smoke Host',
+  });
+
+  try {
+    await session.createRoom();
+    await session.joinRoom();
+    await session.startGame();
+    await session.verifyRoundOneValidation();
+    await session.playCanonicalGame(CANONICAL_GUEST_FLOW_LINES);
+  } finally {
+    await session.close();
+  }
+});

--- a/tests/e2e/prod-smoke.spec.ts
+++ b/tests/e2e/prod-smoke.spec.ts
@@ -4,6 +4,7 @@ import {
   hasClerkBrowserAuth,
   requireClerkBrowserAuth,
 } from './support/clerk';
+import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
 
 const REQUIRE_AUTH_SMOKE =
   process.env.PLAYWRIGHT_REQUIRE_AUTH_SMOKE?.trim() === '1';
@@ -14,8 +15,8 @@ async function createHostedRoom(hostPage: Page, hostName: string) {
     state: 'visible',
     timeout: 10000,
   });
-  await hostPage.fill('input#name', hostName);
-  await hostPage.click('button[type="submit"]');
+  await hostPage.getByTestId(E2E_TEST_IDS.hostNameInput).fill(hostName);
+  await hostPage.getByTestId(E2E_TEST_IDS.hostCreateRoomButton).click();
 
   await hostPage.waitForURL(/\/room\/[A-Z]{4}$/, { timeout: 30000 });
   const roomCode = hostPage.url().match(/\/room\/([A-Z]{4})$/)?.[1] || '';
@@ -27,6 +28,10 @@ async function openContextPage(browser: Browser) {
   const context = await browser.newContext();
   const page = await context.newPage();
   return { context, page };
+}
+
+function visibleTestId(page: Page, testId: string) {
+  return page.getByTestId(testId).filter({ visible: true });
 }
 
 test.describe('Deployment Smoke', () => {
@@ -46,8 +51,10 @@ test.describe('Deployment Smoke', () => {
         state: 'visible',
         timeout: 10000,
       });
-      await guestPage.fill('input#name', 'Canary Guest');
-      await guestPage.click('button[type="submit"]');
+      await guestPage
+        .getByTestId(E2E_TEST_IDS.joinNameInput)
+        .fill('Canary Guest');
+      await guestPage.getByTestId(E2E_TEST_IDS.joinRoomButton).click();
 
       await guestPage.waitForURL(`/room/${roomCode}`, { timeout: 15000 });
 
@@ -57,19 +64,16 @@ test.describe('Deployment Smoke', () => {
       await expect(guestPage.getByText('Canary Host')).toBeVisible();
 
       await expect(
-        hostPage.getByRole('button', { name: /Start Linejam/i })
+        visibleTestId(hostPage, E2E_TEST_IDS.lobbyStartGameButton)
       ).toBeEnabled();
-      await hostPage.click('button:has-text("Start Linejam")');
+      await visibleTestId(hostPage, E2E_TEST_IDS.lobbyStartGameButton).click();
 
-      // Tolerate both copy forms so the smoke passes against current prod
-      // ("Round 1 of 9") and post-deploy prod ("Round 1 · 1 word").
-      const roundOne = /\bRound 1\b/;
-      await expect(hostPage.getByText(roundOne).first()).toBeVisible({
-        timeout: 15000,
-      });
-      await expect(guestPage.getByText(roundOne).first()).toBeVisible({
-        timeout: 15000,
-      });
+      await expect(
+        hostPage.getByTestId(E2E_TEST_IDS.writingPhase)
+      ).toHaveAttribute('data-round', '1', { timeout: 15000 });
+      await expect(
+        guestPage.getByTestId(E2E_TEST_IDS.writingPhase)
+      ).toHaveAttribute('data-round', '1', { timeout: 15000 });
 
       await expect(
         hostPage.getByText(/unexpected error occurred/i)
@@ -105,8 +109,10 @@ test.describe('Deployment Smoke', () => {
         state: 'visible',
         timeout: 10000,
       });
-      await signedInPage.fill('input#name', 'Canary Clerk User');
-      await signedInPage.click('button[type="submit"]');
+      await signedInPage
+        .getByTestId(E2E_TEST_IDS.joinNameInput)
+        .fill('Canary Clerk User');
+      await signedInPage.getByTestId(E2E_TEST_IDS.joinRoomButton).click();
 
       await signedInPage.waitForURL(`/room/${roomCode}`, { timeout: 15000 });
 

--- a/tests/e2e/support/guestFlow.ts
+++ b/tests/e2e/support/guestFlow.ts
@@ -8,6 +8,7 @@ import type {
   ViewportSize,
 } from '@playwright/test';
 import { WORD_COUNTS } from '@/convex/lib/gameRules';
+import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
 
 export const CANONICAL_GUEST_FLOW_LINES = [
   'poetry',
@@ -97,6 +98,10 @@ async function waitForRoomPath(page: Page, label: string, roomCode?: string) {
   if (!pathPattern.test(new URL(page.url()).pathname)) {
     throw new Error(`Unexpected URL for ${label}: ${page.url()}`);
   }
+}
+
+function visibleTestId(page: Page, testId: string) {
+  return page.getByTestId(testId).filter({ visible: true });
 }
 
 export function attachGuestFlowRuntimeErrorLogging(
@@ -319,9 +324,14 @@ export class GuestFlowSession {
 
   async createRoom() {
     await this.hostPage.goto('/host');
-    await ensureVisible(this.hostPage.locator('input#name'), 'host name input');
-    await this.hostPage.fill('input#name', this.hostName);
-    await this.hostPage.getByRole('button', { name: /Create Room/i }).click();
+    await ensureVisible(
+      this.hostPage.getByTestId(E2E_TEST_IDS.hostNameInput),
+      'host name input'
+    );
+    await this.hostPage
+      .getByTestId(E2E_TEST_IDS.hostNameInput)
+      .fill(this.hostName);
+    await this.hostPage.getByTestId(E2E_TEST_IDS.hostCreateRoomButton).click();
     await waitForRoomPath(this.hostPage, 'host room');
 
     const roomCode =
@@ -342,7 +352,7 @@ export class GuestFlowSession {
   async expectHostLobby() {
     await expect(this.playerName(this.hostPage, this.hostName)).toBeVisible();
     await expect(
-      this.hostPage.getByRole('button', { name: /Need.*player/i })
+      visibleTestId(this.hostPage, E2E_TEST_IDS.lobbyStartGameButton)
     ).toBeVisible();
   }
 
@@ -382,11 +392,13 @@ export class GuestFlowSession {
 
     await this.guestPage.goto(`/join?code=${this.roomCode}`);
     await ensureVisible(
-      this.guestPage.locator('input#name'),
+      this.guestPage.getByTestId(E2E_TEST_IDS.joinNameInput),
       'guest name input'
     );
-    await this.guestPage.fill('input#name', this.guestName);
-    await this.guestPage.getByRole('button', { name: /Enter Room/i }).click();
+    await this.guestPage
+      .getByTestId(E2E_TEST_IDS.joinNameInput)
+      .fill(this.guestName);
+    await this.guestPage.getByTestId(E2E_TEST_IDS.joinRoomButton).click();
     await waitForRoomPath(this.guestPage, 'guest room', this.roomCode);
     await this.expectJoinedLobby();
   }
@@ -398,55 +410,63 @@ export class GuestFlowSession {
       timeout: 10000,
     });
     await expect(
-      this.hostPage.getByRole('button', { name: /Start Linejam/i })
+      visibleTestId(this.hostPage, E2E_TEST_IDS.lobbyStartGameButton)
     ).toBeEnabled();
     await expect(
-      this.guestPage.getByRole('button', { name: /Waiting for Host/i })
+      visibleTestId(this.guestPage, E2E_TEST_IDS.lobbyWaitingForHostButton)
     ).toBeVisible();
   }
 
   async startGame() {
-    await this.hostPage.getByRole('button', { name: /Start Linejam/i }).click();
+    await visibleTestId(
+      this.hostPage,
+      E2E_TEST_IDS.lobbyStartGameButton
+    ).click();
     await this.expectRound(1);
     await this.expectWritingUi();
   }
 
   async expectRound(round: number) {
-    // The writing chrome reads "Round N · M words"; the waiting chrome reads
-    // "Round N of 9". Match the round number across both copy forms.
-    const roundLabel = new RegExp(`\\bRound ${round}\\b`);
-    await expect(this.hostPage.getByText(roundLabel).first()).toBeVisible({
-      timeout: 15000,
-    });
-    await expect(this.guestPage.getByText(roundLabel).first()).toBeVisible({
-      timeout: 15000,
-    });
+    await expect(
+      this.hostPage.getByTestId(E2E_TEST_IDS.writingPhase)
+    ).toHaveAttribute('data-round', String(round), { timeout: 15000 });
+    await expect(
+      this.guestPage.getByTestId(E2E_TEST_IDS.writingPhase)
+    ).toHaveAttribute('data-round', String(round), { timeout: 15000 });
   }
 
   async expectWritingUi() {
-    await expect(this.hostPage.getByRole('textbox')).toBeVisible();
-    await expect(this.guestPage.getByRole('textbox')).toBeVisible();
+    await expect(
+      this.hostPage.getByTestId(E2E_TEST_IDS.writingLineInput)
+    ).toBeVisible();
+    await expect(
+      this.guestPage.getByTestId(E2E_TEST_IDS.writingLineInput)
+    ).toBeVisible();
     await this.expectWordSlotsVisible('host');
     await this.expectWordSlotsVisible('guest');
   }
 
   async expectWordSlotsVisible(actor: Actor) {
-    await expect(this.page(actor).locator('#word-slots')).toBeVisible();
+    await expect(
+      this.page(actor).getByTestId(E2E_TEST_IDS.writingWordSlots)
+    ).toBeVisible();
   }
 
   async fillCurrentLine(actor: Actor, line: string) {
-    await this.page(actor).getByRole('textbox').fill(line);
+    await this.page(actor)
+      .getByTestId(E2E_TEST_IDS.writingLineInput)
+      .fill(line);
   }
 
   async expectSealDisabled(actor: Actor) {
     await expect(
-      this.page(actor).getByRole('button', { name: /^Submit$/i })
+      this.page(actor).getByTestId(E2E_TEST_IDS.writingSubmitLineButton)
     ).toBeDisabled();
   }
 
   async expectSealEnabled(actor: Actor) {
     await expect(
-      this.page(actor).getByRole('button', { name: /^Submit$/i })
+      this.page(actor).getByTestId(E2E_TEST_IDS.writingSubmitLineButton)
     ).toBeEnabled();
   }
 
@@ -467,13 +487,13 @@ export class GuestFlowSession {
   async submitCurrentLine(actor: Actor, line: string) {
     await this.fillCurrentLine(actor, line);
     await this.page(actor)
-      .getByRole('button', { name: /^Submit$/i })
+      .getByTestId(E2E_TEST_IDS.writingSubmitLineButton)
       .click();
   }
 
   async waitForWaitingState(actor: Actor) {
     await expect(
-      this.page(actor).getByRole('heading', { name: /Others are writing/i })
+      this.page(actor).getByTestId(E2E_TEST_IDS.waitingPhase)
     ).toBeVisible({ timeout: 15000 });
   }
 
@@ -507,16 +527,16 @@ export class GuestFlowSession {
 
   async expectReadingPhase() {
     await expect(
-      this.hostPage.getByRole('heading', { name: /Reveal poems/i })
+      this.hostPage.getByTestId(E2E_TEST_IDS.revealPhase)
     ).toBeVisible({ timeout: 30000 });
     await expect(
-      this.guestPage.getByRole('heading', { name: /Reveal poems/i })
+      this.guestPage.getByTestId(E2E_TEST_IDS.revealPhase)
     ).toBeVisible({ timeout: 30000 });
     await expect(
-      this.hostPage.getByRole('button', { name: /Reveal & Read/i })
+      this.hostPage.getByTestId(E2E_TEST_IDS.revealPoemButton).first()
     ).toBeVisible();
     await expect(
-      this.guestPage.getByRole('button', { name: /Reveal & Read/i })
+      this.guestPage.getByTestId(E2E_TEST_IDS.revealPoemButton).first()
     ).toBeVisible();
   }
 
@@ -526,12 +546,12 @@ export class GuestFlowSession {
   ) {
     const page = this.page(actor);
 
-    await page.getByRole('button', { name: /Reveal & Read/i }).click();
+    await page.getByTestId(E2E_TEST_IDS.revealPoemButton).first().click();
     await expect(page.getByText(lines[0])).toBeVisible({ timeout: 10000 });
     await expect(page.getByText(lines.at(-1) ?? '')).toBeVisible({
       timeout: 12000,
     });
-    await page.getByRole('button', { name: /Close|Done|Back/i }).click();
+    await page.getByTestId(E2E_TEST_IDS.poemDoneButton).click();
   }
 
   async revealAllPoems(lines: readonly string[] = CANONICAL_GUEST_FLOW_LINES) {
@@ -542,10 +562,10 @@ export class GuestFlowSession {
 
   async expectSessionComplete() {
     await expect(
-      this.hostPage.getByRole('heading', { name: /All poems revealed/i })
+      this.hostPage.getByTestId(E2E_TEST_IDS.sessionComplete)
     ).toBeVisible({ timeout: 15000 });
     await expect(
-      this.guestPage.getByRole('heading', { name: /All poems revealed/i })
+      this.guestPage.getByTestId(E2E_TEST_IDS.sessionComplete)
     ).toBeVisible({ timeout: 15000 });
   }
 

--- a/tests/lib/e2eTestIds.test.ts
+++ b/tests/lib/e2eTestIds.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
+
+const EXPECTED_TEST_IDS = {
+  hostNameInput: 'host-name-input',
+  hostCreateRoomButton: 'host-create-room-button',
+  joinRoomCodeInput: 'join-room-code-input',
+  joinNameInput: 'join-name-input',
+  joinRoomButton: 'join-room-button',
+  lobbyStartGameButton: 'lobby-start-game-button',
+  lobbyWaitingForHostButton: 'lobby-waiting-for-host-button',
+  writingPhase: 'writing-phase',
+  writingLineInput: 'writing-line-input',
+  writingWordSlots: 'writing-word-slots',
+  writingSubmitLineButton: 'writing-submit-line-button',
+  waitingPhase: 'waiting-phase',
+  revealPhase: 'reveal-phase',
+  revealPoemButton: 'reveal-poem-button',
+  poemActions: 'poem-actions',
+  poemDoneButton: 'poem-done-button',
+  sessionComplete: 'session-complete',
+  roomFavoriteCrown: 'room-favorite-crown',
+  sessionRecapShareButton: 'session-recap-share-button',
+} as const;
+
+const SOURCE_FILES = [
+  'app/host/page.tsx',
+  'app/join/page.tsx',
+  'components/Lobby.tsx',
+  'components/WritingScreen.tsx',
+  'components/WaitingScreen.tsx',
+  'components/RevealPhase.tsx',
+  'components/PoemDisplay.tsx',
+  'components/SessionRecapHub.tsx',
+  'components/ui/WordSlots.tsx',
+];
+
+describe('E2E selector contract', () => {
+  it('keeps load-bearing selectors frozen', () => {
+    expect(E2E_TEST_IDS).toEqual(EXPECTED_TEST_IDS);
+  });
+
+  it('binds every contract selector to source markup', () => {
+    const source = SOURCE_FILES.map((path) => readFileSync(path, 'utf8')).join(
+      '\n'
+    );
+
+    for (const key of Object.keys(EXPECTED_TEST_IDS)) {
+      expect(source, `missing data-testid binding for ${key}`).toMatch(
+        new RegExp(`data-testid=\\{E2E_TEST_IDS\\.${key}\\}`)
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `lib/e2eTestIds.ts` as the frozen selector contract for load-bearing browser controls and phase surfaces.
- Bind those test IDs in source, retarget `guestFlow.ts` and `prod-smoke.spec.ts` away from UI copy selectors, and add a unit contract test that fails when a contract selector is removed from source.
- Add `test:e2e:early-smoke` plus a non-draft-gated `early-smoke` CI job in `merge-gate`.

## Verification

- `pnpm vitest run tests/lib/e2eTestIds.test.ts` -> 2 passed.
- `pnpm vitest run tests/lib/e2eTestIds.test.ts tests/components/Lobby.test.tsx tests/components/WritingScreen.test.tsx tests/components/RevealPhase.test.tsx tests/components/PoemDisplay.test.tsx tests/components/SessionRecapHub.test.tsx` -> 107 passed.
- `pnpm format:check` -> passed.
- `CI=1 pnpm build:check` with the local Linejam env loaded -> passed.
- `env -u CANARY_API_KEY -u CANARY_ENDPOINT -u NEXT_PUBLIC_CANARY_ENDPOINT -u NEXT_PUBLIC_CANARY_API_KEY -u LINEJAM_CANARY_WEBHOOK_SECRET pnpm ci:prepush` -> 105 files passed, 1155 tests passed, 1 skipped.
- Push pre-push hook also passed: typecheck, lint, test.

## Notes

Local `pnpm test:e2e:early-smoke` reached app startup but could not complete because the active local Convex backend was missing `guestSessions:checkGuestSessionThrottle`. I did not sync production Convex. Filed `linejam-905` for the separate Canary test hermeticity friction from ambient operator env.

Agent: codex-implementation-lane
Agent-Surface: Codex CLI
Agent-Model: GPT-5.5
Agent-Task: linejam-022
