### PR TITLE
fix(identity): guest archive access + themed Clerk auth

### DIFF
--- a/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -6,10 +6,12 @@ import Link from 'next/link';
 /**
  * Sign-In Page
  *
- * Uses Clerk's prebuilt SignIn component with custom theming.
+ * Uses Clerk's prebuilt SignIn component. Shared theming (colors, fonts,
+ * inputs, buttons — all CSS-variable driven, so every lib/themes preset
+ * works automatically) lives once on <ClerkProvider appearance> in
+ * app/providers.tsx; this page only overrides what's page-specific (hiding
+ * Clerk's own header since we render our own above it).
  * The [[...sign-in]] catch-all route handles OAuth callbacks.
- *
- * Theme-aware: Clerk appearance uses CSS variables for multi-theme support.
  *
  * When Clerk is not configured (no CLERK_SECRET_KEY), shows a message
  * that authentication is unavailable and guests can play without an account.
@@ -58,53 +60,14 @@ export default function SignInPage() {
         </p>
       </div>
 
-      {/* Clerk SignIn Component */}
+      {/* Clerk SignIn Component — shared appearance from ClerkProvider;
+          only the redundant Clerk-native header is hidden here since this
+          page renders its own above. */}
       <SignIn
         appearance={{
           elements: {
-            // Root container
-            rootBox: 'w-full',
-            card: 'shadow-none border-0 p-0 bg-transparent',
-            // Header (hide default, we use custom)
             headerTitle: 'hidden',
             headerSubtitle: 'hidden',
-            // Form
-            formButtonPrimary:
-              'bg-[var(--color-primary)] hover:bg-[var(--color-primary-hover)] text-[var(--color-text-inverse)] font-[var(--font-sans)] font-medium h-12 rounded-[var(--radius-md)] transition-all duration-[var(--duration-normal)]',
-            formFieldInput:
-              'bg-[var(--color-surface)] border-[var(--color-border)] text-[var(--color-text-primary)] font-[var(--font-sans)] h-12 rounded-[var(--radius-md)] focus:border-[var(--color-primary)] focus:ring-[var(--color-focus-ring)] focus:ring-2 focus:ring-offset-2',
-            formFieldLabel:
-              'text-[var(--color-text-secondary)] font-[var(--font-sans)] text-sm',
-            formFieldInputShowPasswordButton:
-              'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]',
-            // Social buttons
-            socialButtonsBlockButton:
-              'bg-[var(--color-surface)] border-[var(--color-border)] text-[var(--color-text-primary)] font-[var(--font-sans)] h-12 rounded-[var(--radius-md)] hover:bg-[var(--color-surface-hover)] transition-all duration-[var(--duration-normal)]',
-            socialButtonsBlockButtonText: 'font-medium',
-            // Divider
-            dividerLine: 'bg-[var(--color-border)]',
-            dividerText:
-              'text-[var(--color-text-muted)] font-[var(--font-sans)] text-sm',
-            // Footer
-            footerActionText:
-              'text-[var(--color-text-secondary)] font-[var(--font-sans)]',
-            footerActionLink:
-              'text-[var(--color-primary)] hover:text-[var(--color-primary-hover)] font-medium',
-            // Identity preview (after first step)
-            identityPreviewText:
-              'text-[var(--color-text-primary)] font-[var(--font-sans)]',
-            identityPreviewEditButton:
-              'text-[var(--color-primary)] hover:text-[var(--color-primary-hover)]',
-            // Alert/Error states
-            alert:
-              'bg-[var(--color-error)]/10 border-[var(--color-error)] text-[var(--color-error)]',
-            // OTP input
-            otpCodeFieldInput:
-              'bg-[var(--color-surface)] border-[var(--color-border)] text-[var(--color-text-primary)] font-[var(--font-mono)] text-xl rounded-[var(--radius-md)]',
-          },
-          layout: {
-            socialButtonsPlacement: 'top',
-            socialButtonsVariant: 'blockButton',
           },
         }}
         routing="path"

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -6,10 +6,12 @@ import Link from 'next/link';
 /**
  * Sign-Up Page
  *
- * Uses Clerk's prebuilt SignUp component with custom theming.
+ * Uses Clerk's prebuilt SignUp component. Shared theming (colors, fonts,
+ * inputs, buttons — all CSS-variable driven, so every lib/themes preset
+ * works automatically) lives once on <ClerkProvider appearance> in
+ * app/providers.tsx; this page only overrides what's page-specific (hiding
+ * Clerk's own header since we render our own above it).
  * The [[...sign-up]] catch-all route handles OAuth callbacks.
- *
- * Theme-aware: Clerk appearance uses CSS variables for multi-theme support.
  *
  * When Clerk is not configured (no CLERK_SECRET_KEY), shows a message
  * that authentication is unavailable and guests can play without an account.
@@ -58,53 +60,14 @@ export default function SignUpPage() {
         </p>
       </div>
 
-      {/* Clerk SignUp Component */}
+      {/* Clerk SignUp Component — shared appearance from ClerkProvider;
+          only the redundant Clerk-native header is hidden here since this
+          page renders its own above. */}
       <SignUp
         appearance={{
           elements: {
-            // Root container
-            rootBox: 'w-full',
-            card: 'shadow-none border-0 p-0 bg-transparent',
-            // Header (hide default, we use custom)
             headerTitle: 'hidden',
             headerSubtitle: 'hidden',
-            // Form
-            formButtonPrimary:
-              'bg-[var(--color-primary)] hover:bg-[var(--color-primary-hover)] text-[var(--color-text-inverse)] font-[var(--font-sans)] font-medium h-12 rounded-[var(--radius-md)] transition-all duration-[var(--duration-normal)]',
-            formFieldInput:
-              'bg-[var(--color-surface)] border-[var(--color-border)] text-[var(--color-text-primary)] font-[var(--font-sans)] h-12 rounded-[var(--radius-md)] focus:border-[var(--color-primary)] focus:ring-[var(--color-focus-ring)] focus:ring-2 focus:ring-offset-2',
-            formFieldLabel:
-              'text-[var(--color-text-secondary)] font-[var(--font-sans)] text-sm',
-            formFieldInputShowPasswordButton:
-              'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]',
-            // Social buttons
-            socialButtonsBlockButton:
-              'bg-[var(--color-surface)] border-[var(--color-border)] text-[var(--color-text-primary)] font-[var(--font-sans)] h-12 rounded-[var(--radius-md)] hover:bg-[var(--color-surface-hover)] transition-all duration-[var(--duration-normal)]',
-            socialButtonsBlockButtonText: 'font-medium',
-            // Divider
-            dividerLine: 'bg-[var(--color-border)]',
-            dividerText:
-              'text-[var(--color-text-muted)] font-[var(--font-sans)] text-sm',
-            // Footer
-            footerActionText:
-              'text-[var(--color-text-secondary)] font-[var(--font-sans)]',
-            footerActionLink:
-              'text-[var(--color-primary)] hover:text-[var(--color-primary-hover)] font-medium',
-            // Identity preview
-            identityPreviewText:
-              'text-[var(--color-text-primary)] font-[var(--font-sans)]',
-            identityPreviewEditButton:
-              'text-[var(--color-primary)] hover:text-[var(--color-primary-hover)]',
-            // Alert/Error states
-            alert:
-              'bg-[var(--color-error)]/10 border-[var(--color-error)] text-[var(--color-error)]',
-            // OTP input
-            otpCodeFieldInput:
-              'bg-[var(--color-surface)] border-[var(--color-border)] text-[var(--color-text-primary)] font-[var(--font-mono)] text-xl rounded-[var(--radius-md)]',
-          },
-          layout: {
-            socialButtonsPlacement: 'top',
-            socialButtonsVariant: 'blockButton',
           },
         }}
         routing="path"

