### PR TITLE
fix(auth): fail open to guest play

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -53,6 +53,7 @@ export function useUser(
   useEffect(() => {
     if ((!isClerkLoaded && !clerkLoadTimedOut) || typeof window === 'undefined')
       return;
+    if (isLoaded && !clerkUser) return;
     let isStale = false;
 
     // Signed-in users don't need guest-session setup to proceed.
@@ -119,6 +120,7 @@ export function useUser(
     isClerkLoaded,
     clerkLoadTimedOut,
     clerkUser,
+    isLoaded,
     fetcher,
     retryCount,
     isConvexAuthLoading,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -7,8 +7,17 @@ import {
   defaultGuestSessionFetcher,
 } from '@/lib/guestSession';
 
+const CLERK_GUEST_FALLBACK_MS = 5_000;
+const CLERK_LOAD_TIMEOUT_MESSAGE =
+  'Clerk did not load in time; continuing with guest play';
+
 /**
  * Hook for managing user identity (Clerk or guest).
+ *
+ * Guest play is the runtime, so an unavailable Clerk frontend must not hold
+ * anonymous users on a loading screen forever. If Clerk does not settle within
+ * the bounded bootstrap window, the hook reports the outage and continues with
+ * the existing guest-session path. A late Clerk session still takes precedence.
  *
  * @param fetcher - Injectable fetcher for guest session (default: API fetch).
  *                  Tests can inject a mock to avoid network calls.
@@ -26,9 +35,24 @@ export function useUser(
   const [isLoaded, setIsLoaded] = useState(false);
   const [authError, setAuthError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
+  const [clerkLoadTimedOut, setClerkLoadTimedOut] = useState(false);
 
   useEffect(() => {
-    if (!isClerkLoaded || typeof window === 'undefined') return;
+    if (isClerkLoaded || typeof window === 'undefined') return;
+
+    const timeout = window.setTimeout(() => {
+      const error = new Error(CLERK_LOAD_TIMEOUT_MESSAGE);
+      error.name = 'ClerkLoadTimeoutError';
+      captureError(error, { operation: 'clerkLoadTimeout' });
+      setClerkLoadTimedOut(true);
+    }, CLERK_GUEST_FALLBACK_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [isClerkLoaded]);
+
+  useEffect(() => {
+    if ((!isClerkLoaded && !clerkLoadTimedOut) || typeof window === 'undefined')
+      return;
     let isStale = false;
 
     // Signed-in users don't need guest-session setup to proceed.
@@ -93,6 +117,7 @@ export function useUser(
     };
   }, [
     isClerkLoaded,
+    clerkLoadTimedOut,
     clerkUser,
     fetcher,
     retryCount,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:watch": "vitest --watch",
     "test:e2e": "playwright test --grep-invert \"@evidence|@slow\"",
     "test:e2e:early-smoke": "playwright test tests/e2e/early-smoke.spec.ts --project=chromium --workers=1 --retries=0 --reporter=line",
+    "test:e2e:clerk-outage": "playwright test tests/e2e/clerk-outage.spec.ts --project=chromium --workers=1 --retries=0 --reporter=line",
     "test:e2e:smoke": "playwright test --config=playwright.smoke.config.ts",
     "test:e2e:evidence": "playwright test tests/e2e/guest-flow.evidence.spec.ts --project=chromium --workers=1 --retries=0 --reporter=line",
     "test:e2e:leaver": "playwright test mid-game-leaver --project=chromium --workers=1 --retries=0 --reporter=line",

--- a/tests/e2e/clerk-outage.spec.ts
+++ b/tests/e2e/clerk-outage.spec.ts
@@ -16,6 +16,7 @@ test.describe('Clerk frontend outage', () => {
     await isolateGuestSessionIp(context);
     const alerts: CanaryErrorPayload[] = [];
 
+    await context.route('**/npm/@clerk/**', (route) => route.abort('failed'));
     await context.route('https://clerk.linejam.app/**', (route) =>
       route.abort('failed')
     );

--- a/tests/e2e/clerk-outage.spec.ts
+++ b/tests/e2e/clerk-outage.spec.ts
@@ -15,11 +15,15 @@ test.describe('Clerk frontend outage', () => {
     const context = await browser.newContext();
     await isolateGuestSessionIp(context);
     const alerts: CanaryErrorPayload[] = [];
+    const abortedClerkScriptRequests: string[] = [];
 
-    await context.route('**/npm/@clerk/**', (route) => route.abort('failed'));
-    await context.route('https://clerk.linejam.app/**', (route) =>
-      route.abort('failed')
-    );
+    // Match Clerk's runtime script path rather than a configured hostname so
+    // the same doctor covers custom-domain production keys and
+    // <slug>.clerk.accounts.dev development keys.
+    await context.route('**/npm/@clerk/**', (route) => {
+      abortedClerkScriptRequests.push(route.request().url());
+      return route.abort('failed');
+    });
     await context.route('**/api/v1/errors', async (route) => {
       const body = route.request().postData();
       if (body) alerts.push(JSON.parse(body) as CanaryErrorPayload);
@@ -33,6 +37,7 @@ test.describe('Clerk frontend outage', () => {
       await expect(page.getByTestId(E2E_TEST_IDS.hostNameInput)).toBeVisible({
         timeout: 8_000,
       });
+      expect(abortedClerkScriptRequests.length).toBeGreaterThan(0);
 
       await expect
         .poll(

--- a/tests/e2e/clerk-outage.spec.ts
+++ b/tests/e2e/clerk-outage.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
+import { isolateGuestSessionIp } from './support/guestFlow';
+
+type CanaryErrorPayload = {
+  error_class?: string;
+  message?: string;
+  context?: { operation?: string };
+};
+
+test.describe('Clerk frontend outage', () => {
+  test('guest Host and Join fail open and report the bounded fallback', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    await isolateGuestSessionIp(context);
+    const alerts: CanaryErrorPayload[] = [];
+
+    await context.route('https://clerk.linejam.app/**', (route) =>
+      route.abort('failed')
+    );
+    await context.route('**/api/v1/errors', async (route) => {
+      const body = route.request().postData();
+      if (body) alerts.push(JSON.parse(body) as CanaryErrorPayload);
+      await route.fulfill({ status: 202, body: '' });
+    });
+
+    const page = await context.newPage();
+
+    try {
+      await page.goto('/host');
+      await expect(page.getByTestId(E2E_TEST_IDS.hostNameInput)).toBeVisible({
+        timeout: 8_000,
+      });
+
+      await expect
+        .poll(
+          () =>
+            alerts.some(
+              (payload) =>
+                payload.error_class === 'ClerkLoadTimeoutError' &&
+                payload.message ===
+                  'Clerk did not load in time; continuing with guest play' &&
+                payload.context?.operation === 'clerkLoadTimeout'
+            ),
+          { timeout: 8_000 }
+        )
+        .toBe(true);
+
+      await page.goto('/join');
+      await expect(
+        page.getByTestId(E2E_TEST_IDS.joinRoomCodeInput)
+      ).toBeVisible({ timeout: 8_000 });
+      await expect(page.getByTestId(E2E_TEST_IDS.joinNameInput)).toBeVisible();
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/tests/lib/auth.test.ts
+++ b/tests/lib/auth.test.ts
@@ -174,6 +174,40 @@ describe('useUser hook', () => {
     expect(fetcher.fetch).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps the guest session when Clerk loads late without a user', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockUseClerkUser.mockReturnValue({
+      user: null,
+      isLoaded: false,
+    });
+    const fetcher = {
+      fetch: vi.fn().mockResolvedValue({
+        guestId: 'guest-stable',
+        token: 'token-stable',
+      }),
+    };
+    const { result, rerender } = renderHook(() => useUser(fetcher));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    await waitFor(() => {
+      expect(result.current.guestId).toBe('guest-stable');
+    });
+
+    mockUseClerkUser.mockReturnValue({ user: null, isLoaded: true });
+    rerender();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+    expect(result.current.guestId).toBe('guest-stable');
+    expect(result.current.guestToken).toBe('token-stable');
+    expect(result.current.isLoading).toBe(false);
+  });
+
   it('returns Clerk user when authenticated, does not fetch guest session', async () => {
     // Arrange
     const clerkUser = {

--- a/tests/lib/auth.test.ts
+++ b/tests/lib/auth.test.ts
@@ -129,6 +129,51 @@ describe('useUser hook', () => {
     );
   });
 
+  it('gives a late authenticated Clerk session precedence over guest fallback', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockUseClerkUser.mockReturnValue({
+      user: null,
+      isLoaded: false,
+    });
+    const fetcher = {
+      fetch: vi.fn().mockResolvedValue({
+        guestId: 'guest-before-clerk',
+        token: 'token-before-clerk',
+      }),
+    };
+    const { result, rerender } = renderHook(() => useUser(fetcher));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    await waitFor(() => {
+      expect(result.current.guestId).toBe('guest-before-clerk');
+    });
+
+    const clerkUser = {
+      id: 'clerk_late',
+      fullName: 'Late Clerk User',
+      firstName: 'Late',
+    };
+    mockUseClerkUser.mockReturnValue({ user: clerkUser, isLoaded: true });
+    mockUseConvexAuth.mockReturnValue({
+      isLoading: false,
+      isAuthenticated: true,
+    });
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+
+    expect(result.current.clerkUser).toEqual(clerkUser);
+    expect(result.current.guestId).toBeNull();
+    expect(result.current.guestToken).toBeNull();
+    expect(result.current.displayName).toBe('Late Clerk User');
+    expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it('returns Clerk user when authenticated, does not fetch guest session', async () => {
     // Arrange
     const clerkUser = {

--- a/tests/lib/auth.test.ts
+++ b/tests/lib/auth.test.ts
@@ -63,6 +63,7 @@ describe('useUser hook', () => {
     // Restore original fetch
     global.fetch = originalFetch;
     localStorage.clear();
+    vi.useRealTimers();
   });
 
   it('returns loading state while Clerk is loading', () => {
@@ -80,6 +81,52 @@ describe('useUser hook', () => {
     expect(result.current.clerkUser).toBeNull();
     expect(result.current.guestId).toBeNull();
     expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('falls back to a guest session when Clerk never finishes loading', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockUseClerkUser.mockReturnValue({
+      user: null,
+      isLoaded: false,
+    });
+    const fetcher = {
+      fetch: vi.fn().mockResolvedValue({
+        guestId: 'guest-clerk-outage',
+        token: 'token-clerk-outage',
+      }),
+    };
+
+    const { result } = renderHook(() => useUser(fetcher));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(fetcher.fetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_999);
+    });
+
+    expect(fetcher.fetch).not.toHaveBeenCalled();
+    expect(mockCaptureError).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+    expect(result.current.guestId).toBe('guest-clerk-outage');
+    expect(result.current.guestToken).toBe('token-clerk-outage');
+    expect(result.current.authError).toBeNull();
+    expect(mockCaptureError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'ClerkLoadTimeoutError',
+        message: 'Clerk did not load in time; continuing with guest play',
+      }),
+      { operation: 'clerkLoadTimeout' }
+    );
   });
 
   it('returns Clerk user when authenticated, does not fetch guest session', async () => {


### PR DESCRIPTION
Powder: linejam-950

Guest play is the runtime, but `useUser()` waited forever for Clerk `isLoaded`. When Clerk custom-domain DNS or clerk-js failed, `/host` and `/join` never fetched a guest session and remained on the setup spinner.

Change:
- after a bounded 5-second Clerk bootstrap window, report `ClerkLoadTimeoutError` to Canary and continue through the existing guest-session path
- preserve late Clerk precedence and all existing signed-in/guest behavior
- add a reusable Playwright production-path doctor that aborts `clerk.linejam.app`, asserts Host/Join fail open, and validates the alert payload

Evidence:
- red unit: the new timeout regression stayed loading forever before implementation
- red live production: `E2E_BASE_URL=https://www.linejam.app pnpm test:e2e:clerk-outage` failed after 8s because `host-name-input` never appeared
- green unit: `tests/lib/auth.test.ts` 14/14
- gate: `pnpm ci:prepush` passed (1,287 passed, 1 skipped; four pre-existing site lint warnings only)

Post-merge acceptance still required: deployed Clerk-fault browser proof, normal Host/Join proof, deployed Canary alert readback, and two consecutive Production Smoke runs. DNS, Convex, and secrets are unchanged.

Agent: codex-worker
Agent-Surface: Codex CLI
Agent-Model: openai/gpt-5.4
Agent-Task: linejam-950