### PR TITLE
chore(deps): bump convex 1.31.7 -> 1.42.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "clsx": "^2.1.1",
-    "convex": "^1.31.7",
+    "convex": "^1.42.1",
     "dompurify": "^3.4.11",
     "import-in-the-middle": "^3.1.0",
     "lucide-react": "^1.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       convex:
-        specifier: ^1.31.7
-        version: 1.31.7(@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        specifier: ^1.42.1
+        version: 1.42.1(@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7)
       dompurify:
         specifier: ^3.4.11
         version: 3.4.11
@@ -144,7 +144,7 @@ importers:
         version: 4.1.9(vitest@4.1.9)
       convex-test:
         specifier: ^0.0.53
-        version: 0.0.53(convex@1.31.7(@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))
+        version: 0.0.53(convex@1.42.1(@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7))
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.7.0)
@@ -3457,18 +3457,21 @@ packages:
     peerDependencies:
       convex: ^1.32.0
 
-  convex@1.31.7:
-    resolution: {integrity: sha512-PtNMe1mAIOvA8Yz100QTOaIdgt2rIuWqencVXrb4McdhxBHZ8IJ1eXTnrgCC9HydyilGT1pOn+KNqT14mqn9fQ==}
+  convex@1.42.1:
+    resolution: {integrity: sha512-yFKp4xerVuBwQqpuTtvosOk9F/fX0twZs+Xti3oj/MlwPUU90QuhgCYo/I2wvFBAFwXsmx9tXpf2q8ekh1+3ug==}
     engines: {node: '>=18.0.0', npm: '>=7.0.0'}
     hasBin: true
     peerDependencies:
       '@auth0/auth0-react': ^2.0.1
       '@clerk/clerk-react': ^4.12.8 || ^5.0.0
+      '@clerk/react': ^6.4.3
       react: ^18.0.0 || ^19.0.0-0 || ^19.0.0
     peerDependenciesMeta:
       '@auth0/auth0-react':
         optional: true
       '@clerk/clerk-react':
+        optional: true
+      '@clerk/react':
         optional: true
       react:
         optional: true
@@ -11164,17 +11167,21 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  convex-test@0.0.53(convex@1.31.7(@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)):
+  convex-test@0.0.53(convex@1.42.1(@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7)):
     dependencies:
-      convex: 1.31.7(@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      convex: 1.42.1(@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7)
 
-  convex@1.31.7(@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  convex@1.42.1(@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7):
     dependencies:
       esbuild: 0.28.1
       prettier: 3.8.4
+      ws: 8.21.0(bufferutil@4.1.0)
     optionalDependencies:
       '@clerk/clerk-react': 5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   cookie-signature@1.2.2: {}
 


### PR DESCRIPTION
## Summary
- Bumps `convex` from `1.31.7` to `1.42.1`, closing the 11-minor-version gap flagged in linejam-932's groom pass on the framework that owns schema, migrations, the scheduler, and every query/mutation.
- Clerk stays pinned to v6 for now — `linejam-933` tracks the dedicated v7 migration ticket (major auth-library bump, its own blast radius, sequenced after linejam-942's in-flight auth work lands).

## Verification
- `pnpm typecheck` — clean, no Convex API breakage.
- `pnpm lint` — clean (pre-existing unrelated warnings only, in `site/mode.js` / `site/theme.js`).
- `pnpm test` — 1209 passed, 1 skipped, 0 failed (full vitest suite).
- linejam-908's `CONVEX_OVERRIDE_ACCESS_TOKEN` isolated-worktree workaround re-verified against the new CLI: `scripts/convex/probe-function-exists.mjs` resolves a real function spec with a synthetic `$HOME` and no `~/.convex/config.json`, using only the override env var.
- `pnpm ci:dagger:all` run locally surfaces one failure in `tests/next-config.test.ts` ("does not include development-only script or localhost allowances in production") — confirmed **pre-existing and unrelated to this bump**: `next.config.ts` and the test file are byte-identical to `master` (`git diff master -- next.config.ts lib/env.ts tests/next-config.test.ts` is empty). It's caused by this workstation's `.env.local`/`.env.production.local` both pointing `NEXT_PUBLIC_CANARY_ENDPOINT` at `http://127.0.0.1:4000` for local dev, which Local Dagger intentionally lets `.env.local` override into the "production" build check (documented in AGENTS.md's Local Dagger section). Deferring to the hosted merge-gate as the authoritative oracle per this card's own acceptance criteria ("Full `pnpm ci:dagger:all` (or hosted merge-gate) is green post-bump").

Closes linejam-932.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>