### PR TITLE
fix(ci): declare the Pages release runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "canary:webhook:setup": "./scripts/canary/setup-webhook.sh",
     "evidence:guest-flow": "node scripts/evidence/guest-flow.mjs",
     "evidence:static-server": "node scripts/evidence/static-server.mjs",
-    "generate:releases": "npx tsx scripts/generate-releases.ts",
+    "generate:releases": "tsx scripts/generate-releases.ts",
     "agent:cli": "npx tsx scripts/cli/linejam-cli.ts",
     "agent:mcp": "npx tsx scripts/mcp/linejam-mcp.ts"
   },
@@ -102,6 +102,7 @@
     "promptfoo": "0.121.17",
     "semantic-release": "^25.0.5",
     "tailwindcss": "^4",
+    "tsx": "4.22.4",
     "typescript": "^5",
     "vite": "7.3.5",
     "vitest": "^4.1.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.3.1
+      tsx:
+        specifier: 4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5
         version: 5.9.3

--- a/tests/ci/pages-workflow.test.ts
+++ b/tests/ci/pages-workflow.test.ts
@@ -2,6 +2,10 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const workflow = readFileSync('.github/workflows/pages.yml', 'utf8');
+const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as {
+  scripts: Record<string, string>;
+  devDependencies: Record<string, string>;
+};
 
 describe('Pages workflow', () => {
   it('installs pnpm before setup-node asks for the pnpm cache', () => {
@@ -20,5 +24,12 @@ describe('Pages workflow', () => {
       "github.event.workflow_run.conclusion == 'success'"
     );
     expect(workflow).toContain('workflow_dispatch:');
+  });
+
+  it('declares the TypeScript runner used by release generation', () => {
+    expect(packageJson.devDependencies.tsx).toBeDefined();
+    expect(packageJson.scripts['generate:releases']).toBe(
+      'tsx scripts/generate-releases.ts'
+    );
   });
 });


### PR DESCRIPTION
## Why

The live Pages run after #323 proved the pnpm ordering fix, then reached the next latent failure: `pnpm generate:releases` invoked `npx tsx`, but `tsx` was not a declared direct dependency (`sh: 1: tsx: not found`).

## Change

- declare exact `tsx@4.22.4` as a dev dependency
- invoke the repo-local binary through pnpm script PATH
- ratchet the Pages workflow contract test so release generation cannot silently depend on a transitive binary

## Proof

- red first: workflow test failed because `devDependencies.tsx` was absent
- `env -u OPENROUTER_API_KEY pnpm generate:releases --dry-run` succeeds and parses 22 releases
- `pnpm ci:prepush`: 128 files, 1286 passed, 1 skipped
- fresh critic: SHIP, no blockers; lockfile adds only a direct importer reference to the already-present `tsx@4.22.4`

After merge, the acceptance oracle is a green live Pages run on `master`.

Powder: linejam-948

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release-generation command to run directly with `tsx`.
  * Added `tsx` as a development dependency so the command works without an extra wrapper.

* **Tests**
  * Expanded coverage to verify the release-generation command and its required dependency are configured correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->