### PR TITLE
fix(e2e): isolate remaining guest session contexts

### DIFF
--- a/tests/e2e/agentic-qa.spec.ts
+++ b/tests/e2e/agentic-qa.spec.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { expect, test, type Browser, type Page } from '@playwright/test';
 import { ensureClerkAuthState, hasClerkBrowserAuth } from './support/clerk';
+import { isolateGuestSessionIp } from './support/guestFlow';
 import { createAgenticManifest } from '@/qa/agentic/manifest.mjs';
 
 const RUN_DIR = process.env.LINEJAM_AGENTIC_RUN_DIR;
@@ -9,6 +10,7 @@ const RESULT_FILE = process.env.LINEJAM_AGENTIC_RESULT_FILE;
 
 async function openPage(browser: Browser) {
   const context = await browser.newContext();
+  await isolateGuestSessionIp(context);
   const page = await context.newPage();
   return { context, page };
 }

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, BrowserContext, Page } from '@playwright/test';
+import { isolateGuestSessionIp } from './support/guestFlow';
 
 /**
  * E2E Test: Authentication Flow
@@ -22,6 +23,10 @@ test.skip(
   missingGuestTokenSecret,
   'Set GUEST_TOKEN_SECRET for local E2E, or E2E_BASE_URL for a remote target'
 );
+
+test.beforeEach(async ({ context }) => {
+  await isolateGuestSessionIp(context);
+});
 
 test.describe('Guest Session API', () => {
   test('returns guestId and token on first request', async ({ page }) => {
@@ -69,6 +74,7 @@ test.describe('Guest Session Persistence', () => {
 
   test.beforeAll(async ({ browser }) => {
     context = await browser.newContext();
+    await isolateGuestSessionIp(context);
     page = await context.newPage();
   });
 
@@ -150,6 +156,7 @@ test.describe('Isolated Guest Sessions', () => {
   }) => {
     // Create first context and trigger guest session
     const context1 = await browser.newContext();
+    await isolateGuestSessionIp(context1);
     const page1 = await context1.newPage();
     await page1.goto('/', { waitUntil: 'networkidle' });
 
@@ -169,6 +176,7 @@ test.describe('Isolated Guest Sessions', () => {
 
     // Create second context and trigger guest session
     const context2 = await browser.newContext();
+    await isolateGuestSessionIp(context2);
     const page2 = await context2.newPage();
     await page2.goto('/', { waitUntil: 'networkidle' });
 

--- a/tests/e2e/errors.spec.ts
+++ b/tests/e2e/errors.spec.ts
@@ -27,6 +27,10 @@ test.skip(
   'Set GUEST_TOKEN_SECRET for local E2E, or E2E_BASE_URL for a remote target'
 );
 
+test.beforeEach(async ({ context }) => {
+  await isolateGuestSessionIp(context);
+});
+
 test.describe('Join Room Error Handling', () => {
   test('shows error for invalid room code', async ({ page }) => {
     // Navigate to join page with invalid code

--- a/tests/e2e/favorites.spec.ts
+++ b/tests/e2e/favorites.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { ensureClerkAuthState, requireClerkBrowserAuth } from './support/clerk';
+import { isolateGuestSessionIp } from './support/guestFlow';
 
 /**
  * E2E Test: Favorites Flow
@@ -16,8 +17,9 @@ import { ensureClerkAuthState, requireClerkBrowserAuth } from './support/clerk';
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Personal Archive Page', () => {
-  test.beforeEach(async ({ page }, testInfo) => {
+  test.beforeEach(async ({ context, page }, testInfo) => {
     requireClerkBrowserAuth(testInfo, 'archive E2E');
+    await isolateGuestSessionIp(context);
     await ensureClerkAuthState(page);
   });
 
@@ -84,8 +86,9 @@ test.describe('Personal Archive Page', () => {
 });
 
 test.describe('Favorites Feature Structure', () => {
-  test.beforeEach(async ({ page }, testInfo) => {
+  test.beforeEach(async ({ context, page }, testInfo) => {
     requireClerkBrowserAuth(testInfo, 'archive E2E');
+    await isolateGuestSessionIp(context);
     await ensureClerkAuthState(page);
   });
 


### PR DESCRIPTION
## Summary
- applies the existing `isolateGuestSessionIp()` helper to older E2E specs that still used default Playwright contexts
- covers `errors`, `auth`, `favorites`, and agentic QA helper contexts
- keeps spoofed forwarding headers scoped to `/api/guest/session*` only

## Why
PR #315 fixed the original guest archive + reveal-share failures, but the immediate master run `28957655998` still failed E2E Mirror in `tests/e2e/errors.spec.ts` after the same remote guest-session throttle window was saturated. The failing page never rendered `/join` inputs because its default context minted guest sessions from the shared CI server IP.

## Verification
- `pnpm exec playwright test tests/e2e/auth.spec.ts tests/e2e/errors.spec.ts tests/e2e/favorites.spec.ts tests/e2e/agentic-qa.spec.ts --project=chromium --workers=2 --retries=0 --reporter=line` (21 passed)
- `pnpm ci:prepush` (122 test files, 1263 passed, 1 skipped)

Agent: codex-gpt-5.5
Agent-Surface: Codex CLI
Agent-Model: openai/gpt-5.5
Agent-Task: linejam-947
