### PR TITLE
chore(release): pin landmark@v0 and release with the workflow token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,13 @@ jobs:
           persist-credentials: false
 
       - name: Run Landmark
-        # Pinned to the v1 tag's commit — this action holds GH_RELEASE_TOKEN
+        # Pinned to the v0 tag's commit — this action holds github.token
         # (repo write: pushes the release commit + tags), so a floating tag is
         # not acceptable here. Bump deliberately when upgrading Landmark.
-        uses: misty-step/landmark@b461fe11b6f609b1a09fd44ef947e8c4c1f234db # v1
+        uses: misty-step/landmark@80ce543041f4ef66b866446cd4b8172638cf0407 # v0
         with:
           mode: full
           node-version: 22
           healthcheck: 'true'
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
Part of the fleet 0.x reset (Powder landmark-017). Landmark v0 line = pre-stable mode.

`GH_RELEASE_TOKEN` is expired and being retired; this workflow now releases with `${{ github.token }}` instead.

## Changes
- `.github/workflows/release.yml`: repin from the `v1` commit (`b461fe1`) to the `v0` commit (`80ce543`) — this repo pins Landmark by commit SHA rather than a floating tag since the action holds repo-write credentials, so the pin itself had to move, not just a tag label
- `.github/workflows/release.yml`: `github-token` now uses `${{ github.token }}` instead of `secrets.GH_RELEASE_TOKEN`
- `.github/workflows/release.yml`: updated the pin-rationale comment to reference `v0` / `github.token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)