### PR TITLE
fix(convex): drop legacy mode columns

### DIFF
--- a/convex/lib/gameRules.ts
+++ b/convex/lib/gameRules.ts
@@ -7,8 +7,8 @@
  * a non-nine-round matrix can exist; no new game is ever anything but classic)
  * finishes without an out-of-bounds throw. Its per-round *word counts* still read
  * from the canonical shape below: a legacy 5-round "quick" game would see classic
- * counts on its two divergent rounds (the original shape lived in the now-deleted
- * `mode` field and isn't recoverable from the matrix). That cosmetic mismatch is
+ * counts on its two divergent rounds (the original shape is no longer stored and
+ * isn't recoverable from the matrix). That cosmetic mismatch is
  * acceptable for a deploy-window-only game; the crash the matrix bound avoids is
  * not.
  */

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,7 +1,44 @@
 import { ConvexError, v } from 'convex/values';
-import { mutation } from './_generated/server';
+import { internalMutation, mutation } from './_generated/server';
 import { verifyGuestToken } from './lib/guestToken';
 import { ensureUserHelper } from './users';
+
+const hasOwn = (value: object, key: string) =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+const removeGameModePatch = { mode: undefined } as never;
+const removeSelectedModePatch = { selectedMode: undefined } as never;
+
+export const dropLegacyModeColumns = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const [games, rooms] = await Promise.all([
+      ctx.db.query('games').collect(),
+      ctx.db.query('rooms').collect(),
+    ]);
+
+    const gamesWithMode = games.filter((game) => hasOwn(game, 'mode'));
+    const roomsWithSelectedMode = rooms.filter((room) =>
+      hasOwn(room, 'selectedMode')
+    );
+
+    await Promise.all([
+      ...gamesWithMode.map((game) =>
+        ctx.db.patch(game._id, removeGameModePatch)
+      ),
+      ...roomsWithSelectedMode.map((room) =>
+        ctx.db.patch(room._id, removeSelectedModePatch)
+      ),
+    ]);
+
+    return {
+      gamesScanned: games.length,
+      gamesCleared: gamesWithMode.length,
+      roomsScanned: rooms.length,
+      roomsCleared: roomsWithSelectedMode.length,
+    };
+  },
+});
 
 export const migrateGuestToUser = mutation({
   args: {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -33,9 +33,6 @@ export default defineSchema({
     completedAt: v.optional(v.number()),
     currentGameId: v.optional(v.id('games')),
     currentCycle: v.optional(v.number()),
-    /** Legacy, unused: the game is single-mode. Retained (optional string) so
-     *  existing rows that carry a mode value stay valid without a migration. */
-    selectedMode: v.optional(v.string()),
   })
     .index('by_code', ['code'])
     .index('by_host', ['hostUserId'])
@@ -59,9 +56,6 @@ export default defineSchema({
     status: v.union(v.literal('IN_PROGRESS'), v.literal('COMPLETED')),
     /** Game session count for this room. First game = 1. */
     cycle: v.number(),
-    /** Legacy, unused: the game is single-mode. Retained (optional string) so
-     *  existing rows that carry a mode value stay valid without a migration. */
-    mode: v.optional(v.string()),
     /** Round index within current game. Shape comes from convex/lib/gameRules.ts. */
     currentRound: v.number(),
     /** When the current round opened. Drives the soft clock and ghostwriter overtime gate. */

--- a/tests/convex/abandonment.test.ts
+++ b/tests/convex/abandonment.test.ts
@@ -111,7 +111,6 @@ async function seedClassicGame(
       roomId,
       status: 'IN_PROGRESS',
       cycle: 1,
-      mode: 'classic',
       currentRound,
       roundStartedAt: opts.roundStartedAt ?? createdAt,
       assignmentMatrix: matrix,

--- a/tests/convex/aiLifecycle.test.ts
+++ b/tests/convex/aiLifecycle.test.ts
@@ -108,7 +108,6 @@ async function seedClassicGame(
       roomId,
       status: 'IN_PROGRESS',
       cycle: 1,
-      mode: 'classic',
       currentRound,
       roundStartedAt: opts.roundStartedAt ?? createdAt,
       assignmentMatrix: matrix,

--- a/tests/convex/fillStaleHumanTurns.test.ts
+++ b/tests/convex/fillStaleHumanTurns.test.ts
@@ -98,7 +98,6 @@ async function seedGame(
       roomId,
       status,
       cycle: 1,
-      mode: 'classic',
       currentRound,
       roundStartedAt: now,
       assignmentMatrix: matrix,

--- a/tests/convex/hostMigration.test.ts
+++ b/tests/convex/hostMigration.test.ts
@@ -95,7 +95,6 @@ async function seedGame(
       roomId,
       status: 'IN_PROGRESS',
       cycle: 1,
-      mode: 'classic',
       currentRound: 0,
       roundStartedAt,
       assignmentMatrix: matrix,

--- a/tests/convex/legacyModeColumns.test.ts
+++ b/tests/convex/legacyModeColumns.test.ts
@@ -1,0 +1,121 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { defineSchema, defineTable } from 'convex/server';
+import { v } from 'convex/values';
+import { internal } from '../../convex/_generated/api';
+import { setupConvexTestWithSchema } from '../helpers/convexTest';
+import schema from '../../convex/schema';
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+
+function readSourceFiles(dir: string): Array<[path: string, source: string]> {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const absolutePath = join(dir, entry.name);
+    if (entry.isDirectory()) return readSourceFiles(absolutePath);
+    if (!entry.name.endsWith('.ts') && !entry.name.endsWith('.tsx')) return [];
+    return [[absolutePath, readFileSync(absolutePath, 'utf8')]];
+  });
+}
+
+const legacyModeSchema = defineSchema({
+  users: defineTable({
+    displayName: v.string(),
+    createdAt: v.number(),
+    kind: v.optional(v.union(v.literal('human'), v.literal('AI'))),
+  }),
+
+  rooms: defineTable({
+    code: v.string(),
+    hostUserId: v.id('users'),
+    status: v.union(
+      v.literal('LOBBY'),
+      v.literal('IN_PROGRESS'),
+      v.literal('COMPLETED')
+    ),
+    createdAt: v.number(),
+    selectedMode: v.optional(v.string()),
+  }),
+
+  games: defineTable({
+    roomId: v.id('rooms'),
+    status: v.union(v.literal('IN_PROGRESS'), v.literal('COMPLETED')),
+    cycle: v.number(),
+    mode: v.optional(v.string()),
+    currentRound: v.number(),
+    assignmentMatrix: v.array(v.array(v.id('users'))),
+    createdAt: v.number(),
+  }),
+});
+
+describe('legacy mode column migration', () => {
+  it('clears existing game.mode and room.selectedMode values before the schema drop', async () => {
+    const t = setupConvexTestWithSchema(legacyModeSchema);
+
+    const { gameId, roomId } = await t.run(async (ctx) => {
+      const hostUserId = await ctx.db.insert('users', {
+        displayName: 'Host',
+        kind: 'human',
+        createdAt: 0,
+      });
+      const roomId = await ctx.db.insert('rooms', {
+        code: 'DROP',
+        hostUserId,
+        status: 'IN_PROGRESS',
+        selectedMode: 'classic',
+        createdAt: 0,
+      });
+      const gameId = await ctx.db.insert('games', {
+        roomId,
+        status: 'IN_PROGRESS',
+        cycle: 1,
+        mode: 'classic',
+        currentRound: 0,
+        assignmentMatrix: [[hostUserId]],
+        createdAt: 0,
+      });
+
+      return { gameId, roomId };
+    });
+
+    const result = await t.mutation(
+      internal.migrations.dropLegacyModeColumns,
+      {}
+    );
+
+    expect(result).toEqual({
+      gamesScanned: 1,
+      gamesCleared: 1,
+      roomsScanned: 1,
+      roomsCleared: 1,
+    });
+
+    const { game, room } = await t.run(async (ctx) => ({
+      game: await ctx.db.get(gameId),
+      room: await ctx.db.get(roomId),
+    }));
+
+    expect(game).not.toHaveProperty('mode');
+    expect(room).not.toHaveProperty('selectedMode');
+  });
+
+  it('keeps the final schema and tests free of the retired mode columns', async () => {
+    const schemaSource = readFileSync(
+      join(repoRoot, 'convex/schema.ts'),
+      'utf8'
+    );
+    const convexTestSources = readSourceFiles(join(repoRoot, 'tests/convex'));
+
+    expect(JSON.stringify(schema)).not.toContain('selectedMode');
+    expect(JSON.stringify(schema)).not.toContain('"mode"');
+    expect(schemaSource).not.toContain('selectedMode');
+    expect(schemaSource).not.toMatch(/\bmode:\s*v\.optional/);
+
+    const staleSeeders = convexTestSources
+      .filter(([path]) => !path.endsWith('legacyModeColumns.test.ts'))
+      .filter(([, source]) => /\bmode:\s*['"]classic['"]/.test(source));
+
+    expect(staleSeeders).toEqual([]);
+  });
+});

--- a/tests/convex/roomLifecycle.test.ts
+++ b/tests/convex/roomLifecycle.test.ts
@@ -64,7 +64,6 @@ async function seedCompletedRoom(
       roomId,
       status: 'COMPLETED',
       cycle: 1,
-      mode: 'classic',
       currentRound: 8,
       assignmentMatrix: [[hostId, guestId]],
       createdAt: 0,

--- a/tests/convex/rooms.test.ts
+++ b/tests/convex/rooms.test.ts
@@ -76,7 +76,6 @@ async function seedRoomWithActiveGame(
       roomId,
       status: 'IN_PROGRESS',
       cycle: 1,
-      mode: 'classic',
       currentRound: 0,
       assignmentMatrix: [[hostId, guestId]],
       createdAt: 0,

--- a/tests/helpers/convexTest.ts
+++ b/tests/helpers/convexTest.ts
@@ -1,4 +1,5 @@
 import { convexTest } from 'convex-test';
+import type { GenericSchema, SchemaDefinition } from 'convex/server';
 import schema from '../../convex/schema';
 
 // `import.meta.glob` is a Vite transform — present at runtime under Vitest but
@@ -25,4 +26,10 @@ const modules = import.meta.glob('../../convex/**/*.*s');
 
 export function setupConvexTest() {
   return convexTest(schema, modules);
+}
+
+export function setupConvexTestWithSchema<Schema extends GenericSchema>(
+  testSchema: SchemaDefinition<Schema, boolean>
+) {
+  return convexTest(testSchema, modules);
 }


### PR DESCRIPTION
## Summary
- add `internal.migrations.dropLegacyModeColumns` to clear legacy `games.mode` and `rooms.selectedMode` values
- drop the retired fields from the Convex schema after the migration contract
- remove stale `mode: classic` test seeders and add convex-test coverage for legacy rows

## Verification
- red first: `pnpm vitest run tests/convex/legacyModeColumns.test.ts` failed before implementation on the missing migration export and live schema fields
- `pnpm vitest run tests/convex/legacyModeColumns.test.ts`
- `pnpm vitest run tests/convex/legacyModeColumns.test.ts tests/convex/hostMigration.test.ts tests/convex/abandonment.test.ts tests/convex/roomLifecycle.test.ts tests/convex/rooms.test.ts tests/convex/fillStaleHumanTurns.test.ts tests/convex/aiLifecycle.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `LINEJAM_ALLOW_UNSYNCED_CONVEX_THROTTLE=1 CI=1 pnpm build:check` with the canonical populated `.env.local` loaded
- clean-env `pnpm ci:prepush` -> 107 files passed, 1162 tests passed, 1 skipped
- push hook reran typecheck, lint, and tests -> 107 files passed, 1162 tests passed, 1 skipped
- no reader/writer grep outside the migration and migration test: `rg -n "selectedMode|mode: 'classic'|mode: \\\"classic\\\"|\\bmode:\\s*v\\.optional|\\bgame\\.mode\\b|\\broom\\.selectedMode\\b" convex app components lib tests -g "!convex/_generated/**" -g "!convex/migrations.ts" -g "!tests/convex/legacyModeColumns.test.ts"` returned no matches\n\n## Convex migration note\nProduction Convex was not synced by this lane. A dev-only `convex run` attempt from the isolated worktree failed because its `.env.local` selectors are blank. Retrying with the canonical checkout selector reached Convex but failed with MissingAccessToken and instructions to authenticate via `npx convex dev`, which repo AGENTS forbids agents from running. That tooling gap is filed as Powder `linejam-908`; production still needs the migration run before any production schema sync.\n\nAgent: codex-linejam-019\nAgent-Surface: Codex CLI\nAgent-Model: GPT-5.5\nAgent-Task: linejam-019\nAgent-Context: /Users/phaedrus/Development/linejam-campaign-work