--- a/app/me/poems/page.tsx
+++ b/app/me/poems/page.tsx
@@ -27,6 +27,7 @@ import {
   ArchiveStats,
   ArchiveStatsSkeleton,
   EmptyArchive,
+  ArchiveInfoStrip,
 } from '@/components/archive';
 
 export default function ArchivePage() {
@@ -35,6 +36,7 @@ export default function ArchivePage() {
     isLoading: authLoading,
     authError,
     retryAuth,
+    isAuthenticated,
   } = useUser();
 
   const archiveData = useQuery(
@@ -80,13 +82,13 @@ export default function ArchivePage() {
             ) : null}
           </div>
 
-          {/* Hint Text - sandwiched between hairlines */}
-          {!isLoading && poems.length > 0 && (
-            <div className="mt-8 py-4 border-y border-[var(--color-border-subtle)]">
-              <p className="text-sm text-[var(--color-text-muted)] font-mono">
-                Tap any poem to reveal the full verse
-              </p>
-            </div>
+          {/* Reveal hint (signed-in + has poems) and/or guest identity
+              explainer (always, per linejam-942 — never a dead end) */}
+          {!isLoading && (
+            <ArchiveInfoStrip
+              isAuthenticated={isAuthenticated}
+              hasPoems={poems.length > 0}
+            />
           )}
         </header>
 

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -7,11 +7,21 @@ import { ThemeProvider } from '@/lib/themes';
 import { PostHogProvider } from '@/lib/posthog/PostHogProvider';
 import { PostHogPageview } from '@/lib/posthog/PostHogPageview';
 import { CanaryClientObserver } from '@/components/CanaryClientObserver';
+import {
+  linejamClerkAppearance,
+  useClerkThemeVariables,
+} from '@/lib/clerk/appearance';
 import { ReactNode } from 'react';
 
 export function Providers({ children }: { children: ReactNode }) {
+  const variables = useClerkThemeVariables();
+
   return (
-    <ClerkProvider>
+    <ClerkProvider
+      appearance={{ ...linejamClerkAppearance, variables }}
+      signInUrl="/sign-in"
+      signUpUrl="/sign-up"
+    >
       <PostHogProvider>
         <PostHogPageview />
         <CanaryClientObserver />

--- a/components/archive/ArchiveInfoStrip.tsx
+++ b/components/archive/ArchiveInfoStrip.tsx
@@ -1,0 +1,58 @@
+/**
+ * ArchiveInfoStrip
+ *
+ * The archive page's one persistent, low-key info line. Reuses the exact
+ * hairline-hint convention the page already used for signed-in users
+ * ("Tap any poem to reveal the full verse") and layers in a guest-specific
+ * line explaining what signing in adds — chosen over 9 other structural
+ * directions in explorations/guest-archive-identity-lab (see DECISION.md
+ * there) specifically because it is always visible, never a modal or
+ * redirect, and matches an existing pattern instead of inventing new
+ * chrome.
+ *
+ * linejam-942: the archive entry point must never dead-end on a bare auth
+ * wall — a guest sees this even with zero poems.
+ */
+
+'use client';
+
+import Link from 'next/link';
+
+type ArchiveInfoStripProps = {
+  isAuthenticated: boolean;
+  hasPoems: boolean;
+};
+
+export function ArchiveInfoStrip({
+  isAuthenticated,
+  hasPoems,
+}: ArchiveInfoStripProps) {
+  const showRevealHint = hasPoems;
+  const showGuestNote = !isAuthenticated;
+
+  if (!showRevealHint && !showGuestNote) {
+    return null;
+  }
+
+  return (
+    <div className="mt-8 py-4 border-y border-[var(--color-border-subtle)] space-y-1.5">
+      {showRevealHint && (
+        <p className="text-sm text-[var(--color-text-muted)] font-mono">
+          Tap any poem to reveal the full verse
+        </p>
+      )}
+      {showGuestNote && (
+        <p className="text-sm text-[var(--color-text-muted)] font-mono">
+          Saved to this browser only.{' '}
+          <Link
+            href="/sign-up"
+            className="text-[var(--color-primary)] hover:text-[var(--color-primary-hover)] underline underline-offset-2"
+          >
+            Sign up
+          </Link>{' '}
+          to keep it forever, on any device.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/archive/index.ts
+++ b/components/archive/index.ts
@@ -9,3 +9,4 @@ export { AuthorDots, AuthorDotsInline } from './AuthorDots';
 export { PoemCard, PoemCardSkeleton } from './PoemCard';
 export { ArchiveStats, ArchiveStatsSkeleton } from './ArchiveStats';
 export { EmptyArchive } from './EmptyArchive';
+export { ArchiveInfoStrip } from './ArchiveInfoStrip';

--- a/explorations/guest-archive-identity-lab/DECISION.md
+++ b/explorations/guest-archive-identity-lab/DECISION.md
@@ -1,0 +1,50 @@
+# Guest Archive Identity Lab — Decision
+
+**Card:** linejam-942
+**Lab:** `index.html` in this directory (10 structurally distinct options, light/dark toggle)
+
+## Winner: Option 3 — Hairline Info Strip
+
+Extends the archive page's own existing convention: the mono, hairline-bordered
+hint bar already shown to signed-in users ("Tap any poem to reveal the full
+verse"). For a guest, the same strip carries an additional line: _"Saved to
+this browser only. Sign up to keep it forever, on any device."_
+
+## Why this one
+
+- **Matches an existing pattern instead of inventing a new one.** The archive
+  page already has this exact visual grammar (mono text, hairline top/bottom
+  border, muted color) for exactly this purpose — a small persistent
+  footnote under the header. No new chrome, no new interaction model.
+- **Never a dead end.** It is not a modal, not a redirect, not gated behind a
+  click — it is always present, in place, whether the guest has 0 poems or 20.
+  That is the literal acceptance bar ("never dead-ends on a bare auth wall").
+- **Reads as information, not a wall.** Options that scored worse on this
+  axis specifically: the top banner (competes with the H1 for attention every
+  visit), the first-visit modal (structurally a wall with extra steps — the
+  same anti-pattern the card exists to remove), and the sticky bottom bar
+  (fixed chrome that reads like the game's own gating).
+- **Cheap to build and maintain.** One extra conditional line inside a
+  component that already exists in the page; no new dismiss/reappear state
+  machine (footer strip, corner toast, and the modal all need one).
+
+## Runners-up considered and rejected
+
+| #   | Option                      | Rejected because                                                                                   |
+| --- | --------------------------- | -------------------------------------------------------------------------------------------------- |
+| 1   | Top Manuscript Banner       | Competes with the page title every visit; heavier than the message needs                           |
+| 2   | Stat-Row Chip               | Reads as a status label, not an explanation — too terse to satisfy "explains what signing in adds" |
+| 4   | Ghost Card in Gallery       | Charming but pushes real poems down; needs a separate empty-state treatment                        |
+| 5   | Sidebar Rail / Bottom Sheet | Two layouts (rail + sheet) for a one-line message — overbuilt                                      |
+| 6   | Sticky Bottom Bar           | Fixed chrome reads like another gate, undermining the "no more walls" goal                         |
+| 7   | Footer Strip                | Easy to never scroll to; a guest checking 2 recent poems may never see it                          |
+| 8   | First-Visit Modal           | Structurally a wall with extra steps                                                               |
+| 9   | Accordion Teaser            | Opt-in disclosure — guests who never click never learn what signing in adds                        |
+| 10  | Persistent Corner Toast     | Disconnected from the content it explains; needs its own state machine                             |
+
+## Implementation
+
+Shipped as `components/archive/ArchiveInfoStrip.tsx`, replacing the inline
+"tap to reveal" block in `app/me/poems/page.tsx`. Renders the existing hint
+line when `hasPoems`, and an additional guest line whenever `!isAuthenticated`
+— independently, so it appears for guests with zero poems too.

--- a/explorations/guest-archive-identity-lab/index.html
+++ b/explorations/guest-archive-identity-lab/index.html
@@ -1,0 +1,492 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Linejam Guest Archive Identity Lab</title>
+    <style>
+      :root {
+        --color-primary: #e85d2b;
+        --color-primary-hover: #c44521;
+        --color-background: #faf9f7;
+        --color-surface: #ffffff;
+        --color-surface-hover: #f5f5f4;
+        --color-muted: #f5f5f4;
+        --color-border: #e7e5e4;
+        --color-border-subtle: #f0efed;
+        --color-text-primary: #1c1917;
+        --color-text-secondary: #57534e;
+        --color-text-muted: #a8a29e;
+        --color-text-inverse: #faf9f7;
+        --font-display: Georgia, 'Times New Roman', serif;
+        --font-sans:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        --font-mono: 'SFMono-Regular', Menlo, Consolas, monospace;
+      }
+      [data-mode='dark'] {
+        --color-background: #17140f;
+        --color-surface: #221e17;
+        --color-surface-hover: #2b2620;
+        --color-muted: #2b2620;
+        --color-border: #3a342b;
+        --color-border-subtle: #2b2620;
+        --color-text-primary: #f5f1ea;
+        --color-text-secondary: #c9c2b6;
+        --color-text-muted: #857c6d;
+        --color-text-inverse: #17140f;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: var(--font-sans);
+        background: #0d0d0d;
+        color: var(--color-text-primary);
+      }
+      .lab-shell {
+        display: grid;
+        grid-template-columns: 300px 1fr;
+        min-height: 100vh;
+      }
+      aside {
+        background: #141210;
+        color: #e7e2d9;
+        padding: 28px 22px;
+        overflow-y: auto;
+        border-right: 1px solid #2a2620;
+      }
+      aside .eyebrow {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--color-primary);
+        margin: 0 0 6px;
+      }
+      aside h1 {
+        font-family: var(--font-display);
+        font-size: 22px;
+        margin: 0 0 10px;
+      }
+      aside p.intro {
+        font-size: 13px;
+        line-height: 1.5;
+        color: #a89f92;
+        margin: 0 0 22px;
+      }
+      .opt-btn {
+        display: block;
+        width: 100%;
+        text-align: left;
+        background: transparent;
+        border: 1px solid transparent;
+        border-radius: 8px;
+        color: #cfc8ba;
+        padding: 10px 12px;
+        margin-bottom: 4px;
+        font-size: 13px;
+        cursor: pointer;
+        font-family: inherit;
+      }
+      .opt-btn small {
+        display: block;
+        color: #7f7566;
+        font-size: 11px;
+        margin-top: 2px;
+      }
+      .opt-btn:hover {
+        background: #201c17;
+      }
+      .opt-btn.active {
+        background: #2a2015;
+        border-color: var(--color-primary);
+        color: #fff;
+      }
+      .modebar {
+        display: flex;
+        gap: 6px;
+        margin-top: 20px;
+        margin-bottom: 4px;
+      }
+      .modebar button {
+        flex: 1;
+        padding: 8px;
+        border-radius: 6px;
+        border: 1px solid #3a342b;
+        background: #1c1813;
+        color: #cfc8ba;
+        font-size: 12px;
+        cursor: pointer;
+        font-family: var(--font-mono);
+      }
+      .modebar button.active {
+        border-color: var(--color-primary);
+        color: var(--color-primary);
+      }
+      .viewer {
+        overflow-y: auto;
+        background: var(--color-background);
+        color: var(--color-text-primary);
+        padding: 40px;
+      }
+      .viewer-inner {
+        max-width: 880px;
+        margin: 0 auto;
+      }
+      .rationale {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        color: var(--color-text-muted);
+        border: 1px dashed var(--color-border);
+        border-radius: 8px;
+        padding: 14px 16px;
+        margin-bottom: 28px;
+        line-height: 1.6;
+      }
+      .rationale b {
+        color: var(--color-text-secondary);
+      }
+      .mock {
+        background: var(--color-background);
+      }
+      h2.page-title {
+        font-family: var(--font-display);
+        font-size: 44px;
+        letter-spacing: -0.02em;
+        margin: 0 0 20px;
+        line-height: 0.95;
+      }
+      .stats-row {
+        display: flex;
+        gap: 24px;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        color: var(--color-text-secondary);
+        margin-bottom: 18px;
+      }
+      .hairline {
+        border-top: 1px solid var(--color-border-subtle);
+        border-bottom: 1px solid var(--color-border-subtle);
+        padding: 14px 0;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        color: var(--color-text-muted);
+      }
+      .cta-link {
+        color: var(--color-primary);
+        text-decoration: underline;
+        text-underline-offset: 2px;
+        cursor: pointer;
+        font-weight: 600;
+      }
+      .cta-button {
+        display: inline-block;
+        background: var(--color-primary);
+        color: var(--color-text-inverse);
+        padding: 10px 20px;
+        border-radius: 8px;
+        font-size: 13px;
+        font-weight: 600;
+        text-decoration: none;
+        cursor: pointer;
+        border: none;
+      }
+      .cta-button.secondary {
+        background: transparent;
+        border: 1px solid var(--color-border);
+        color: var(--color-text-primary);
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 18px;
+        margin-top: 24px;
+      }
+      .card {
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: 10px;
+        padding: 16px;
+        min-height: 150px;
+      }
+      .card.ghost {
+        border-style: dashed;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        gap: 8px;
+        color: var(--color-text-muted);
+      }
+      .shape-line {
+        height: 3px;
+        border-radius: 2px;
+        background: var(--color-text-muted);
+        opacity: 0.35;
+        margin: 4px 0;
+      }
+      .badge-dot {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--color-primary);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="lab-shell">
+      <aside>
+        <p class="eyebrow">Linejam Lab &middot; linejam-942</p>
+        <h1>Guest Archive Identity</h1>
+        <p class="intro">
+          10 structurally distinct ways the archive entry point can tell a
+          guest what signing in adds &mdash; without ever redirecting them
+          away from their own poems.
+        </p>
+        <nav id="opt-list"></nav>
+        <div class="modebar">
+          <button id="btn-light" class="active">Light</button>
+          <button id="btn-dark">Dark</button>
+        </div>
+      </aside>
+      <main class="viewer">
+        <div class="viewer-inner" id="viewer-inner"></div>
+      </main>
+    </div>
+
+    <script>
+      const options = [
+        {
+          id: 'top-banner',
+          name: '1. Top Manuscript Banner',
+          blurb: 'Full-width card under the H1',
+          rationale:
+            'Impossible to miss on first load, but competes with the page title for attention every single visit &mdash; the same "here is a box about your account" energy the operator flagged as the problem.',
+          render: () => `
+            <h2 class="page-title">Archive</h2>
+            <div style="background:var(--color-surface); border:1px solid var(--color-border); border-radius:12px; padding:20px 24px; margin-bottom:24px;">
+              <p style="font-family:var(--font-display); font-size:18px; margin:0 0 6px;">Your poems live in this browser</p>
+              <p style="font-size:13px; color:var(--color-text-secondary); margin:0 0 14px; line-height:1.5;">Clear your cookies or switch devices and they're gone. Sign up (free, no ads) to keep every collaboration forever and read it anywhere.</p>
+              <a class="cta-button">Save my archive</a>
+            </div>
+            <div class="stats-row"><span>3 poems</span><span>1 favorite</span><span>2 collaborators</span></div>
+          `,
+        },
+        {
+          id: 'stat-chip',
+          name: '2. Stat-Row Chip',
+          blurb: 'Inline pill inside the existing stats line',
+          rationale:
+            'Cheapest possible surface &mdash; rides the stats the guest already scans. But it reads as a status label, not an explanation; thin on "what signing in adds."',
+          render: () => `
+            <h2 class="page-title">Archive</h2>
+            <div class="stats-row">
+              <span>3 poems</span><span>1 favorite</span><span>2 collaborators</span>
+              <span style="border:1px solid var(--color-border); border-radius:999px; padding:2px 10px; font-size:11px;">🔒 local only &middot; <span class="cta-link">sync it</span></span>
+            </div>
+          `,
+        },
+        {
+          id: 'ribbon',
+          name: '3. Hairline Info Strip (winner)',
+          blurb: 'Extends the existing "tap to reveal" hint bar',
+          rationale:
+            'Reuses the page\'s own established convention (the mono hairline hint already shown to authenticated users) instead of inventing new chrome. Always visible &mdash; never a dead end &mdash; and reads as a footnote, not a wall.',
+          render: () => `
+            <h2 class="page-title">Archive</h2>
+            <div class="stats-row"><span>3 poems</span><span>1 favorite</span><span>2 collaborators</span></div>
+            <div class="hairline" style="margin-top:18px;">
+              Saved to this browser only. <span class="cta-link">Sign up</span> to keep it forever, on any device.
+            </div>
+            <div class="grid">
+              <div class="card"><div class="shape-line" style="width:60%"></div><div class="shape-line" style="width:80%"></div><div class="shape-line" style="width:40%"></div></div>
+              <div class="card"><div class="shape-line" style="width:70%"></div><div class="shape-line" style="width:50%"></div></div>
+              <div class="card"><div class="shape-line" style="width:90%"></div><div class="shape-line" style="width:30%"></div></div>
+            </div>
+          `,
+        },
+        {
+          id: 'ghost-card',
+          name: '4. Ghost Card in the Gallery',
+          blurb: 'A CTA styled as one more artifact in the grid',
+          rationale:
+            'On-theme with "manuscript gallery" framing &mdash; identity-as-artifact. Charming, but pushes real poems down and needs a different treatment when the grid is empty.',
+          render: () => `
+            <h2 class="page-title">Archive</h2>
+            <div class="grid">
+              <div class="card ghost">
+                <span style="font-size:20px;">📜</span>
+                <p style="font-family:var(--font-display); font-size:15px; margin:4px 0;">This could be permanent</p>
+                <a class="cta-button secondary" style="font-size:12px; padding:6px 14px;">Sign up</a>
+              </div>
+              <div class="card"><div class="shape-line" style="width:60%"></div><div class="shape-line" style="width:80%"></div></div>
+              <div class="card"><div class="shape-line" style="width:70%"></div><div class="shape-line" style="width:50%"></div></div>
+            </div>
+          `,
+        },
+        {
+          id: 'sidebar-rail',
+          name: '5. Sidebar Rail / Bottom Sheet',
+          blurb: 'Persistent aside panel on desktop',
+          rationale:
+            'Strong for desktop information density, but doubles layout complexity (rail + collapsed mobile sheet) for a message this short &mdash; overbuilt for the job.',
+          render: () => `
+            <div style="display:grid; grid-template-columns: 1fr 220px; gap:24px;">
+              <div>
+                <h2 class="page-title" style="font-size:36px;">Archive</h2>
+                <div class="grid" style="grid-template-columns:repeat(2,1fr);">
+                  <div class="card"><div class="shape-line" style="width:60%"></div><div class="shape-line" style="width:80%"></div></div>
+                  <div class="card"><div class="shape-line" style="width:70%"></div><div class="shape-line" style="width:50%"></div></div>
+                </div>
+              </div>
+              <div style="border:1px solid var(--color-border); border-radius:10px; padding:16px; height:fit-content; background:var(--color-surface);">
+                <p style="font-size:12px; text-transform:uppercase; letter-spacing:0.08em; color:var(--color-text-muted); margin:0 0 8px;">Guest session</p>
+                <p style="font-size:13px; line-height:1.5; margin:0 0 12px;">Saved to this browser only. Sign up to keep it forever.</p>
+                <a class="cta-button" style="font-size:12px; padding:8px 14px; display:block; text-align:center;">Save archive</a>
+              </div>
+            </div>
+          `,
+        },
+        {
+          id: 'sticky-bar',
+          name: '6. Sticky Bottom Bar',
+          blurb: 'App-style persistent footer bar',
+          rationale:
+            'Familiar mobile-app pattern, but a fixed bar competing with the header/nav on every screen risks feeling exactly like the "wall" the game already hides behind during play.',
+          render: () => `
+            <h2 class="page-title">Archive</h2>
+            <div class="stats-row"><span>3 poems</span><span>1 favorite</span></div>
+            <div class="grid">
+              <div class="card"><div class="shape-line" style="width:60%"></div><div class="shape-line" style="width:80%"></div></div>
+              <div class="card"><div class="shape-line" style="width:70%"></div><div class="shape-line" style="width:50%"></div></div>
+            </div>
+            <div style="position:sticky; bottom:0; margin-top:24px; background:var(--color-surface); border:1px solid var(--color-border); border-radius:10px; padding:12px 16px; display:flex; justify-content:space-between; align-items:center;">
+              <span style="font-size:13px;">Guest archive &middot; local to this browser</span>
+              <a class="cta-button secondary" style="font-size:12px; padding:6px 14px;">Sign up</a>
+            </div>
+          `,
+        },
+        {
+          id: 'footer-strip',
+          name: '7. Footer Strip',
+          blurb: 'Below the grid, after the poems',
+          rationale:
+            'Correctly low-pressure, but easy to never scroll to &mdash; a guest who only checks their 2 latest poems may never see the explanation at all, weakening the acceptance bar.',
+          render: () => `
+            <h2 class="page-title">Archive</h2>
+            <div class="grid">
+              <div class="card"><div class="shape-line" style="width:60%"></div><div class="shape-line" style="width:80%"></div></div>
+              <div class="card"><div class="shape-line" style="width:70%"></div><div class="shape-line" style="width:50%"></div></div>
+            </div>
+            <div style="margin-top:32px; text-align:center; padding-top:24px; border-top:1px solid var(--color-border-subtle);">
+              <p style="font-size:12px; font-family:var(--font-mono); color:var(--color-text-muted); text-transform:uppercase; letter-spacing:0.08em;">This browser is the only copy</p>
+              <a class="cta-button secondary" style="margin-top:10px; font-size:12px; padding:8px 16px;">Sign up to keep it</a>
+            </div>
+          `,
+        },
+        {
+          id: 'first-visit-modal',
+          name: '8. First-Visit Modal',
+          blurb: 'One-time dialog, then a quiet link remains',
+          rationale:
+            'Explains the most, but a modal is structurally a wall with extra steps &mdash; the exact anti-pattern this card exists to remove, even if it only fires once per session.',
+          render: () => `
+            <h2 class="page-title">Archive</h2>
+            <div style="position:relative;">
+              <div style="filter:blur(1.5px); opacity:0.5;">
+                <div class="grid"><div class="card"><div class="shape-line" style="width:60%"></div></div><div class="card"><div class="shape-line" style="width:70%"></div></div></div>
+              </div>
+              <div style="position:absolute; inset:0; display:flex; align-items:center; justify-content:center;">
+                <div style="background:var(--color-surface); border:1px solid var(--color-border); border-radius:12px; padding:24px; max-width:340px; box-shadow:0 12px 32px rgba(0,0,0,0.18);">
+                  <p style="font-family:var(--font-display); font-size:18px; margin:0 0 8px;">Before you dive in</p>
+                  <p style="font-size:13px; color:var(--color-text-secondary); line-height:1.5; margin:0 0 16px;">This archive lives in your browser only. Sign up once to keep it forever.</p>
+                  <div style="display:flex; gap:8px;">
+                    <a class="cta-button" style="flex:1; text-align:center;">Sign up</a>
+                    <a class="cta-button secondary" style="flex:1; text-align:center;">Not now</a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          `,
+        },
+        {
+          id: 'accordion',
+          name: '9. Accordion Teaser',
+          blurb: 'Collapsed one-liner, expands on click',
+          rationale:
+            'Quiet by default, but opt-in disclosure means guests who never click never learn what signing in adds &mdash; fails "explains what signing in adds" as a passive guarantee.',
+          render: () => `
+            <h2 class="page-title">Archive</h2>
+            <div style="border:1px solid var(--color-border-subtle); border-radius:8px; padding:10px 14px; margin-bottom:20px; font-size:13px; color:var(--color-text-secondary); cursor:pointer;">
+              Why isn't this permanent yet? <span style="color:var(--color-primary);">▾</span>
+              <div style="margin-top:8px; font-size:12px; color:var(--color-text-muted); line-height:1.5;">Guest archives live in this browser's storage only. Sign up to sync across devices and keep it forever.</div>
+            </div>
+            <div class="grid"><div class="card"><div class="shape-line" style="width:60%"></div></div><div class="card"><div class="shape-line" style="width:70%"></div></div></div>
+          `,
+        },
+        {
+          id: 'corner-toast',
+          name: '10. Persistent Corner Toast',
+          blurb: 'Small anchored toast, bottom-right',
+          rationale:
+            'Unobtrusive, but disconnected from the content it is explaining &mdash; guests scanning the grid may never look at the corner, and it needs its own dismiss/reappear state machine.',
+          render: () => `
+            <h2 class="page-title">Archive</h2>
+            <div class="grid"><div class="card"><div class="shape-line" style="width:60%"></div></div><div class="card"><div class="shape-line" style="width:70%"></div></div><div class="card"><div class="shape-line" style="width:50%"></div></div></div>
+            <div style="position:fixed; bottom:24px; right:24px; background:var(--color-surface); border:1px solid var(--color-border); border-radius:10px; padding:12px 16px; box-shadow:0 8px 20px rgba(0,0,0,0.15); max-width:260px; font-size:12px;">
+              <span class="badge-dot" style="margin-right:6px;"></span>Guest archive &middot; local only. <span class="cta-link">Sign up</span>
+            </div>
+          `,
+        },
+      ];
+
+      let mode = 'light';
+      let activeId = options[2].id; // ribbon = winner, shown by default
+
+      const nav = document.getElementById('opt-list');
+      const viewer = document.getElementById('viewer-inner');
+
+      function renderNav() {
+        nav.innerHTML = '';
+        options.forEach((opt) => {
+          const btn = document.createElement('button');
+          btn.className = 'opt-btn' + (opt.id === activeId ? ' active' : '');
+          btn.innerHTML = `${opt.name}<small>${opt.blurb}</small>`;
+          btn.onclick = () => {
+            activeId = opt.id;
+            renderNav();
+            renderViewer();
+          };
+          nav.appendChild(btn);
+        });
+      }
+
+      function renderViewer() {
+        const opt = options.find((o) => o.id === activeId);
+        viewer.innerHTML = `
+          <div class="rationale"><b>Verdict:</b> ${opt.rationale}</div>
+          <div class="mock">${opt.render()}</div>
+        `;
+      }
+
+      document.getElementById('btn-light').onclick = () => {
+        mode = 'light';
+        document.body.removeAttribute('data-mode');
+        document.getElementById('btn-light').classList.add('active');
+        document.getElementById('btn-dark').classList.remove('active');
+      };
+      document.getElementById('btn-dark').onclick = () => {
+        mode = 'dark';
+        document.body.setAttribute('data-mode', 'dark');
+        document.getElementById('btn-dark').classList.add('active');
+        document.getElementById('btn-light').classList.remove('active');
+      };
+
+      renderNav();
+      renderViewer();
+    </script>
+  </body>
+</html>

--- a/lib/clerk/appearance.ts
+++ b/lib/clerk/appearance.ts
@@ -1,0 +1,183 @@
+import { useEffect, useState } from 'react';
+import { kenyaTheme } from '@/lib/themes/presets/kenya';
+
+/**
+ * Shared Clerk Appearance
+ *
+ * Single source of truth for how Clerk's prebuilt UI (SignIn, SignUp,
+ * UserButton and its "Manage account" modal) is themed. Set once on
+ * <ClerkProvider appearance={...}> in app/providers.tsx so every Clerk
+ * surface in the app inherits it — not just the two auth pages.
+ *
+ * Every value is a CSS custom property already driven by the active
+ * lib/themes preset (persimmon/mono/hyper/vintage-paper, light or dark),
+ * so this never needs to change when a theme is added or edited.
+ *
+ * Individual pages/components can still pass their own `appearance` prop
+ * to override or extend specific elements (Clerk merges component-level
+ * appearance on top of the provider-level appearance below).
+ */
+export const linejamClerkAppearance = {
+  elements: {
+    // Root container
+    rootBox: 'w-full',
+    card: 'shadow-none border-0 p-0 bg-transparent',
+    // Form
+    formButtonPrimary:
+      'bg-[var(--color-primary)] hover:bg-[var(--color-primary-hover)] text-[var(--color-text-inverse)] font-[var(--font-sans)] font-medium h-12 rounded-[var(--radius-md)] transition-all duration-[var(--duration-normal)]',
+    formFieldInput:
+      'bg-[var(--color-surface)] border-[var(--color-border)] text-[var(--color-text-primary)] font-[var(--font-sans)] h-12 rounded-[var(--radius-md)] focus:border-[var(--color-primary)] focus:ring-[var(--color-focus-ring)] focus:ring-2 focus:ring-offset-2',
+    formFieldLabel:
+      'text-[var(--color-text-secondary)] font-[var(--font-sans)] text-sm',
+    formFieldInputShowPasswordButton:
+      'text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]',
+    // Social buttons
+    socialButtonsBlockButton:
+      'bg-[var(--color-surface)] border-[var(--color-border)] text-[var(--color-text-primary)] font-[var(--font-sans)] h-12 rounded-[var(--radius-md)] hover:bg-[var(--color-surface-hover)] transition-all duration-[var(--duration-normal)]',
+    socialButtonsBlockButtonText: 'font-medium',
+    // Divider
+    dividerLine: 'bg-[var(--color-border)]',
+    dividerText:
+      'text-[var(--color-text-muted)] font-[var(--font-sans)] text-sm',
+    // Footer
+    footerActionText:
+      'text-[var(--color-text-secondary)] font-[var(--font-sans)]',
+    footerActionLink:
+      'text-[var(--color-primary)] hover:text-[var(--color-primary-hover)] font-medium',
+    // Identity preview (after first step)
+    identityPreviewText:
+      'text-[var(--color-text-primary)] font-[var(--font-sans)]',
+    identityPreviewEditButton:
+      'text-[var(--color-primary)] hover:text-[var(--color-primary-hover)]',
+    // Alert/Error states
+    alert:
+      'bg-[var(--color-error)]/10 border-[var(--color-error)] text-[var(--color-error)]',
+    // OTP input
+    otpCodeFieldInput:
+      'bg-[var(--color-surface)] border-[var(--color-border)] text-[var(--color-text-primary)] font-[var(--font-mono)] text-xl rounded-[var(--radius-md)]',
+    // UserButton popover + embedded "Manage account" modal
+    userButtonPopoverCard:
+      'bg-[var(--color-surface)] border border-[var(--color-border)] shadow-[var(--shadow-lg)]',
+    userButtonPopoverActionButton:
+      'text-[var(--color-text-primary)] font-[var(--font-sans)] hover:bg-[var(--color-surface-hover)]',
+    userButtonPopoverActionButtonText: 'font-[var(--font-sans)]',
+    userButtonPopoverFooter: 'hidden',
+    modalBackdrop: 'bg-[var(--color-background)]/80',
+    modalContent: 'bg-[var(--color-surface)]',
+  },
+  layout: {
+    socialButtonsPlacement: 'top' as const,
+    socialButtonsVariant: 'blockButton' as const,
+  },
+};
+
+const FALLBACK_TOKENS = kenyaTheme.tokens.light;
+
+function readCssVar(token: string, fallback: string): string {
+  if (typeof document === 'undefined') return fallback;
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(`--${token}`)
+    .trim();
+  return value || fallback;
+}
+
+/**
+ * Resolve Clerk's `variables` theming knobs (colorPrimary, colorBackground,
+ * ...) from the currently applied lib/themes tokens.
+ *
+ * Why not just reference `var(--color-primary)` here the way the `elements`
+ * classes above do? Clerk's own internal stylesheet defines its default
+ * component colors as custom properties too, and it loads after Tailwind's
+ * utilities in the cascade — at equal specificity, Clerk's own default
+ * wins, so `elements` classes referencing our CSS vars are silently
+ * overridden (found live while QA-ing linejam-942: the "Continue" button
+ * rendered Clerk's stock `#2F3037` gray, not the theme's accent, even with
+ * a hand-authored `bg-[var(--color-primary)]` class). `variables` set
+ * Clerk's own custom properties directly, which its internal styles read
+ * with no cascade fight — but Clerk also uses these to compute derived
+ * hover/active shades in JS, which needs a real parseable color, not a
+ * `var()` reference. So this reads the resolved literal value lib/themes
+ * already applied to the document instead of re-pointing at the variable.
+ *
+ * A plain function, not a hook, because ClerkProvider sits above
+ * ThemeProvider in the tree and has no React context to read the active
+ * theme from — {@link useClerkThemeVariables} below calls it on mount and
+ * again whenever the document root changes.
+ */
+export function resolveClerkThemeVariables() {
+  return {
+    colorPrimary: readCssVar('color-primary', FALLBACK_TOKENS['color-primary']),
+    colorPrimaryForeground: readCssVar(
+      'color-text-inverse',
+      FALLBACK_TOKENS['color-text-inverse']
+    ),
+    colorDanger: readCssVar(
+      'color-error',
+      FALLBACK_TOKENS['color-error'] ?? '#ef4444'
+    ),
+    colorSuccess: readCssVar(
+      'color-success',
+      FALLBACK_TOKENS['color-success'] ?? '#10b981'
+    ),
+    colorWarning: readCssVar(
+      'color-warning',
+      FALLBACK_TOKENS['color-warning'] ?? '#f59e0b'
+    ),
+    colorBackground: readCssVar(
+      'color-surface',
+      FALLBACK_TOKENS['color-surface']
+    ),
+    colorForeground: readCssVar(
+      'color-text-primary',
+      FALLBACK_TOKENS['color-text-primary']
+    ),
+    colorMutedForeground: readCssVar(
+      'color-text-muted',
+      FALLBACK_TOKENS['color-text-muted']
+    ),
+    colorMuted: readCssVar('color-muted', FALLBACK_TOKENS['color-muted']),
+    colorInput: readCssVar('color-surface', FALLBACK_TOKENS['color-surface']),
+    colorInputForeground: readCssVar(
+      'color-text-primary',
+      FALLBACK_TOKENS['color-text-primary']
+    ),
+    colorBorder: readCssVar('color-border', FALLBACK_TOKENS['color-border']),
+    colorNeutral: readCssVar(
+      'color-text-primary',
+      FALLBACK_TOKENS['color-text-primary']
+    ),
+    // Not color-derived by Clerk's JS, so these can stay live var()
+    // references and keep tracking the active theme with no extra plumbing.
+    fontFamily: 'var(--font-sans)',
+    fontFamilyButtons: 'var(--font-sans)',
+    borderRadius: 'var(--radius-md)',
+  };
+}
+
+/**
+ * React binding for {@link resolveClerkThemeVariables}: re-resolves whenever
+ * lib/themes' `applyTheme` mutates `document.documentElement` (its
+ * `style`/`data-theme`/mode class), so switching theme or light/dark while a
+ * Clerk surface (UserButton popover, embedded account modal) is visible
+ * re-themes it without a full page reload.
+ */
+export function useClerkThemeVariables() {
+  const [variables, setVariables] = useState(resolveClerkThemeVariables);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const update = () => setVariables(resolveClerkThemeVariables());
+
+    // Pick up whatever lib/themes already applied before this effect ran.
+    update();
+
+    const observer = new MutationObserver(update);
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ['style', 'data-theme', 'class'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return variables;
+}

--- a/lib/clerk/appearance.ts
+++ b/lib/clerk/appearance.ts
@@ -71,7 +71,13 @@ export const linejamClerkAppearance = {
   },
 };
 
-const FALLBACK_TOKENS = kenyaTheme.tokens.light;
+// kenyaTheme.tokens.light hardcodes every optional semantic color (see
+// lib/themes/presets/kenya.ts); this cast just tells TypeScript what's
+// already true so callers below don't need dead `?? 'literal'` fallbacks
+// for fields that can never actually be missing on this preset.
+const FALLBACK_TOKENS = kenyaTheme.tokens.light as Required<
+  typeof kenyaTheme.tokens.light
+>;
 
 function readCssVar(token: string, fallback: string): string {
   if (typeof document === 'undefined') return fallback;
@@ -111,18 +117,9 @@ export function resolveClerkThemeVariables() {
       'color-text-inverse',
       FALLBACK_TOKENS['color-text-inverse']
     ),
-    colorDanger: readCssVar(
-      'color-error',
-      FALLBACK_TOKENS['color-error'] ?? '#ef4444'
-    ),
-    colorSuccess: readCssVar(
-      'color-success',
-      FALLBACK_TOKENS['color-success'] ?? '#10b981'
-    ),
-    colorWarning: readCssVar(
-      'color-warning',
-      FALLBACK_TOKENS['color-warning'] ?? '#f59e0b'
-    ),
+    colorDanger: readCssVar('color-error', FALLBACK_TOKENS['color-error']),
+    colorSuccess: readCssVar('color-success', FALLBACK_TOKENS['color-success']),
+    colorWarning: readCssVar('color-warning', FALLBACK_TOKENS['color-warning']),
     colorBackground: readCssVar(
       'color-surface',
       FALLBACK_TOKENS['color-surface']

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,40 +2,32 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 /**
- * Route Protection Middleware
+ * Root Middleware
  *
- * Linejam uses hybrid auth: Clerk (authenticated) + guest tokens (anonymous).
- * Most routes are public since guests can play without accounts.
+ * Linejam uses hybrid identity: Clerk (authenticated) + guest tokens
+ * (anonymous, HttpOnly cookie). Every route is public; there is no
+ * Clerk-only route today.
  *
- * Protected routes (require Clerk auth):
- * - /me/* - User profile and poem archive
- *
- * Public routes (no auth required):
- * - / - Homepage
- * - /room/* - Game rooms (guests use localStorage token)
- * - /sign-in, /sign-up - Auth pages
- * - /api/* - API routes handle their own auth
+ * `/me/poems` and `/me/profile` look account-gated but are NOT — both
+ * resolve identity themselves via `useUser()` client-side and
+ * `getUser(ctx, guestToken)` in Convex, and work for guests and signed-in
+ * users alike. Do NOT reintroduce an `auth.protect()` gate on `/me/*` (or
+ * any future page built the same hybrid way) here: Clerk's `protect()`
+ * falls back to the hosted Account Portal (accounts.<domain>) when no
+ * in-app sign-in page is configured for it, which is exactly the "guest
+ * gets dumped on a stock wall with no way back to their poems" bug this
+ * middleware used to cause (linejam-942). A page that genuinely requires
+ * a Clerk account belongs behind its own guard in the page component, not
+ * a middleware-wide redirect.
  *
  * When Clerk is not configured (no CLERK_SECRET_KEY), the app runs in
- * guest-only mode. Protected routes redirect to home, auth pages show
- * a message that auth is unavailable.
+ * guest-only mode and this middleware is a no-op passthrough.
  */
 
 // Check if Clerk is configured (secret key available)
 const isClerkConfigured = !!process.env.CLERK_SECRET_KEY;
 
-// Route matchers (simple path checking to avoid Clerk import)
-function isProtectedRoute(pathname: string): boolean {
-  return pathname.startsWith('/me');
-}
-
-// Fallback middleware for when Clerk is not configured
-function guestOnlyMiddleware(req: NextRequest) {
-  // Redirect protected routes to home in guest-only mode
-  if (isProtectedRoute(req.nextUrl.pathname)) {
-    return NextResponse.redirect(new URL('/', req.url));
-  }
-  // Auth routes will show "auth unavailable" via their page logic
+function passthroughMiddleware() {
   return NextResponse.next();
 }
 
@@ -48,27 +40,20 @@ let middleware: (
 if (isClerkConfigured) {
   try {
     // Only import Clerk when configured to avoid initialization errors
+    const { clerkMiddleware } = require('@clerk/nextjs/server'); // eslint-disable-line @typescript-eslint/no-require-imports
 
-    const {
-      clerkMiddleware,
-      createRouteMatcher,
-    } = require('@clerk/nextjs/server'); // eslint-disable-line @typescript-eslint/no-require-imports
-    const isProtectedClerkRoute = createRouteMatcher(['/me(.*)']);
-
-    middleware = clerkMiddleware(
-      async (auth: { protect: () => Promise<void> }, req: NextRequest) => {
-        if (isProtectedClerkRoute(req)) {
-          await auth.protect();
-        }
-      }
-    );
+    // clerkMiddleware still wraps every request so Clerk can attach the
+    // session state (cookies/JWT) that useAuth()/ConvexProviderWithClerk
+    // read client-side. It intentionally takes no handler — nothing calls
+    // auth.protect() because no route is Clerk-only.
+    middleware = clerkMiddleware();
   } catch {
     // If Clerk initialization fails, fall back to guest-only mode
     console.warn('Clerk initialization failed, running in guest-only mode');
-    middleware = guestOnlyMiddleware;
+    middleware = passthroughMiddleware;
   }
 } else {
-  middleware = guestOnlyMiddleware;
+  middleware = passthroughMiddleware;
 }
 
 export default middleware;

--- a/tests/components/archive/ArchiveInfoStrip.test.tsx
+++ b/tests/components/archive/ArchiveInfoStrip.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ArchiveInfoStrip } from '@/components/archive/ArchiveInfoStrip';
+
+/**
+ * Winning direction from explorations/guest-archive-identity-lab (Option 3:
+ * Hairline Info Strip) — see DECISION.md there. Regression coverage for
+ * linejam-942 acceptance: the archive entry point must always explain what
+ * signing in adds for a guest, and must never depend on an auth wall.
+ */
+describe('ArchiveInfoStrip', () => {
+  it('renders nothing for a signed-in user with no poems yet', () => {
+    const { container } = render(
+      <ArchiveInfoStrip isAuthenticated hasPoems={false} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the reveal hint (no guest copy) for a signed-in user with poems', () => {
+    render(<ArchiveInfoStrip isAuthenticated hasPoems />);
+    expect(
+      screen.getByText(/tap any poem to reveal the full verse/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/sign up/i)).not.toBeInTheDocument();
+  });
+
+  it('explains the guest tradeoff even with zero poems (never a dead end)', () => {
+    render(<ArchiveInfoStrip isAuthenticated={false} hasPoems={false} />);
+    expect(screen.getByText(/saved to this browser only/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /sign up/i })).toHaveAttribute(
+      'href',
+      '/sign-up'
+    );
+  });
+
+  it('shows both the reveal hint and the guest explainer for a guest with poems', () => {
+    render(<ArchiveInfoStrip isAuthenticated={false} hasPoems />);
+    expect(
+      screen.getByText(/tap any poem to reveal the full verse/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/saved to this browser only/i)).toBeInTheDocument();
+  });
+});

--- a/tests/e2e/guest-archive-access.spec.ts
+++ b/tests/e2e/guest-archive-access.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test';
+import {
+  CANONICAL_GUEST_FLOW_LINES,
+  GuestFlowSession,
+} from '@/tests/e2e/support/guestFlow';
+
+/**
+ * Regression coverage for linejam-942.
+ *
+ * Live prod bug (2026-07-06): tapping the header archive icon as a guest
+ * redirected (middleware.ts protecting /me/*) to accounts.linejam.app —
+ * Clerk's hosted Account Portal, stock violet, "Secured by Clerk" — with no
+ * way back to the poems the guest just wrote. /me/poems and /me/profile
+ * already resolved guest identity themselves via the guest cookie; the
+ * middleware gate was the only thing standing between a guest and their own
+ * archive.
+ */
+
+test.describe.configure({ mode: 'serial' });
+
+const missingGuestTokenSecret =
+  !process.env.GUEST_TOKEN_SECRET && !process.env.E2E_BASE_URL;
+test.skip(
+  missingGuestTokenSecret,
+  'Set GUEST_TOKEN_SECRET for local E2E, or E2E_BASE_URL for a remote target'
+);
+
+test.describe('guest archive access (no account)', () => {
+  test('a guest who never played reaches /me/poems directly, no redirect', async ({
+    page,
+  }) => {
+    await page.goto('/me/poems');
+    await page.waitForLoadState('networkidle');
+
+    // Never bounced to Clerk's hosted Account Portal or an in-app sign-in wall.
+    expect(page.url()).toContain('/me/poems');
+    expect(page.url()).not.toContain('accounts.');
+    expect(page.url()).not.toContain('/sign-in');
+
+    await expect(page.getByRole('heading', { name: 'Archive' })).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Never a dead end: the guest identity explainer is always present.
+    await expect(page.getByText(/saved to this browser only/i)).toBeVisible();
+    await expect(page.getByRole('link', { name: /sign up/i })).toHaveAttribute(
+      'href',
+      '/sign-up'
+    );
+  });
+
+  test('a guest who never played reaches /me/profile directly, no redirect', async ({
+    page,
+  }) => {
+    await page.goto('/me/profile');
+    await page.waitForLoadState('networkidle');
+
+    expect(page.url()).toContain('/me/profile');
+    expect(page.url()).not.toContain('accounts.');
+    expect(page.url()).not.toContain('/sign-in');
+
+    await expect(page.getByRole('heading', { name: 'Identity' })).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(
+      page.getByText(/authenticate to preserve your works/i)
+    ).toBeVisible();
+  });
+});
+
+test.describe('guest archive access after a played game @slow', () => {
+  let session: GuestFlowSession | null = null;
+
+  test.afterEach(async () => {
+    await session?.close();
+    session = null;
+  });
+
+  test('a guest who just played reaches their poem from the archive entry point', async ({
+    browser,
+  }) => {
+    session = await GuestFlowSession.create(browser);
+    await session.createRoom();
+    await session.joinRoom();
+    await session.startGame();
+    await session.playCanonicalGame(CANONICAL_GUEST_FLOW_LINES);
+    await session.revealAssignedPoem('host', CANONICAL_GUEST_FLOW_LINES);
+    await session.expectSessionComplete();
+
+    // Same guest session/cookie, navigating to the archive entry point —
+    // never redirected away from the poem just written.
+    await session.hostPage.goto('/me/poems');
+    await session.hostPage.waitForLoadState('networkidle');
+
+    expect(session.hostPage.url()).toContain('/me/poems');
+    await expect(
+      session.hostPage.getByRole('heading', { name: 'Archive' })
+    ).toBeVisible({ timeout: 15000 });
+
+    // The poem this guest just wrote is reachable without an account.
+    await expect(
+      session.hostPage.getByText(/saved to this browser only/i)
+    ).toBeVisible();
+    const emptyState = session.hostPage.getByText(/your archive awaits/i);
+    await expect(emptyState).toHaveCount(0);
+  });
+});

--- a/tests/e2e/guest-archive-access.spec.ts
+++ b/tests/e2e/guest-archive-access.spec.ts
@@ -37,7 +37,11 @@ test.describe('guest archive access (no account)', () => {
     expect(page.url()).not.toContain('accounts.');
     expect(page.url()).not.toContain('/sign-in');
 
-    await expect(page.getByRole('heading', { name: 'Archive' })).toBeVisible({
+    // exact: true — the empty-archive state's "Your archive awaits" h2
+    // otherwise substring-matches the same role/name query.
+    await expect(
+      page.getByRole('heading', { name: 'Archive', exact: true })
+    ).toBeVisible({
       timeout: 15000,
     });
 
@@ -59,7 +63,9 @@ test.describe('guest archive access (no account)', () => {
     expect(page.url()).not.toContain('accounts.');
     expect(page.url()).not.toContain('/sign-in');
 
-    await expect(page.getByRole('heading', { name: 'Identity' })).toBeVisible({
+    await expect(
+      page.getByRole('heading', { name: 'Identity', exact: true })
+    ).toBeVisible({
       timeout: 15000,
     });
     await expect(
@@ -94,7 +100,7 @@ test.describe('guest archive access after a played game @slow', () => {
 
     expect(session.hostPage.url()).toContain('/me/poems');
     await expect(
-      session.hostPage.getByRole('heading', { name: 'Archive' })
+      session.hostPage.getByRole('heading', { name: 'Archive', exact: true })
     ).toBeVisible({ timeout: 15000 });
 
     // The poem this guest just wrote is reachable without an account.

--- a/tests/lib/clerk/appearance.test.ts
+++ b/tests/lib/clerk/appearance.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+  resolveClerkThemeVariables,
+  useClerkThemeVariables,
+} from '@/lib/clerk/appearance';
+import { kenyaTheme } from '@/lib/themes/presets/kenya';
+
+/**
+ * Regression coverage for a live bug found while QA-ing linejam-942: Clerk's
+ * own default component styles (`.cl-formButtonPrimary { background:
+ * var(--accent) }`) load after Tailwind's utilities and win the cascade tie
+ * against our `elements` classes (`bg-[var(--color-primary)]`), so the
+ * "Continue" button rendered Clerk's stock #2F3037 gray instead of the
+ * theme's accent color. `variables` sets Clerk's own custom properties
+ * directly instead of fighting that cascade — but Clerk also uses these to
+ * compute derived hover/active shades in JS, which needs a real parseable
+ * color, not a `var()` reference. This resolves the literal value
+ * lib/themes already applied to the document.
+ */
+
+function clearRootStyle() {
+  const root = document.documentElement;
+  for (const key of Array.from(root.style)) {
+    if (key.startsWith('--')) root.style.removeProperty(key);
+  }
+}
+
+describe('resolveClerkThemeVariables', () => {
+  afterEach(() => {
+    clearRootStyle();
+  });
+
+  it('resolves colorPrimary from the applied --color-primary, not a var() passthrough', () => {
+    document.documentElement.style.setProperty('--color-primary', '#e85d2b');
+
+    const variables = resolveClerkThemeVariables();
+
+    expect(variables.colorPrimary).toBe('#e85d2b');
+    expect(variables.colorPrimary).not.toContain('var(');
+  });
+
+  it('reflects a different theme once the document root changes', () => {
+    document.documentElement.style.setProperty('--color-primary', '#ff00ff');
+    document.documentElement.style.setProperty('--color-background', '#0b0b0b');
+
+    const variables = resolveClerkThemeVariables();
+
+    expect(variables.colorPrimary).toBe('#ff00ff');
+  });
+
+  it('falls back to the kenya default when a token is not yet applied', () => {
+    // Nothing set on the root — simulates the earliest possible render
+    // before the anti-FOUC blocking script has run.
+    const variables = resolveClerkThemeVariables();
+
+    expect(variables.colorPrimary).toBe(
+      kenyaTheme.tokens.light['color-primary']
+    );
+    expect(variables.colorBackground).toBe(
+      kenyaTheme.tokens.light['color-surface']
+    );
+  });
+
+  it('passes fontFamily/borderRadius through as live CSS variable references', () => {
+    // These aren't parsed by Clerk's color-derivation math, so they can stay
+    // reactive var() references rather than snapshotted literals.
+    const variables = resolveClerkThemeVariables();
+
+    expect(variables.fontFamily).toBe('var(--font-sans)');
+    expect(variables.borderRadius).toBe('var(--radius-md)');
+  });
+});
+
+describe('useClerkThemeVariables', () => {
+  afterEach(() => {
+    clearRootStyle();
+    vi.useRealTimers();
+  });
+
+  it('picks up a theme switch applied to the document root after mount', async () => {
+    document.documentElement.style.setProperty('--color-primary', '#e85d2b');
+    document.documentElement.setAttribute('data-theme', 'kenya');
+
+    const { result } = renderHook(() => useClerkThemeVariables());
+    expect(result.current.colorPrimary).toBe('#e85d2b');
+
+    act(() => {
+      document.documentElement.style.setProperty('--color-primary', '#ff00ff');
+      document.documentElement.setAttribute('data-theme', 'hyper');
+    });
+
+    await waitFor(() => {
+      expect(result.current.colorPrimary).toBe('#ff00ff');
+    });
+  });
+});

--- a/tests/lib/clerk/appearance.test.ts
+++ b/tests/lib/clerk/appearance.test.ts
@@ -63,6 +63,22 @@ describe('resolveClerkThemeVariables', () => {
     );
   });
 
+  it('falls back to the kenya default during SSR (no document)', () => {
+    vi.stubGlobal('document', undefined);
+    try {
+      const variables = resolveClerkThemeVariables();
+
+      expect(variables.colorPrimary).toBe(
+        kenyaTheme.tokens.light['color-primary']
+      );
+      expect(variables.colorBorder).toBe(
+        kenyaTheme.tokens.light['color-border']
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('passes fontFamily/borderRadius through as live CSS variable references', () => {
     // These aren't parsed by Clerk's color-derivation math, so they can stay
     // reactive var() references rather than snapshotted literals.

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -7,12 +7,15 @@ import { NextRequest } from 'next/server';
  * themselves (Clerk session or guest cookie via useUser()/getUser()), so
  * middleware must not gate them.
  *
- * Only the guest-only (Clerk-not-configured) branch is unit-testable here:
- * middleware.ts intentionally dynamic-`require()`s '@clerk/nextjs/server'
- * (see the file's own comment) so the module isn't imported at all when
- * Clerk is unconfigured — that guard makes the require() unmockable via
- * vi.mock in this pool. The Clerk-configured path (the one that hit
- * production) is covered live in tests/e2e/guest-archive-access.spec.ts.
+ * The full Clerk-configured *request* path (the one that hit production)
+ * can't be unit-tested here — invoking the returned middleware against a
+ * request drives Clerk's real session validation, which needs live keys
+ * and network. That path is covered live in
+ * tests/e2e/guest-archive-access.spec.ts. What *is* unit-testable, and
+ * covered below, is that constructing the middleware when Clerk
+ * credentials are present takes the success path (no
+ * "initialization failed" fallback) without ever calling `auth.protect()`
+ * — since nothing in this file calls it for any route.
  */
 
 const ORIGINAL_CLERK_SECRET_KEY = process.env.CLERK_SECRET_KEY;
@@ -24,6 +27,7 @@ afterEach(() => {
     process.env.CLERK_SECRET_KEY = ORIGINAL_CLERK_SECRET_KEY;
   }
   vi.resetModules();
+  vi.restoreAllMocks();
 });
 
 describe('middleware — guest-only mode (Clerk not configured)', () => {
@@ -47,5 +51,27 @@ describe('middleware — guest-only mode (Clerk not configured)', () => {
     const res = await middleware(req);
 
     expect(res.headers.get('location')).toBeNull();
+  });
+});
+
+describe('middleware — Clerk configured', () => {
+  it('takes the clerkMiddleware() success path, not the init-failure fallback', async () => {
+    // Not a real credential — just needs to be a non-empty string so
+    // isClerkConfigured is true. clerkMiddleware() itself doesn't validate
+    // key format or touch the network until a request is actually handled
+    // (Clerk's key/publishable-key checks live inside the per-request
+    // handler), so this covers the `if (isClerkConfigured)` branch without
+    // needing to drive a full authenticated request through Clerk.
+    process.env.CLERK_SECRET_KEY = 'test-value-not-a-real-clerk-secret';
+    vi.resetModules();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { default: middleware } = await import('../middleware');
+
+    // Proves the `try` succeeded (middleware is a real function, not the
+    // passthrough init-failure fallback) with no auth.protect() call site
+    // anywhere in this file.
+    expect(typeof middleware).toBe('function');
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+/**
+ * Regression coverage for linejam-942: a guest hitting /me/* must never be
+ * redirected away. The pages under /me/* already resolve identity
+ * themselves (Clerk session or guest cookie via useUser()/getUser()), so
+ * middleware must not gate them.
+ *
+ * Only the guest-only (Clerk-not-configured) branch is unit-testable here:
+ * middleware.ts intentionally dynamic-`require()`s '@clerk/nextjs/server'
+ * (see the file's own comment) so the module isn't imported at all when
+ * Clerk is unconfigured — that guard makes the require() unmockable via
+ * vi.mock in this pool. The Clerk-configured path (the one that hit
+ * production) is covered live in tests/e2e/guest-archive-access.spec.ts.
+ */
+
+const ORIGINAL_CLERK_SECRET_KEY = process.env.CLERK_SECRET_KEY;
+
+afterEach(() => {
+  if (ORIGINAL_CLERK_SECRET_KEY === undefined) {
+    delete process.env.CLERK_SECRET_KEY;
+  } else {
+    process.env.CLERK_SECRET_KEY = ORIGINAL_CLERK_SECRET_KEY;
+  }
+  vi.resetModules();
+});
+
+describe('middleware — guest-only mode (Clerk not configured)', () => {
+  it('does not redirect /me/poems away', async () => {
+    delete process.env.CLERK_SECRET_KEY;
+    vi.resetModules();
+
+    const { default: middleware } = await import('../middleware');
+    const req = new NextRequest('http://localhost:3000/me/poems');
+    const res = await middleware(req);
+
+    expect(res.headers.get('location')).toBeNull();
+  });
+
+  it('does not redirect /me/profile away', async () => {
+    delete process.env.CLERK_SECRET_KEY;
+    vi.resetModules();
+
+    const { default: middleware } = await import('../middleware');
+    const req = new NextRequest('http://localhost:3000/me/profile');
+    const res = await middleware(req);
+
+    expect(res.headers.get('location')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Powder card: linejam-942 (P1 identity seam)

Live prod bug: tapping the header archive icon as a guest who just played a full game redirected (middleware.ts protecting `/me/*`) to `accounts.linejam.app` — Clerk's hosted Account Portal, stock violet, "Secured by Clerk" — with no way back to the poems the guest just wrote.

**Root cause found in the data layer, not just the UI:** both `/me/poems` and `/me/profile` already resolve identity themselves via the guest cookie (`getUser(ctx, guestToken)` in Convex, `useUser()` client-side) — they were *already built* to work for guests. The middleware's Clerk gate on `/me/*` was the only thing standing between a guest and their own archive. Removing it (Clerk's `auth.protect()` falls back to the hosted Account Portal when no in-app sign-in page is configured for it — that's the stock wall) lets guests straight through to pages already designed to handle them.

- `middleware.ts` — no route in this app is Clerk-only; `/me/*` is public, pages guard themselves. `clerkMiddleware()` still wraps every request (needed for `useAuth()`/`ConvexProviderWithClerk` session propagation) but never calls `.protect()`.
- `app/providers.tsx` — `ClerkProvider` now carries `signInUrl="/sign-in"` / `signUpUrl="/sign-up"` (code-level, not env-var-dependent) so any future Clerk redirect points at our themed in-app pages, never the hosted portal.
- `lib/clerk/appearance.ts` (new) — shared, theme-driven Clerk appearance (colors/fonts) set once on `ClerkProvider` instead of duplicated per sign-in/sign-up page. **Found and fixed a live cascade bug while QA-ing this**: Clerk's own default component CSS (`.cl-formButtonPrimary { background: var(--accent) }`) loads after Tailwind's utilities and wins the specificity tie, so the existing `bg-[var(--color-primary)]` `elements` class was silently overridden — the "Continue" button rendered Clerk's stock `#2F3037` gray, not the theme's accent, even before this PR touched the file. Fixed by using Clerk's own `variables` theming API (which its internals read directly, and which supports the derived hover/active shade math `var()` values can't) instead of fighting the cascade. A `useClerkThemeVariables()` hook keeps it reactive to theme/mode switches via a `MutationObserver` on `document.documentElement` (no React context needed — `ClerkProvider` sits above `ThemeProvider` in the tree).
- `components/archive/ArchiveInfoStrip.tsx` (new) — the archive entry point now always explains what signing in adds (guest or not, 0 poems or many) instead of ever dead-ending on a wall. Winning direction out of 10 structurally distinct options explored in `explorations/guest-archive-identity-lab/` (see `DECISION.md` there) — chosen because it extends the page's own existing hairline-hint convention ("Tap any poem to reveal the full verse") rather than inventing new chrome.
- Guest-to-account poem migration on sign-up already existed (`convex/migrations.ts` `migrateGuestToUser` + `app/(auth)/callback`) and needed no changes.

## Acceptance (linejam-942)

- [x] Guest reaches recent poems from the archive entry point without an account — live-verified on a fresh browser profile (see QA below)
- [x] Guest archive entry never dead-ends on a bare wall — `ArchiveInfoStrip` always present
- [x] Clerk sign-in/sign-up visually match the active theme (accent, fonts, dark/light) — screenshot evidence across all 4 themes + light/dark
- [x] Sign-up links the guest's existing poems to the new account — pre-existing, verified unchanged
- [x] Archive/identity surface locked via a design lab (10 options) — `explorations/guest-archive-identity-lab/`

Not in code-controlled scope: Clerk's *hosted* Account Portal (`accounts.linejam.app`) branding lives in the Clerk Dashboard, not this repo. Since `signInUrl`/`signUpUrl` now keep users on our in-app pages for the entire sign-in/sign-up/redirect flow, the hosted portal should no longer appear in the normal guest journey — recorded here rather than silently assumed.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (0 errors; 4 pre-existing unrelated warnings in `site/*.js`)
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 114 files / 1223 tests passed (1 pre-existing skip), including new:
  - `tests/middleware.test.ts` — guest-only mode no longer redirects `/me/poems`/`/me/profile`
  - `tests/lib/clerk/appearance.test.ts` — `resolveClerkThemeVariables`/`useClerkThemeVariables` (the cascade-bug regression test)
  - `tests/components/archive/ArchiveInfoStrip.test.tsx`
- [x] New `tests/e2e/guest-archive-access.spec.ts` (Playwright) — added following repo conventions; **could not execute locally**: this sandbox's Playwright `globalSetup` fails with `TypeError: context.conditions?.includes is not a function` reproducibly on an *unmodified* existing spec too (confirmed on `tests/e2e/auth.spec.ts` before touching anything), so this is a pre-existing environment issue, not something this diff introduced. Will be exercised by CI's `e2e`/`agentic-qa` gate.
- [x] Live manual QA (this sandbox, real dev Clerk keys + Convex dev deployment):
  - `curl` before/after comparison on `middleware.ts` (via `git stash`) — buggy version 404'd `/me/poems` and `/me/profile` for a guest; fixed version returns 200 with real `Archive`/`Identity` markup
  - Browser walk: fresh guest → homepage → click header archive icon → lands on `/me/poems`, no redirect, "Your archive awaits" + "Saved to this browser only. Sign up to keep it forever, on any device." visible
  - Screenshot evidence across all 4 themes (Kenya/Mono/Vintage Paper/Hyper) × light/dark on `/sign-in` — accent color, fonts, and the "Continue" button all correctly reactive to the live theme picker with no page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)