### PR TITLE
chore(release): advance landmark SHA pin to v0.28.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         # Pinned to the v0 tag's commit — this action holds github.token
         # (repo write: pushes the release commit + tags), so a floating tag is
         # not acceptable here. Bump deliberately when upgrading Landmark.
-        uses: misty-step/landmark@80ce543041f4ef66b866446cd4b8172638cf0407 # v0
+        uses: misty-step/landmark@35d002b7a2bc80efc6d0f412b5adbc3f6a96eeab # v0.28.1
         with:
           mode: full
           node-version: 22


### PR DESCRIPTION
Advances the SHA pin from 80ce543 (whose tree bootstraps binaries from the retired v1.28.0 release) to v0.28.1's commit — the first self-consistent 0.x landmark release. Part of Powder landmark-017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)