### PR TITLE
fix(ui): wire themed design tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ Testing this needs the real scheduler/DB: use convex-test via
 Kenya Hara minimalism—Zen garden aesthetic.
 
 - **Accent**: Vermillion `oklch(0.55 0.22 25)` (calligrapher's seal)
-- **Typography**: Cormorant Garamond (display) + Inter (body)
+- **Typography**: Kenya uses Libre Baskerville (display) + IBM Plex Sans (body/UI) + JetBrains Mono (technical labels); other themes define their own pairings in `lib/themes/presets/`.
 - **Colors**: Warm white background, near-black text
 - **Tokens**: CSS custom properties in `globals.css`
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for system overview: domain mod
 
 ## Design
 
-Zen Garden aesthetic—Kenya Hara minimalism with warm white, near-black text, and vermillion accent. Typography: Cormorant Garamond for display, Inter for body.
+Zen Garden aesthetic—Kenya Hara minimalism with warm white, near-black text, and vermillion accent. The default Kenya theme uses Libre Baskerville for display, IBM Plex Sans for body/UI, and JetBrains Mono for counts and technical labels; other themes define their own pairings in `lib/themes/presets/`.
 
 ## License
 

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { Button } from '@/components/ui/Button';
 import { captureError } from '@/lib/error';
 
 export default function Error({
@@ -18,19 +19,33 @@ export default function Error({
   }, [error]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
-      <h2 className="text-3xl font-semibold">Something went wrong</h2>
-      <p className="max-w-md text-sm text-muted-foreground">
-        The current round hit an unexpected error. Reload this screen and try
-        again.
-      </p>
-      <button
-        className="rounded-full border border-current px-5 py-2 text-sm font-medium"
-        onClick={reset}
-        type="button"
-      >
-        Try again
-      </button>
+    <div className="fixed inset-0 z-[100] flex flex-col items-center justify-center overflow-hidden bg-[var(--color-background)] px-6 text-center">
+      <div className="pointer-events-none absolute left-1/2 top-1/2 h-[60vh] w-[60vh] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--color-surface)] opacity-60 blur-[100px]" />
+
+      <div className="relative z-10 max-w-xl space-y-6 animate-fade-in-up">
+        <div className="space-y-2">
+          <p className="font-mono text-xs uppercase tracking-wider text-[var(--color-primary)]">
+            Error boundary
+          </p>
+          <h2 className="font-[var(--font-display)] text-3xl leading-tight text-[var(--color-text-primary)] md:text-5xl">
+            Something went wrong
+          </h2>
+          <p className="text-sm leading-relaxed text-[var(--color-text-secondary)] md:text-base">
+            The current round hit an unexpected error. Reload this screen and
+            try again.
+          </p>
+        </div>
+
+        <Button
+          className="bg-[var(--color-background)]/50 backdrop-blur-sm"
+          onClick={reset}
+          size="md"
+          type="button"
+          variant="outline"
+        >
+          Try again
+        </Button>
+      </div>
     </div>
   );
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { Button } from '@/components/ui/Button';
 import { captureError } from '@/lib/error';
 
 export default function GlobalError({
@@ -20,19 +21,33 @@ export default function GlobalError({
   return (
     <html lang="en">
       <body>
-        <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
-          <h2 className="text-3xl font-semibold">Application error</h2>
-          <p className="max-w-md text-sm text-muted-foreground">
-            Linejam hit an unexpected failure and could not recover
-            automatically.
-          </p>
-          <button
-            className="rounded-full border border-current px-5 py-2 text-sm font-medium"
-            onClick={reset}
-            type="button"
-          >
-            Try again
-          </button>
+        <div className="fixed inset-0 z-[100] flex flex-col items-center justify-center overflow-hidden bg-[var(--color-background)] px-6 text-center">
+          <div className="pointer-events-none absolute left-1/2 top-1/2 h-[60vh] w-[60vh] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--color-surface)] opacity-60 blur-[100px]" />
+
+          <div className="relative z-10 max-w-xl space-y-6 animate-fade-in-up">
+            <div className="space-y-2">
+              <p className="font-mono text-xs uppercase tracking-wider text-[var(--color-primary)]">
+                Global boundary
+              </p>
+              <h2 className="font-[var(--font-display)] text-3xl leading-tight text-[var(--color-text-primary)] md:text-5xl">
+                Application error
+              </h2>
+              <p className="text-sm leading-relaxed text-[var(--color-text-secondary)] md:text-base">
+                Linejam hit an unexpected failure and could not recover
+                automatically.
+              </p>
+            </div>
+
+            <Button
+              className="bg-[var(--color-background)]/50 backdrop-blur-sm"
+              onClick={reset}
+              size="md"
+              type="button"
+              variant="outline"
+            >
+              Try again
+            </Button>
+          </div>
         </div>
       </body>
     </html>

--- a/app/globals.css
+++ b/app/globals.css
@@ -45,6 +45,45 @@
   --color-warning: var(--color-warning);
   --color-info: var(--color-info);
 
+  /* Fonts */
+  --font-display: var(--font-display);
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
+
+  /* Typography */
+  --text-xs: var(--text-xs);
+  --text-sm: var(--text-sm);
+  --text-base: var(--text-base);
+  --text-md: var(--text-md);
+  --text-lg: var(--text-lg);
+  --text-xl: var(--text-xl);
+  --text-2xl: var(--text-2xl);
+  --text-3xl: var(--text-3xl);
+  --text-4xl: var(--text-4xl);
+  --text-5xl: var(--text-5xl);
+
+  /* Spacing - opt-in utilities (px-space-3, gap-space-3, etc.) */
+  --spacing-space-1: var(--space-1);
+  --spacing-space-2: var(--space-2);
+  --spacing-space-3: var(--space-3);
+  --spacing-space-4: var(--space-4);
+  --spacing-space-5: var(--space-5);
+  --spacing-space-6: var(--space-6);
+  --spacing-space-7: var(--space-7);
+  --spacing-space-8: var(--space-8);
+
+  /* Leading */
+  --leading-tight: var(--leading-tight);
+  --leading-normal: var(--leading-normal);
+  --leading-relaxed: var(--leading-relaxed);
+
+  /* Tracking */
+  --tracking-tighter: var(--tracking-tighter);
+  --tracking-tight: var(--tracking-tight);
+  --tracking-normal: var(--tracking-normal);
+  --tracking-wide: var(--tracking-wide);
+  --tracking-wider: var(--tracking-wider);
+
   /* Shadows */
   --shadow-sm: var(--shadow-sm);
   --shadow-md: var(--shadow-md);

--- a/components/Lobby.tsx
+++ b/components/Lobby.tsx
@@ -280,7 +280,7 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
               ))}
             </ul>
 
-            <div className="md:hidden fixed bottom-0 left-0 right-0 p-6 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[0_-8px_32px_rgba(0,0,0,0.1)] dark:shadow-[0_-8px_32px_rgba(0,0,0,0.4)]">
+            <div className="md:hidden fixed bottom-0 left-0 right-0 p-6 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[var(--shadow-lg)]">
               {error && (
                 <Alert variant="error" className="mb-4">
                   {error}

--- a/components/PoemDisplay.tsx
+++ b/components/PoemDisplay.tsx
@@ -363,8 +363,8 @@ export function PoemDisplay({
       <div
         data-testid={E2E_TEST_IDS.poemActions}
         className={cn(
-          'px-6 md:px-12 lg:px-24 py-6 border-t border-border-subtle',
-          'flex flex-col items-center gap-4',
+          'px-space-3 py-space-3 md:px-space-5 lg:px-space-6 border-t border-border-subtle',
+          'flex flex-col items-center gap-space-3',
           'transition-opacity duration-500',
           allRevealed ? 'opacity-100' : 'opacity-0 pointer-events-none'
         )}
@@ -380,7 +380,7 @@ export function PoemDisplay({
             the recap.
           </p>
         )}
-        <div className="flex items-center justify-center gap-4">
+        <div className="flex items-center justify-center gap-space-3">
           {/* Reveal variant: heart the poem toward the room-favorite crown */}
           {!isArchive && (
             <HeartButton poemId={poemId} guestToken={guestToken} />

--- a/tests/lib/themes/tailwind-theme-contract.test.ts
+++ b/tests/lib/themes/tailwind-theme-contract.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const globalsCss = readFileSync('app/globals.css', 'utf8');
+const appError = readFileSync('app/error.tsx', 'utf8');
+const globalError = readFileSync('app/global-error.tsx', 'utf8');
+const lobby = readFileSync('components/Lobby.tsx', 'utf8');
+const poemDisplay = readFileSync('components/PoemDisplay.tsx', 'utf8');
+const readme = readFileSync('README.md', 'utf8');
+const agents = readFileSync('AGENTS.md', 'utf8');
+
+const textTokens = [
+  'text-xs',
+  'text-sm',
+  'text-base',
+  'text-md',
+  'text-lg',
+  'text-xl',
+  'text-2xl',
+  'text-3xl',
+  'text-4xl',
+  'text-5xl',
+] as const;
+
+const spacingTokens = [
+  'space-1',
+  'space-2',
+  'space-3',
+  'space-4',
+  'space-5',
+  'space-6',
+  'space-7',
+  'space-8',
+] as const;
+
+const lineHeightTokens = [
+  'leading-tight',
+  'leading-normal',
+  'leading-relaxed',
+] as const;
+
+const trackingTokens = [
+  'tracking-tighter',
+  'tracking-tight',
+  'tracking-normal',
+  'tracking-wide',
+  'tracking-wider',
+] as const;
+
+describe('Tailwind theme contract', () => {
+  it('registers runtime typography and opt-in spacing tokens as first-class Tailwind utilities', () => {
+    for (const token of textTokens) {
+      expect(globalsCss).toContain(`--${token}: var(--${token});`);
+    }
+
+    for (const token of spacingTokens) {
+      const suffix = token.replace('space-', '');
+      expect(globalsCss).toContain(`--spacing-${token}: var(--${token});`);
+      expect(globalsCss).not.toContain(`--spacing-${suffix}: var(--${token});`);
+    }
+
+    for (const token of lineHeightTokens) {
+      expect(globalsCss).toContain(`--${token}: var(--${token});`);
+    }
+
+    for (const token of trackingTokens) {
+      expect(globalsCss).toContain(`--${token}: var(--${token});`);
+    }
+  });
+
+  it('keeps application error boundaries on the theme system', () => {
+    for (const source of [appError, globalError]) {
+      expect(source).toContain(
+        "import { Button } from '@/components/ui/Button'"
+      );
+      expect(source).toContain('<Button');
+      expect(source).toContain('font-[var(--font-display)]');
+      expect(source).not.toContain('text-muted-foreground');
+    }
+  });
+
+  it('does not use raw rgba shadow escapes in the lobby chrome', () => {
+    expect(lobby).not.toMatch(/shadow-\[[^\]]*rgba/);
+  });
+
+  it('uses opt-in theme spacing utilities instead of globally remapping numeric padding', () => {
+    expect(poemDisplay).toContain('px-space-3');
+    expect(poemDisplay).toContain('gap-space-3');
+  });
+
+  it('documents the default Kenya font pairing without stale preset drift', () => {
+    for (const source of [readme, agents]) {
+      expect(source).toContain('Libre Baskerville');
+      expect(source).toContain('IBM Plex Sans');
+      expect(source).not.toContain(
+        'Cormorant Garamond for display, Inter for body'
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Register runtime font, text, spacing, leading, and tracking tokens in Tailwind's theme bridge.
- Move app error boundaries onto the shared Button/theme treatment and remove the undefined text-muted-foreground class.
- Reconcile Kenya font docs with the actual preset and replace the mobile lobby raw rgba shadow with a theme shadow token.
- Add a static contract test for the design-token wiring and drift checks.

## Evidence
- Red first: `pnpm vitest run tests/lib/themes/tailwind-theme-contract.test.ts` failed 3/3 before implementation.
- `pnpm vitest run tests/lib/themes/tailwind-theme-contract.test.ts tests/lib/themes/schema.test.ts tests/lib/themes/apply.test.ts tests/lib/themes/context.test.tsx tests/components/Lobby.test.tsx` -> 5 files passed, 29 tests passed.
- `pnpm typecheck` -> passed.
- `pnpm lint` -> passed.
- `pnpm format:check` -> passed.
- `CI=1 pnpm build:check` -> passed.
- Pre-push hook on branch push -> typecheck, lint, and Vitest passed: 106 files, 1159 tests passed, 1 skipped.
- Four-theme visual evidence captured locally at `/Users/phaedrus/.factory-lanes/campaign/linejam-025-theme-diff/` with `kenya.png`, `mono.png`, `vintage-paper.png`, `hyper.png`, and `manifest.json` showing distinct token values across themes.

## Residual Risk
- No production deploy or Convex sync was performed by this lane.

Agent: codex-implementation-lane
Agent-Surface: Codex CLI
Agent-Model: GPT-5.5
Agent-Task: linejam-025
Agent-Context: /Users/phaedrus/Development/linejam-campaign-work