### PR TITLE
fix(e2e): stabilize guest archive and reveal share

### DIFF
--- a/components/PoemDisplay.tsx
+++ b/components/PoemDisplay.tsx
@@ -387,7 +387,7 @@ export function PoemDisplay({
             the recap.
           </p>
         )}
-        <div className="flex items-center justify-center gap-space-3">
+        <div className="flex w-full max-w-md flex-wrap items-center justify-center gap-space-2 sm:gap-space-3">
           {/* Reveal variant: heart the poem toward the room-favorite crown */}
           {!isArchive && (
             <HeartButton poemId={poemId} guestToken={guestToken} />
@@ -396,7 +396,7 @@ export function PoemDisplay({
             onClick={handleShare}
             variant="primary"
             size="lg"
-            className="min-w-[140px] h-12"
+            className="h-12 min-w-[120px] flex-1"
             stampAnimate={copied}
           >
             {shared ? 'Shared!' : copied ? 'Copied!' : 'Share'}
@@ -406,7 +406,7 @@ export function PoemDisplay({
             data-testid={E2E_TEST_IDS.poemSaveImageButton}
             variant="outline"
             size="lg"
-            className="min-w-[140px] h-12"
+            className="h-12 min-w-[120px] flex-1"
             disabled={saving}
           >
             <Download className="mr-2 h-4 w-4" aria-hidden="true" />

--- a/tests/e2e/guest-archive-access.spec.ts
+++ b/tests/e2e/guest-archive-access.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import {
   CANONICAL_GUEST_FLOW_LINES,
   GuestFlowSession,
+  isolateGuestSessionIp,
 } from '@/tests/e2e/support/guestFlow';
 
 /**
@@ -27,50 +28,65 @@ test.skip(
 
 test.describe('guest archive access (no account)', () => {
   test('a guest who never played reaches /me/poems directly, no redirect', async ({
-    page,
+    browser,
   }) => {
-    await page.goto('/me/poems');
-    await page.waitForLoadState('networkidle');
+    const context = await browser.newContext();
+    await isolateGuestSessionIp(context);
+    const page = await context.newPage();
 
-    // Never bounced to Clerk's hosted Account Portal or an in-app sign-in wall.
-    expect(page.url()).toContain('/me/poems');
-    expect(page.url()).not.toContain('accounts.');
-    expect(page.url()).not.toContain('/sign-in');
+    try {
+      await page.goto('/me/poems');
+      await page.waitForLoadState('networkidle');
 
-    // exact: true — the empty-archive state's "Your archive awaits" h2
-    // otherwise substring-matches the same role/name query.
-    await expect(
-      page.getByRole('heading', { name: 'Archive', exact: true })
-    ).toBeVisible({
-      timeout: 15000,
-    });
+      // Never bounced to Clerk's hosted Account Portal or an in-app sign-in wall.
+      expect(page.url()).toContain('/me/poems');
+      expect(page.url()).not.toContain('accounts.');
+      expect(page.url()).not.toContain('/sign-in');
 
-    // Never a dead end: the guest identity explainer is always present.
-    await expect(page.getByText(/saved to this browser only/i)).toBeVisible();
-    await expect(page.getByRole('link', { name: /sign up/i })).toHaveAttribute(
-      'href',
-      '/sign-up'
-    );
+      // exact: true — the empty-archive state's "Your archive awaits" h2
+      // otherwise substring-matches the same role/name query.
+      await expect(
+        page.getByRole('heading', { name: 'Archive', exact: true })
+      ).toBeVisible({
+        timeout: 15000,
+      });
+
+      // Never a dead end: the guest identity explainer is always present.
+      await expect(page.getByText(/saved to this browser only/i)).toBeVisible();
+      await expect(
+        page.getByRole('link', { name: /sign up/i })
+      ).toHaveAttribute('href', '/sign-up');
+    } finally {
+      await context.close();
+    }
   });
 
   test('a guest who never played reaches /me/profile directly, no redirect', async ({
-    page,
+    browser,
   }) => {
-    await page.goto('/me/profile');
-    await page.waitForLoadState('networkidle');
+    const context = await browser.newContext();
+    await isolateGuestSessionIp(context);
+    const page = await context.newPage();
 
-    expect(page.url()).toContain('/me/profile');
-    expect(page.url()).not.toContain('accounts.');
-    expect(page.url()).not.toContain('/sign-in');
+    try {
+      await page.goto('/me/profile');
+      await page.waitForLoadState('networkidle');
 
-    await expect(
-      page.getByRole('heading', { name: 'Identity', exact: true })
-    ).toBeVisible({
-      timeout: 15000,
-    });
-    await expect(
-      page.getByText(/authenticate to preserve your works/i)
-    ).toBeVisible();
+      expect(page.url()).toContain('/me/profile');
+      expect(page.url()).not.toContain('accounts.');
+      expect(page.url()).not.toContain('/sign-in');
+
+      await expect(
+        page.getByRole('heading', { name: 'Identity', exact: true })
+      ).toBeVisible({
+        timeout: 15000,
+      });
+      await expect(
+        page.getByText(/authenticate to preserve your works/i)
+      ).toBeVisible();
+    } finally {
+      await context.close();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- isolate the direct guest archive/profile E2E checks with the existing guest-session IP helper
- let reveal poem footer controls wrap on mobile after the Save image action
- fixes master CI E2E Mirror failures from linejam-947

## Root Cause
- `tests/e2e/guest-archive-access.spec.ts` used Playwright's shared `page`, so CI could saturate the per-IP guest-session throttle before `/me/poems` loaded; `/api/guest/session` returned 429 and the `Archive` heading never rendered.
- PR #308 added a fixed-width `Save image` button to the mobile reveal footer. At 390px the row overflowed horizontally, hiding `Favorite this poem`; Playwright waited until the test timeout and teardown surfaced `Failed to close guest flow session`.

## Verification
- Reproduced line-44 `/me/poems` failure locally by saturating `/api/guest/session` until 429, then rerunning the direct archive test.
- After fix: saturated `/me/poems` direct check passed.
- After fix: `reveal-share.spec.ts` passed in 28.2s after previously timing out at 120s.
- `pnpm build:check`
- `pnpm exec playwright test tests/e2e/guest-archive-access.spec.ts tests/e2e/reveal-share.spec.ts --grep-invert "@slow" --project=chromium --workers=1 --retries=0 --reporter=line` (3 passed)
- `pnpm ci:prepush` (122 test files, 1263 passed, 1 skipped)

Agent: codex-gpt-5.5
Agent-Surface: Codex CLI
Agent-Model: openai/gpt-5.5
Agent-Task: linejam-947
