### PR TITLE
fix(errors): ConvexError taxonomy so friendly messages survive production

### DIFF
--- a/app/host/page.tsx
+++ b/app/host/page.tsx
@@ -89,7 +89,11 @@ export default function HostPage() {
             </div>
 
             {error && (
-              <Alert variant="error" className="mt-4">
+              <Alert
+                variant="error"
+                data-testid={E2E_TEST_IDS.hostErrorAlert}
+                className="mt-4"
+              >
                 {error}
               </Alert>
             )}

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -129,7 +129,11 @@ function JoinForm() {
           </div>
 
           {error && (
-            <Alert variant="error" className="mt-4">
+            <Alert
+              variant="error"
+              data-testid={E2E_TEST_IDS.joinErrorAlert}
+              className="mt-4"
+            >
               {error}
             </Alert>
           )}

--- a/convex/README.md
+++ b/convex/README.md
@@ -46,3 +46,13 @@ LOBBY -> IN_PROGRESS (9 rounds) -> COMPLETED
 ```
 
 Assignment matrix ensures no player writes consecutive lines on same poem.
+
+## Error Convention
+
+Player-facing functions throw `ConvexError` (from `convex/values`), never
+plain `Error`: Convex redacts plain `Error` messages in production, which
+silently breaks the friendly-message mappings in `lib/errorFeedback.ts`.
+An eslint `no-restricted-syntax` gate (see `eslint.config.mjs`) enforces
+this for `convex/*.ts` and the player-path lib modules. Internal invariants
+(guest token internals, canary, AI providers) may keep plain `Error` —
+there, prod redaction is a feature.

--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -5,7 +5,7 @@
  * AI players are real user records with kind='AI' for clean attribution.
  */
 
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 import {
   mutation,
   internalMutation,
@@ -313,7 +313,7 @@ export const addAiPlayer = mutation({
   },
   handler: async (ctx, { code, guestToken }) => {
     const user = await getUser(ctx, guestToken);
-    if (!user) throw new Error('User not found');
+    if (!user) throw new ConvexError('User not found');
 
     await checkMutationAbuseRateLimit(ctx, {
       operation: 'addAiPlayer',
@@ -323,11 +323,11 @@ export const addAiPlayer = mutation({
 
     const room = await requireRoomByCode(ctx, code);
     if (room.hostUserId !== user._id)
-      throw new Error('Only host can add AI player');
+      throw new ConvexError('Only host can add AI player');
 
     // Can only add AI in lobby (no active game)
     const activeGame = await getActiveGame(ctx, room._id);
-    if (activeGame) throw new Error('Can only add AI in lobby');
+    if (activeGame) throw new ConvexError('Can only add AI in lobby');
 
     // Check player count
     const players = await ctx.db
@@ -335,7 +335,7 @@ export const addAiPlayer = mutation({
       .withIndex('by_room', (q) => q.eq('roomId', room._id))
       .collect();
 
-    if (players.length >= 8) throw new Error('Room is full');
+    if (players.length >= 8) throw new ConvexError('Room is full');
 
     // Bots are capped per room (configurable). Solo play wants a few, not a
     // swarm. Selection stays inside this mutation so Convex OCC serializes the
@@ -346,7 +346,7 @@ export const addAiPlayer = mutation({
     );
     const existingAi = existingUsers.filter((u) => u?.kind === 'AI');
     if (existingAi.length >= getMaxAiPlayers()) {
-      throw new Error('Bot limit reached');
+      throw new ConvexError('Bot limit reached');
     }
 
     // Distinct persona per bot until the roster is exhausted.
@@ -393,15 +393,15 @@ export const removeAiPlayer = mutation({
   },
   handler: async (ctx, { code, guestToken, aiUserId }) => {
     const user = await getUser(ctx, guestToken);
-    if (!user) throw new Error('User not found');
+    if (!user) throw new ConvexError('User not found');
 
     const room = await requireRoomByCode(ctx, code);
     if (room.hostUserId !== user._id)
-      throw new Error('Only host can remove AI player');
+      throw new ConvexError('Only host can remove AI player');
 
     // Can only remove AI in lobby (no active game)
     const activeGame = await getActiveGame(ctx, room._id);
-    if (activeGame) throw new Error('Can only remove AI in lobby');
+    if (activeGame) throw new ConvexError('Can only remove AI in lobby');
 
     const players = await ctx.db
       .query('roomPlayers')

--- a/convex/favorites.ts
+++ b/convex/favorites.ts
@@ -1,4 +1,4 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 import { mutation, query } from './_generated/server';
 import { getUser, checkParticipation } from './lib/auth';
 import { getRoomByCode, getCompletedGame } from './lib/room';
@@ -10,7 +10,7 @@ export const toggleFavorite = mutation({
   },
   handler: async (ctx, { poemId, guestToken }) => {
     const user = await getUser(ctx, guestToken);
-    if (!user) throw new Error('User not found');
+    if (!user) throw new ConvexError('User not found');
 
     const existing = await ctx.db
       .query('favorites')

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -39,7 +39,7 @@ export const startGame = mutation({
   },
   handler: async (ctx, { code, guestToken }) => {
     const user = await getUser(ctx, guestToken);
-    if (!user) throw new Error('User not found');
+    if (!user) throw new ConvexError('User not found');
 
     await checkMutationAbuseRateLimit(ctx, {
       operation: 'startGame',
@@ -57,20 +57,20 @@ export const startGame = mutation({
         checkParticipation(ctx, room._id, user._id),
       ]);
       if (!completedGame || !isParticipant) {
-        throw new Error('Only host can start game');
+        throw new ConvexError('Only host can start game');
       }
     }
 
     // Check no game is currently in progress (authoritative check)
     const activeGame = await getActiveGame(ctx, room._id);
-    if (activeGame) throw new Error('Game already in progress');
+    if (activeGame) throw new ConvexError('Game already in progress');
 
     const players = await ctx.db
       .query('roomPlayers')
       .withIndex('by_room', (q) => q.eq('roomId', room._id))
       .collect();
 
-    if (players.length < 2) throw new Error('Need at least 2 players');
+    if (players.length < 2) throw new ConvexError('Need at least 2 players');
 
     // Assign seats (cryptographically secure random shuffle)
     const shuffledPlayers = secureShuffle([...players]);
@@ -142,7 +142,7 @@ export const startNewCycle = mutation({
   },
   handler: async (ctx, { roomCode, guestToken }) => {
     const user = await getUser(ctx, guestToken);
-    if (!user) throw new Error('User not found');
+    if (!user) throw new ConvexError('User not found');
 
     const room = await requireRoomByCode(ctx, roomCode);
 
@@ -150,7 +150,7 @@ export const startNewCycle = mutation({
     // a vanished host must never strand the recap.
     const isParticipant = await checkParticipation(ctx, room._id, user._id);
     if (!isParticipant) {
-      throw new Error('Only players in this room can start a new cycle');
+      throw new ConvexError('Only players in this room can start a new cycle');
     }
 
     // Check that there's a completed game (authoritative check)
@@ -164,10 +164,10 @@ export const startNewCycle = mutation({
     });
     if (!cycleReset.ok) {
       if (cycleReset.reason === 'GAME_STILL_IN_PROGRESS') {
-        throw new Error('Game still in progress');
+        throw new ConvexError('Game still in progress');
       }
 
-      throw new Error('No completed game to continue from');
+      throw new ConvexError('No completed game to continue from');
     }
 
     // Reset room to LOBBY for the next cycle
@@ -248,7 +248,7 @@ export const submitLine = mutation({
   },
   handler: async (ctx, { poemId, lineIndex, text, guestToken }) => {
     const user = await getUser(ctx, guestToken);
-    if (!user) throw new Error('User not found');
+    if (!user) throw new ConvexError('User not found');
 
     await checkMutationAbuseRateLimit(ctx, {
       operation: 'submitLine',
@@ -257,16 +257,16 @@ export const submitLine = mutation({
     });
 
     const poem = await ctx.db.get(poemId);
-    if (!poem) throw new Error('Poem not found');
+    if (!poem) throw new ConvexError('Poem not found');
 
     // Get game directly from poem (stable, immutable reference)
     // This avoids race conditions from room.currentGameId pointer
     const game = await ctx.db.get(poem.gameId);
-    if (!game) throw new Error('Game not found');
+    if (!game) throw new ConvexError('Game not found');
 
     // Fetch room for completion logic (host assignment)
     const room = await ctx.db.get(poem.roomId);
-    if (!room) throw new Error('Room not found');
+    if (!room) throw new ConvexError('Room not found');
 
     // Check if already submitted (idempotent - silently succeed if already done)
     const existing = await ctx.db
@@ -286,21 +286,21 @@ export const submitLine = mutation({
     const submissionWindow = getSubmissionWindow(game, lineIndex);
     if (!submissionWindow.ok) {
       if (submissionWindow.reason === 'GAME_NOT_IN_PROGRESS') {
-        throw new Error('Game not in progress');
+        throw new ConvexError('Game not in progress');
       }
 
       if (submissionWindow.reason === 'INVALID_ROUND') {
-        throw new Error('Invalid round');
+        throw new ConvexError('Invalid round');
       }
 
-      throw new Error('Round not started yet');
+      throw new ConvexError('Round not started yet');
     }
 
     // Validate assignment (immutable matrix - always stable)
     const assignedUserId = getMatrixRound(game.assignmentMatrix, lineIndex)[
       poem.indexInRoom
     ];
-    if (assignedUserId !== user._id) throw new Error('Not your turn');
+    if (assignedUserId !== user._id) throw new ConvexError('Not your turn');
 
     // Validate line length (prevent storage abuse)
     if (text.length > MAX_LINE_LENGTH) {
@@ -313,7 +313,9 @@ export const submitLine = mutation({
     const wordCount = countWords(text);
     const expectedCount = WORD_COUNTS[lineIndex];
     if (wordCount !== expectedCount) {
-      throw new Error(`Expected ${expectedCount} words, got ${wordCount}`);
+      throw new ConvexError(
+        `Expected ${expectedCount} words, got ${wordCount}`
+      );
     }
 
     await ctx.db.insert('lines', {
@@ -341,20 +343,20 @@ export const summonGhostwriter = mutation({
   },
   handler: async (ctx, { roomCode, guestToken }) => {
     const user = await getUser(ctx, guestToken);
-    if (!user) throw new Error('User not found');
+    if (!user) throw new ConvexError('User not found');
 
     const room = await requireRoomByCode(ctx, roomCode);
     if (room.hostUserId !== user._id) {
-      throw new Error('Only host can summon the ghostwriter');
+      throw new ConvexError('Only host can summon the ghostwriter');
     }
 
     const game = await getActiveGame(ctx, room._id);
-    if (!game) throw new Error('No game in progress');
+    if (!game) throw new ConvexError('No game in progress');
 
     // The ghost only answers after real overtime — no skipping slow friends.
     const roundStartedAt = game.roundStartedAt ?? game.createdAt;
     if (Date.now() - roundStartedAt < GHOSTWRITER_OVERTIME_MS) {
-      throw new Error('The ghostwriter only answers after overtime');
+      throw new ConvexError('The ghostwriter only answers after overtime');
     }
 
     const poems = await ctx.db
@@ -560,17 +562,17 @@ export const revealPoem = mutation({
   },
   handler: async (ctx, { poemId, guestToken }) => {
     const user = await getUser(ctx, guestToken);
-    if (!user) throw new Error('User not found');
+    if (!user) throw new ConvexError('User not found');
 
     const poem = await ctx.db.get(poemId);
-    if (!poem) throw new Error('Poem not found');
+    if (!poem) throw new ConvexError('Poem not found');
 
     if (poem.assignedReaderId !== user._id) {
-      throw new Error('This poem is not assigned to you');
+      throw new ConvexError('This poem is not assigned to you');
     }
 
     if (poem.revealedAt) {
-      throw new Error('Poem already revealed');
+      throw new ConvexError('Poem already revealed');
     }
 
     await ctx.db.patch(poemId, {

--- a/convex/lib/assignPoemReaders.ts
+++ b/convex/lib/assignPoemReaders.ts
@@ -10,6 +10,7 @@
  * - No leaky abstractions: Callers don't know about AI players
  */
 
+import { ConvexError } from 'convex/values';
 import { Id } from '../_generated/dataModel';
 
 interface Poem {
@@ -49,7 +50,7 @@ export function assignPoemReaders(
   const humanPlayers = allPlayers.filter((p) => p.kind !== 'AI');
 
   if (humanPlayers.length === 0) {
-    throw new Error('Cannot assign readers: no human players');
+    throw new ConvexError('Cannot assign readers: no human players');
   }
 
   // Shuffle poems for randomness (avoid predictable patterns)

--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -1,3 +1,4 @@
+import { ConvexError } from 'convex/values';
 import { QueryCtx, MutationCtx } from '../_generated/server';
 import { Doc, Id } from '../_generated/dataModel';
 import { verifyGuestToken } from './guestToken';
@@ -47,7 +48,7 @@ export async function requireUser(
 ): Promise<Doc<'users'>> {
   const user = await getUser(ctx, guestToken);
   if (!user) {
-    throw new Error('Unauthorized: User not found');
+    throw new ConvexError('Unauthorized: User not found');
   }
   return user;
 }

--- a/convex/lib/room.ts
+++ b/convex/lib/room.ts
@@ -1,3 +1,4 @@
+import { ConvexError } from 'convex/values';
 import { QueryCtx, MutationCtx } from '../_generated/server';
 import { Doc, Id } from '../_generated/dataModel';
 import { isPresenceStale } from './gameRules';
@@ -96,7 +97,7 @@ export async function requireRoomByCode(
 ): Promise<Doc<'rooms'>> {
   const room = await getRoomByCode(ctx, code);
   if (!room) {
-    throw new Error('Room not found');
+    throw new ConvexError('Room not found');
   }
   return room;
 }

--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -1,6 +1,6 @@
 import { v, ConvexError } from 'convex/values';
 import { mutation, query } from './_generated/server';
-import { ensureUserHelper } from './users';
+import { ensureUserHelper, normalizeDisplayName } from './users';
 import { getUser, checkParticipation } from './lib/auth';
 import { PRESENCE_AWAY_MS, isPresenceStale } from './lib/gameRules';
 import { checkMutationAbuseRateLimit } from './lib/abuseRateLimit';
@@ -103,19 +103,7 @@ export const joinRoom = mutation({
     // Check no game is in progress (authoritative check)
     const activeGame = await getActiveGame(ctx, room._id);
     if (activeGame) {
-      throw new Error('Cannot join a room with a game in progress');
-    }
-
-    const roomPlayers = await ctx.db
-      .query('roomPlayers')
-      .withIndex('by_room_user', (q) =>
-        q.eq('roomId', room._id).eq('userId', user._id)
-      )
-      .first();
-
-    if (roomPlayers) {
-      // User is already in the room, just return room state
-      return room;
+      throw new ConvexError('Cannot join a room with a game in progress');
     }
 
     const currentPlayers = await ctx.db
@@ -123,16 +111,40 @@ export const joinRoom = mutation({
       .withIndex('by_room', (q) => q.eq('roomId', room._id))
       .collect();
 
+    // A COMPLETED room with players is a between-games lobby (still
+    // joinable); a COMPLETED room with none was closed by the host or
+    // swept — a dead code, not a party.
+    if (room.status === 'COMPLETED' && currentPlayers.length === 0) {
+      throw new ConvexError('Room is closed');
+    }
+
+    const typedName = normalizeDisplayName(displayName);
+    const existingPlayer = currentPlayers.find((p) => p.userId === user._id);
+
+    if (existingPlayer) {
+      // User is already in the room. Honor the typed display name rather
+      // than silently discarding it (rejoins only reach here in lobby —
+      // the in-progress guard above fires first).
+      if (existingPlayer.displayName !== typedName) {
+        await ctx.db.patch(existingPlayer._id, { displayName: typedName });
+        await ctx.db.patch(user._id, { displayName: typedName });
+      }
+      return room;
+    }
+
     if (currentPlayers.length >= 8) {
-      throw new Error('Room is full');
+      throw new ConvexError('Room is full');
     }
 
     await ctx.db.insert('roomPlayers', {
       roomId: room._id,
       userId: user._id,
-      displayName: displayName,
+      displayName: typedName,
       joinedAt: Date.now(),
     });
+    if (user.displayName !== typedName) {
+      await ctx.db.patch(user._id, { displayName: typedName });
+    }
 
     return room;
   },

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -79,7 +79,7 @@ export const ensureUser = mutation({
 
 const MAX_DISPLAY_NAME_LENGTH = 50;
 
-const normalizeDisplayName = (raw: string): string => {
+export const normalizeDisplayName = (raw: string): string => {
   const normalized = raw.trim().replace(/\s+/g, ' ');
   if (!normalized) {
     throw new ConvexError('Display name is required');

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,6 +52,11 @@ const eslintConfig = defineConfig([
           message:
             "Convex redacts plain Error in production, so lib/errorFeedback.ts mappings never fire. Throw ConvexError (from 'convex/values') on player-facing paths instead.",
         },
+        {
+          selector: "ThrowStatement > CallExpression[callee.name='Error']",
+          message:
+            "Convex redacts plain Error in production, so lib/errorFeedback.ts mappings never fire. Throw ConvexError (from 'convex/values') on player-facing paths instead.",
+        },
       ],
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,33 @@ const eslintConfig = defineConfig([
       "no-console": ["error", { allow: ["warn", "error"] }],
     },
   },
+  // Player-path Convex functions must throw ConvexError, never plain Error:
+  // Convex redacts plain Error messages in production ("Server Error"), which
+  // silently breaks every friendly mapping in lib/errorFeedback.ts
+  // (linejam-941). Top-level convex/*.ts modules hold all public
+  // mutations/queries; the listed lib modules throw on player paths. Internal
+  // lib code (guestToken, canary, AI providers) may keep plain Error — for
+  // genuinely internal invariants, prod redaction is a feature.
+  {
+    files: [
+      "convex/*.ts",
+      "convex/lib/room.ts",
+      "convex/lib/auth.ts",
+      "convex/lib/rateLimit.ts",
+      "convex/lib/abuseRateLimit.ts",
+      "convex/lib/assignPoemReaders.ts",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "ThrowStatement > NewExpression[callee.name='Error']",
+          message:
+            "Convex redacts plain Error in production, so lib/errorFeedback.ts mappings never fire. Throw ConvexError (from 'convex/values') on player-facing paths instead.",
+        },
+      ],
+    },
+  },
   // Relax no-console in files that legitimately need it
   {
     files: [

--- a/lib/e2eTestIds.ts
+++ b/lib/e2eTestIds.ts
@@ -4,6 +4,8 @@ export const E2E_TEST_IDS = {
   joinRoomCodeInput: 'join-room-code-input',
   joinNameInput: 'join-name-input',
   joinRoomButton: 'join-room-button',
+  joinErrorAlert: 'join-error-alert',
+  hostErrorAlert: 'host-error-alert',
   lobbyStartGameButton: 'lobby-start-game-button',
   lobbyWaitingForHostButton: 'lobby-waiting-for-host-button',
   writingPhase: 'writing-phase',

--- a/lib/errorFeedback.ts
+++ b/lib/errorFeedback.ts
@@ -77,6 +77,21 @@ export function errorToFeedback(error: unknown): ErrorFeedback {
     };
   }
 
+  if (isRoomFullError(message)) {
+    return {
+      message:
+        'This room is full (8 players max). Ask the host to start a new room.',
+      variant: 'error',
+    };
+  }
+
+  if (isRoomClosedError(message)) {
+    return {
+      message: 'This room has been closed. Ask the host for a new room code.',
+      variant: 'error',
+    };
+  }
+
   if (isRateLimitError(message)) {
     return {
       message:
@@ -102,6 +117,21 @@ export function errorToFeedback(error: unknown): ErrorFeedback {
  * Handles: Error objects, strings, unknown objects
  */
 function extractErrorMessage(error: unknown): string {
+  // ConvexError carries its payload in `data` — the ONLY field that survives
+  // Convex's production redaction (plain `Error.message` becomes "Server
+  // Error" in prod, which is why every player-path Convex function must throw
+  // ConvexError; see the eslint no-restricted-syntax gate in eslint.config.mjs).
+  // Duck-typed rather than instanceof so it works across bundler copies of
+  // the convex package.
+  if (
+    error &&
+    typeof error === 'object' &&
+    'data' in error &&
+    typeof (error as { data: unknown }).data === 'string'
+  ) {
+    return (error as { data: string }).data;
+  }
+
   if (error instanceof Error) {
     return error.message;
   }
@@ -155,8 +185,17 @@ function isGameAlreadyStartedError(message: string): boolean {
   const lowerMessage = message.toLowerCase();
   return (
     lowerMessage.includes('not in lobby status') ||
-    lowerMessage.includes('already started')
+    lowerMessage.includes('already started') ||
+    lowerMessage.includes('game in progress')
   );
+}
+
+function isRoomFullError(message: string): boolean {
+  return message.toLowerCase().includes('room is full');
+}
+
+function isRoomClosedError(message: string): boolean {
+  return message.toLowerCase().includes('room is closed');
 }
 
 function isRateLimitError(message: string): boolean {

--- a/tests/convex/rooms.test.ts
+++ b/tests/convex/rooms.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { ConvexError } from 'convex/values';
 import { api } from '../../convex/_generated/api';
 import type { Id } from '../../convex/_generated/dataModel';
 import { setupConvexTest } from '../helpers/convexTest';
@@ -389,6 +390,148 @@ describe('joinRoom', () => {
         guestToken,
       })
     ).rejects.toThrow('Rate limit exceeded');
+  });
+
+  it('throws ConvexError (not plain Error) so messages survive prod redaction', async () => {
+    // Convex redacts plain Error messages in production, which breaks the
+    // lib/errorFeedback.ts friendly-message mappings (linejam-941 root cause).
+    const t = setupConvexTest();
+    await seedClerkUser(t, 'redacted', { displayName: 'Redacted' });
+
+    let caught: unknown;
+    try {
+      await asUser(t, 'redacted').mutation(api.rooms.joinRoom, {
+        code: 'ZZZZ',
+        displayName: 'Redacted',
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ConvexError);
+    expect((caught as ConvexError<string>).data).toContain('Room not found');
+  });
+
+  it('throws ConvexError with data for in-progress and full rooms', async () => {
+    const t = setupConvexTest();
+
+    // Game in progress
+    await seedClerkUser(t, 'late-ce', { displayName: 'LateCE' });
+    const { code: activeCode } = await seedRoomWithActiveGame(
+      t,
+      'hostce',
+      'guestce'
+    );
+    let caught: unknown;
+    try {
+      await asUser(t, 'late-ce').mutation(api.rooms.joinRoom, {
+        code: activeCode,
+        displayName: 'LateCE',
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ConvexError);
+    expect((caught as ConvexError<string>).data).toContain('game in progress');
+
+    // Room full
+    const { code: fullCode, roomId: fullRoomId } = await seedLobbyRoom(
+      t,
+      'fullhost'
+    );
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 7; i++) {
+        const uid = await ctx.db.insert('users', {
+          displayName: `fillce${i}`,
+          kind: 'human',
+          createdAt: 0,
+        });
+        await ctx.db.insert('roomPlayers', {
+          roomId: fullRoomId,
+          userId: uid,
+          displayName: `fillce${i}`,
+          joinedAt: i,
+        });
+      }
+    });
+    await seedClerkUser(t, 'ninth-ce', { displayName: 'NinthCE' });
+    caught = undefined;
+    try {
+      await asUser(t, 'ninth-ce').mutation(api.rooms.joinRoom, {
+        code: fullCode,
+        displayName: 'NinthCE',
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ConvexError);
+    expect((caught as ConvexError<string>).data).toContain('Room is full');
+  });
+
+  it('rejects joining a closed room (COMPLETED with no players) with ConvexError', async () => {
+    const t = setupConvexTest();
+    const { code } = await seedLobbyRoom(t, 'closer');
+
+    // Host closes the room: players removed, status COMPLETED
+    await asUser(t, 'closer').mutation(api.rooms.closeRoom, {
+      roomCode: code,
+    });
+
+    await seedClerkUser(t, 'latecomer', { displayName: 'Latecomer' });
+    let caught: unknown;
+    try {
+      await asUser(t, 'latecomer').mutation(api.rooms.joinRoom, {
+        code,
+        displayName: 'Latecomer',
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ConvexError);
+    expect((caught as ConvexError<string>).data).toContain('Room is closed');
+  });
+
+  it('still allows joining a COMPLETED room that has players (between games)', async () => {
+    const t = setupConvexTest();
+    const { code, roomId } = await seedLobbyRoom(t, 'recaphost');
+    await t.run((ctx) => ctx.db.patch(roomId, { status: 'COMPLETED' }));
+
+    await seedClerkUser(t, 'between', { displayName: 'Between' });
+    await asUser(t, 'between').mutation(api.rooms.joinRoom, {
+      code,
+      displayName: 'Between',
+    });
+
+    const players = await t.run((ctx) =>
+      ctx.db
+        .query('roomPlayers')
+        .withIndex('by_room', (q) => q.eq('roomId', roomId))
+        .collect()
+    );
+    expect(players).toHaveLength(2);
+  });
+
+  it('honors the typed display name when an existing member rejoins', async () => {
+    const t = setupConvexTest();
+    const { code, roomId } = await seedLobbyRoom(t, 'renamer', 'Phae');
+
+    // Same identity rejoins with a different typed name — input must not be
+    // silently discarded (linejam-941 secondary UX gap).
+    await asUser(t, 'renamer').mutation(api.rooms.joinRoom, {
+      code,
+      displayName: '  Emm  ',
+    });
+
+    const players = await t.run((ctx) =>
+      ctx.db
+        .query('roomPlayers')
+        .withIndex('by_room', (q) => q.eq('roomId', roomId))
+        .collect()
+    );
+    expect(players).toHaveLength(1);
+    expect(players[0].displayName).toBe('Emm');
+
+    const user = await t.run((ctx) => ctx.db.get(players[0].userId));
+    expect(user?.displayName).toBe('Emm');
   });
 });
 

--- a/tests/e2e/errors.spec.ts
+++ b/tests/e2e/errors.spec.ts
@@ -155,15 +155,22 @@ test.describe('Form Validation', () => {
 let ipCounter = 0;
 
 /**
- * New browser context with a unique client IP (the app trusts
- * x-forwarded-for) so per-IP guest-session rate-limit buckets never bleed
- * between tests or into the other spec files sharing this dev server.
+ * New browser context with a unique client IP so per-IP guest-session
+ * rate-limit buckets never bleed between tests or into the other spec files
+ * sharing this server. The spoofed x-forwarded-for is scoped to the app's
+ * guest-session route (where the bucket key is derived) — a context-wide
+ * extraHTTPHeaders also hits Clerk/Convex third-party hosts, which choke on
+ * untrusted forwarding headers and strand the page in its loading state.
  */
 async function newGuestContext(
   browser: Browser
 ): Promise<{ context: BrowserContext; page: Page }> {
-  const context = await browser.newContext({
-    extraHTTPHeaders: { 'x-forwarded-for': `10.94.1.${++ipCounter}` },
+  const ip = `10.94.1.${++ipCounter}`;
+  const context = await browser.newContext();
+  await context.route('**/api/guest/session*', async (route) => {
+    await route.continue({
+      headers: { ...route.request().headers(), 'x-forwarded-for': ip },
+    });
   });
   const page = await context.newPage();
   return { context, page };

--- a/tests/e2e/errors.spec.ts
+++ b/tests/e2e/errors.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
+import type { Browser, BrowserContext, Page } from '@playwright/test';
 
 import { GuestFlowSession } from './support/guestFlow';
+import { E2E_TEST_IDS } from '../../lib/e2eTestIds';
 
 /**
  * E2E Test: Error Scenarios and Validation
@@ -46,14 +48,14 @@ test.describe('Join Room Error Handling', () => {
     // Click join button
     await page.click('button[type="submit"]');
 
-    // The join form should surface a user-visible alert for an invalid code.
-    const errorAlert = page.locator('main [role="alert"]').filter({
-      hasText: /Room code not found|unexpected error occurred/i,
-    });
+    // The join form must surface the SPECIFIC friendly message — seeing the
+    // generic fallback here means the ConvexError taxonomy regressed
+    // (linejam-941: Convex redacts plain Error in prod).
+    const errorAlert = page.getByTestId(E2E_TEST_IDS.joinErrorAlert);
 
     await expect(errorAlert).toBeVisible({ timeout: 30000 });
     await expect(errorAlert).toContainText(
-      /Room code not found|unexpected error occurred/i
+      'Room code not found. Please check the code and try again.'
     );
   });
 
@@ -138,5 +140,175 @@ test.describe('Form Validation', () => {
     // Fill both - now enabled
     await page.fill('input#code', 'ABCD');
     await expect(submitButton).toBeEnabled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Party-path error taxonomy (linejam-941)
+//
+// Every join/create failure a party guest can hit must render its SPECIFIC
+// friendly message through the E2E_TEST_IDS contract. The generic fallback
+// appearing in any of these flows means a Convex function threw plain Error
+// (redacted in prod) instead of ConvexError.
+// ─────────────────────────────────────────────────────────────────────────────
+
+let ipCounter = 0;
+
+/**
+ * New browser context with a unique client IP (the app trusts
+ * x-forwarded-for) so per-IP guest-session rate-limit buckets never bleed
+ * between tests or into the other spec files sharing this dev server.
+ */
+async function newGuestContext(
+  browser: Browser
+): Promise<{ context: BrowserContext; page: Page }> {
+  const context = await browser.newContext({
+    extraHTTPHeaders: { 'x-forwarded-for': `10.94.1.${++ipCounter}` },
+  });
+  const page = await context.newPage();
+  return { context, page };
+}
+
+async function submitJoin(page: Page, code: string, name: string) {
+  await page.goto(`/join?code=${code}`);
+  await page
+    .getByTestId(E2E_TEST_IDS.joinNameInput)
+    .fill(name, { timeout: 30000 });
+  await page.getByTestId(E2E_TEST_IDS.joinRoomButton).click();
+}
+
+function joinErrorAlert(page: Page) {
+  return page.getByTestId(E2E_TEST_IDS.joinErrorAlert);
+}
+
+test.describe('Party-path error taxonomy', () => {
+  test('joining a room with a game in progress shows the started message', async ({
+    browser,
+  }) => {
+    const session = await GuestFlowSession.create(browser, {
+      hostName: 'Taxonomy Host',
+      guestName: 'Taxonomy Guest',
+    });
+    try {
+      await session.createRoom();
+      await session.joinRoom();
+      await session.startGame();
+
+      const { context, page } = await newGuestContext(browser);
+      try {
+        await submitJoin(page, session.roomCode, 'Latecomer');
+        await expect(joinErrorAlert(page)).toContainText(
+          'This game has already started. Please wait for the next session or ask the host to create a new room.',
+          { timeout: 30000 }
+        );
+      } finally {
+        await context.close();
+      }
+    } finally {
+      await session.close();
+    }
+  });
+
+  test('joining a full room shows the room-full message', async ({
+    browser,
+  }) => {
+    test.setTimeout(240000); // fills 8 seats through the real UI
+
+    const session = await GuestFlowSession.create(browser, {
+      hostName: 'Full Host',
+    });
+    try {
+      await session.createRoom();
+
+      // Fill seats 2-8 (host holds seat 1)
+      for (let i = 0; i < 7; i++) {
+        const { context, page } = await newGuestContext(browser);
+        try {
+          await submitJoin(page, session.roomCode, `Filler ${i + 1}`);
+          await page.waitForURL(`**/room/${session.roomCode}`, {
+            timeout: 30000,
+          });
+        } finally {
+          await context.close();
+        }
+      }
+
+      // Seat 9 must bounce with the specific message
+      const { context, page } = await newGuestContext(browser);
+      try {
+        await submitJoin(page, session.roomCode, 'Ninth Wheel');
+        await expect(joinErrorAlert(page)).toContainText(
+          'This room is full (8 players max). Ask the host to start a new room.',
+          { timeout: 30000 }
+        );
+      } finally {
+        await context.close();
+      }
+    } finally {
+      await session.close();
+    }
+  });
+
+  test('joining a closed room shows the closed message', async ({
+    browser,
+  }) => {
+    const session = await GuestFlowSession.create(browser, {
+      hostName: 'Closing Host',
+    });
+    try {
+      await session.createRoom();
+      const code = session.roomCode;
+
+      await session.hostPage
+        .getByRole('button', { name: /close room/i })
+        .click();
+      await session.hostPage.waitForURL('**/', { timeout: 30000 });
+
+      const { context, page } = await newGuestContext(browser);
+      try {
+        await submitJoin(page, code, 'Latecomer');
+        await expect(joinErrorAlert(page)).toContainText(
+          'This room has been closed. Ask the host for a new room code.',
+          { timeout: 30000 }
+        );
+      } finally {
+        await context.close();
+      }
+    } finally {
+      await session.close();
+    }
+  });
+
+  test('rate-limited room creation shows the too-many-attempts message', async ({
+    browser,
+  }) => {
+    test.setTimeout(240000);
+
+    // createRoom allows 3 per user per window; the 4th must bounce with the
+    // specific rate-limit message, not the generic fallback.
+    const { context, page } = await newGuestContext(browser);
+    try {
+      for (let i = 0; i < 3; i++) {
+        await page.goto('/host');
+        await page
+          .getByTestId(E2E_TEST_IDS.hostNameInput)
+          .fill('Eager Host', { timeout: 30000 });
+        await page.getByTestId(E2E_TEST_IDS.hostCreateRoomButton).click();
+        await page.waitForURL('**/room/**', { timeout: 30000 });
+      }
+
+      await page.goto('/host');
+      await page
+        .getByTestId(E2E_TEST_IDS.hostNameInput)
+        .fill('Eager Host', { timeout: 30000 });
+      await page.getByTestId(E2E_TEST_IDS.hostCreateRoomButton).click();
+
+      await expect(page.getByTestId(E2E_TEST_IDS.hostErrorAlert)).toContainText(
+        'Too many attempts. Please wait a few minutes before trying again.',
+        { timeout: 30000 }
+      );
+    } finally {
+      await context.close();
+    }
   });
 });

--- a/tests/e2e/errors.spec.ts
+++ b/tests/e2e/errors.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import type { Browser, BrowserContext, Page } from '@playwright/test';
 
-import { GuestFlowSession } from './support/guestFlow';
+import { GuestFlowSession, isolateGuestSessionIp } from './support/guestFlow';
 import { E2E_TEST_IDS } from '../../lib/e2eTestIds';
 
 /**
@@ -152,26 +152,16 @@ test.describe('Form Validation', () => {
 // (redacted in prod) instead of ConvexError.
 // ─────────────────────────────────────────────────────────────────────────────
 
-let ipCounter = 0;
-
 /**
- * New browser context with a unique client IP so per-IP guest-session
- * rate-limit buckets never bleed between tests or into the other spec files
- * sharing this server. The spoofed x-forwarded-for is scoped to the app's
- * guest-session route (where the bucket key is derived) — a context-wide
- * extraHTTPHeaders also hits Clerk/Convex third-party hosts, which choke on
- * untrusted forwarding headers and strand the page in its loading state.
+ * New browser context with its own client IP (see isolateGuestSessionIp) so
+ * per-IP rate-limit buckets never bleed between tests or into the other spec
+ * files sharing this server.
  */
 async function newGuestContext(
   browser: Browser
 ): Promise<{ context: BrowserContext; page: Page }> {
-  const ip = `10.94.1.${++ipCounter}`;
   const context = await browser.newContext();
-  await context.route('**/api/guest/session*', async (route) => {
-    await route.continue({
-      headers: { ...route.request().headers(), 'x-forwarded-for': ip },
-    });
-  });
+  await isolateGuestSessionIp(context);
   const page = await context.newPage();
   return { context, page };
 }

--- a/tests/e2e/room-auth.spec.ts
+++ b/tests/e2e/room-auth.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, Browser, BrowserContext, Page } from '@playwright/test';
 import { ensureClerkAuthState, requireClerkBrowserAuth } from './support/clerk';
+import { isolateGuestSessionIp } from './support/guestFlow';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -14,6 +15,7 @@ async function openIsolatedPage(browser: Browser): Promise<{
   page: Page;
 }> {
   const context = await browser.newContext();
+  await isolateGuestSessionIp(context);
   const page = await context.newPage();
   return { context, page };
 }

--- a/tests/e2e/room-chrome-layout.spec.ts
+++ b/tests/e2e/room-chrome-layout.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect, BrowserContext, Page, devices } from '@playwright/test';
 
+import { isolateGuestSessionIp } from './support/guestFlow';
+
 test.describe.configure({ mode: 'serial' });
 
 const missingGuestTokenSecret = !process.env.GUEST_TOKEN_SECRET;
@@ -83,6 +85,12 @@ test('room chrome does not cover lobby or writing content on desktop and mobile'
     mobileContext = await browser.newContext({
       ...devices['iPhone 14'],
     });
+
+    await Promise.all([
+      isolateGuestSessionIp(hostContext),
+      isolateGuestSessionIp(guestContext),
+      isolateGuestSessionIp(mobileContext),
+    ]);
 
     const hostPage = await hostContext.newPage();
     const guestPage = await guestContext.newPage();

--- a/tests/e2e/support/guestFlow.ts
+++ b/tests/e2e/support/guestFlow.ts
@@ -203,6 +203,29 @@ function hasSearchParam(requestUrl: string, param: string) {
   }
 }
 
+/**
+ * Give a browser context its own client IP for guest-session issuance so the
+ * per-IP rate-limit buckets (the guest-session throttle, and the
+ * createRoom/joinRoom abuse buckets keyed off the token's rateLimitKey)
+ * never bleed between tests, spec files, or parallel workers sharing the CI
+ * server's single IP.
+ *
+ * The spoofed x-forwarded-for is scoped to the app's guest-session route
+ * (where the bucket key is derived) — a context-wide extraHTTPHeaders also
+ * hits Clerk/Convex third-party hosts, which choke on untrusted forwarding
+ * headers and strand the page in its loading state.
+ */
+export async function isolateGuestSessionIp(context: BrowserContext) {
+  const octet = () => 1 + Math.floor(Math.random() * 254);
+  const ip = `10.${octet()}.${octet()}.${octet()}`;
+  await context.route('**/api/guest/session*', async (route) => {
+    await route.continue({
+      headers: { ...route.request().headers(), 'x-forwarded-for': ip },
+    });
+  });
+  return ip;
+}
+
 export class GuestFlowSession {
   readonly guestContext: BrowserContext;
   readonly guestName: string;
@@ -263,6 +286,11 @@ export class GuestFlowSession {
           : {}),
       });
       guestContext = await browser.newContext({ viewport });
+
+      await Promise.all([
+        isolateGuestSessionIp(hostContext),
+        isolateGuestSessionIp(guestContext),
+      ]);
 
       const [hostPage, guestPage] = await Promise.all([
         hostContext.newPage(),

--- a/tests/lib/e2eTestIds.test.ts
+++ b/tests/lib/e2eTestIds.test.ts
@@ -9,6 +9,8 @@ const EXPECTED_TEST_IDS = {
   joinRoomCodeInput: 'join-room-code-input',
   joinNameInput: 'join-name-input',
   joinRoomButton: 'join-room-button',
+  joinErrorAlert: 'join-error-alert',
+  hostErrorAlert: 'host-error-alert',
   lobbyStartGameButton: 'lobby-start-game-button',
   lobbyWaitingForHostButton: 'lobby-waiting-for-host-button',
   writingPhase: 'writing-phase',

--- a/tests/lib/errorFeedback.test.ts
+++ b/tests/lib/errorFeedback.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { ConvexError } from 'convex/values';
 import { errorToFeedback } from '@/lib/errorFeedback';
 
 describe('errorToFeedback', () => {
@@ -49,6 +50,62 @@ describe('errorToFeedback', () => {
 
       expect(feedback.message).toContain('Too many attempts');
       expect(feedback.message).toContain('wait');
+      expect(feedback.variant).toBe('error');
+    });
+  });
+
+  describe('ConvexError data extraction (survives production redaction)', () => {
+    it('classifies from ConvexError.data, the only field that survives prod', () => {
+      // In production Convex redacts Error.message to "Server Error" — only
+      // ConvexError.data reaches the client. Simulate that exact shape.
+      const error = new ConvexError('Room not found');
+      error.message = '[Request ID: abc123] Server Error';
+
+      const feedback = errorToFeedback(error);
+
+      expect(feedback.message).toBe(
+        'Room code not found. Please check the code and try again.'
+      );
+    });
+
+    it('classifies duck-typed ConvexError shapes with string data', () => {
+      const error = { message: 'Server Error', data: 'Room is full' };
+      const feedback = errorToFeedback(error);
+
+      expect(feedback.message).toContain('room is full');
+    });
+  });
+
+  describe('party-path error taxonomy', () => {
+    it('maps game-in-progress joins to the already-started message', () => {
+      const error = new ConvexError(
+        'Cannot join a room with a game in progress'
+      );
+      const feedback = errorToFeedback(error);
+
+      expect(feedback.message).toBe(
+        'This game has already started. Please wait for the next session or ask the host to create a new room.'
+      );
+      expect(feedback.variant).toBe('error');
+    });
+
+    it('maps room-full errors to a distinct message', () => {
+      const error = new ConvexError('Room is full');
+      const feedback = errorToFeedback(error);
+
+      expect(feedback.message).toBe(
+        'This room is full (8 players max). Ask the host to start a new room.'
+      );
+      expect(feedback.variant).toBe('error');
+    });
+
+    it('maps room-closed errors to a distinct message', () => {
+      const error = new ConvexError('Room is closed');
+      const feedback = errorToFeedback(error);
+
+      expect(feedback.message).toBe(
+        'This room has been closed. Ask the host for a new room code.'
+      );
       expect(feedback.variant).toBe('error');
     });
   });


### PR DESCRIPTION
## Summary

Clears **linejam-941** (party-proof error states). Convex redacts plain `Error` messages in production, so the friendly mappings in `lib/errorFeedback.ts` could never fire on prod — a guest typoing a room code at a party got the generic "An unexpected error occurred" dead-end.

- **Root cause fixed**: `convex/lib/room.ts` `requireRoomByCode` (and every other player-path throw in `convex/`) now throws `ConvexError`, whose `data` survives prod redaction. `errorToFeedback` reads `ConvexError.data` first.
- **Regression gate**: eslint `no-restricted-syntax` forbids plain `Error` throws in `convex/*.ts` + player-path lib modules (verified it fires). Internal invariants (guestToken, canary, AI providers) deliberately keep plain `Error` — redaction is a feature there.
- **Taxonomy**: distinct live messages for bad code, game in progress, room full, room closed (new `joinRoom` guard: COMPLETED + zero players; between-games COMPLETED rooms stay joinable), rate-limited.
- **Name honesty**: rejoin with a different typed display name now renames (roomPlayers + users doc) instead of silently discarding input; names normalized on insert.
- **E2E**: `joinErrorAlert`/`hostErrorAlert` added to the frozen selector contract; new "Party-path error taxonomy" specs cover in-progress, full (8 real UI joins), closed, and rate-limited (createRoom userMax=3) — each context gets a unique `x-forwarded-for` so per-IP buckets never bleed across tests.

## Testing

- `pnpm ci:prepush` green (typecheck, lint, 1209 unit/convex-test tests).
- New failing-first tests: errorFeedback taxonomy + ConvexError-data extraction; convex-test assertions that join errors are `ConvexError` instances with the expected `data`; closed-room/between-games/rename behaviors.
- Lint gate proven: reintroducing a plain `throw new Error` in `convex/rooms.ts` fails `eslint`.
- E2E runs on the merge-gate (local dev-server runs are operator-only per AGENTS.md Invariant 2).

Powder: linejam-941

🤖 Generated with [Claude Code](https://claude.com/claude-code)