### PR TITLE
fix: bound abandonment sweep + gate health on Convex env capabilities (prod incident 2026-07-09)

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,5 +1,6 @@
 import { ConvexHttpClient } from 'convex/browser';
 import { api } from '@/convex/_generated/api';
+import type { ConvexEnvHealthReport } from '@/convex/lib/env';
 import {
   captureCanaryException,
   isCanaryEnabled,
@@ -14,17 +15,19 @@ export async function GET() {
   const startedAt = Date.now();
 
   try {
-    const convexStatus = await checkConvex();
+    const { status: convexStatus, report: convexEnv } = await checkConvex();
     const envChecks = checkEnvVars();
     const serviceHealthy =
       envChecks.guestTokenSecret &&
       envChecks.convexUrl &&
-      convexStatus === 'connected';
+      convexStatus === 'connected' &&
+      convexEnv?.ok === true;
     const canaryReady = envChecks.canaryIngestKey;
     const status = serviceHealthy ? 200 : 503;
     const body = {
       status: serviceHealthy ? 'ok' : 'unhealthy',
       convex: convexStatus,
+      convexEnv: convexEnv?.capabilities ?? null,
       env: {
         nodeEnv: process.env.NODE_ENV ?? 'development',
         ...envChecks,
@@ -80,22 +83,29 @@ function checkEnvVars() {
   };
 }
 
+type ConvexHealth = {
+  status: 'connected' | 'unreachable' | 'skipped';
+  report: ConvexEnvHealthReport | null;
+};
+
 /**
- * Ping Convex without allowing network errors to explode the health endpoint.
- * Treat network errors as "unreachable" so the route can return an explicit
- * unhealthy signal instead of a 500 crash.
+ * One query proves Convex is reachable AND returns the deployment's env
+ * capability report (convex/health.ts `capabilities`), so a prod deployment
+ * missing a required env var (the 2026-07-09 incident: OPENROUTER_API_KEY
+ * absent for days while every monitor stayed green) fails this route instead
+ * of degrading silently. Network errors are "unreachable", never a 500 crash.
  */
-async function checkConvex() {
+async function checkConvex(): Promise<ConvexHealth> {
   const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
-  if (!convexUrl) return 'skipped';
+  if (!convexUrl) return { status: 'skipped', report: null };
 
   const startedAt = Date.now();
 
   try {
     const client = new ConvexHttpClient(convexUrl);
-    await Promise.race([
-      client.query(api.health.ping),
-      new Promise((_, reject) => {
+    const report = (await Promise.race([
+      client.query(api.health.capabilities),
+      new Promise<never>((_, reject) => {
         setTimeout(() => {
           reject(
             new Error(
@@ -104,8 +114,8 @@ async function checkConvex() {
           );
         }, CONVEX_HEALTH_TIMEOUT_MS);
       }),
-    ]);
-    return 'connected';
+    ])) as ConvexEnvHealthReport;
+    return { status: 'connected', report };
   } catch (error) {
     log.warn('Convex health ping failed; marking unreachable', {
       method: 'GET',
@@ -115,7 +125,7 @@ async function checkConvex() {
       errorName: error instanceof Error ? error.name : 'UnknownError',
       errorMessage: error instanceof Error ? error.message : String(error),
     });
-    return 'unreachable';
+    return { status: 'unreachable', report: null };
   }
 }
 

--- a/convex/abandonment.ts
+++ b/convex/abandonment.ts
@@ -111,20 +111,40 @@ function anyHumanPresent(
 }
 
 /**
+ * Hard bounds for one sweep tick. Convex rejects a mutation that schedules
+ * more than 1,000 functions — an unbounded sweep over a large stranded
+ * backlog throws, rolls back every finisher it scheduled, and completes
+ * nothing, forever (the 2026-07-09 incident). Capping the tick keeps each
+ * run small and lets the every-minute cron drain any backlog at
+ * MAX_FINISHERS_PER_SWEEP games per minute. The scan bound keeps read volume
+ * flat; index order is oldest-idle-first, so the queue drains front to back
+ * and completed games leave the index.
+ */
+const MAX_FINISHERS_PER_SWEEP = 200;
+const MAX_SWEEP_SCAN = 1000;
+
+/**
  * Cron entry point. Cheap and self-bounding: an indexed range scan reads only
  * games whose round has been idle past ABANDONMENT_THRESHOLD_MS. Still-active
  * games (recent roundStartedAt) are excluded by the index — not scanned then
  * discarded — so the work scales with the number of *stuck* games (≈0 in a
- * healthy system), never with total traffic. Every idle game is examined each
- * tick, so an idle-but-not-abandoned game (a present player whose round hasn't
- * advanced, a degenerate no-human game) can never pin the scan or starve an
- * abandoned room behind it. Heavy completion work is scheduled out per game. (If
- * the idle set itself ever grew huge, a cursor-paged scan would be the next step
- * — far beyond any realistic scale for this game.)
+ * healthy system), never with total traffic. An idle-but-not-abandoned game
+ * (a present player whose round hasn't advanced) consumes scan but never a
+ * finisher slot, so it cannot pin the batch cap either. Heavy completion work
+ * is scheduled out per game, at most MAX_FINISHERS_PER_SWEEP per tick.
+ *
+ * `limit` narrows the per-tick finisher cap (test seam); it can never raise
+ * it above MAX_FINISHERS_PER_SWEEP.
  */
 export const sweepAbandonedGames = internalMutation({
-  args: {},
-  handler: async (ctx) => {
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, { limit }) => {
+    const maxFinishers = Math.max(
+      1,
+      Math.min(limit ?? MAX_FINISHERS_PER_SWEEP, MAX_FINISHERS_PER_SWEEP)
+    );
+    let scheduled = 0;
+    let scanned = 0;
     try {
       const now = Date.now();
       const idleCutoff = now - ABANDONMENT_THRESHOLD_MS;
@@ -133,10 +153,15 @@ export const sweepAbandonedGames = internalMutation({
         .withIndex('by_status_round', (q) =>
           q.eq('status', 'IN_PROGRESS').lte('roundStartedAt', idleCutoff)
         )
-        .collect();
+        .take(MAX_SWEEP_SCAN);
+      scanned = idleGames.length;
 
-      let scheduled = 0;
+      let truncated = false;
       for (const game of idleGames) {
+        if (scheduled >= maxFinishers) {
+          truncated = true;
+          break;
+        }
         if (!(await isGameAbandoned(ctx, game, now))) continue;
         await ctx.scheduler.runAfter(
           0,
@@ -149,14 +174,20 @@ export const sweepAbandonedGames = internalMutation({
       if (scheduled > 0) {
         log.warn('Abandonment sweep scheduled stranded games for completion', {
           scheduled,
-          scanned: idleGames.length,
+          scanned,
+          truncated,
         });
       }
 
-      return { scheduled, scanned: idleGames.length };
+      return { scheduled, scanned };
     } catch (error) {
+      // Report without rethrowing: a mutation that throws rolls back
+      // everything it did — the finishers scheduled above AND this Canary
+      // report. Swallowing keeps the partial batch (finishers are idempotent
+      // and re-derived) and lets the error actually reach Canary; the cron
+      // retries the remainder next minute regardless.
       const err = error instanceof Error ? error : new Error(String(error));
-      logError('sweepAbandonedGames failed', err, {});
+      logError('sweepAbandonedGames failed', err, { scheduled, scanned });
       await ctx.scheduler.runAfter(
         0,
         internal.errors.reportBackendErrorToCanary,
@@ -167,7 +198,7 @@ export const sweepAbandonedGames = internalMutation({
           operation: 'sweepAbandonedGames',
         }
       );
-      throw error;
+      return { scheduled, scanned, error: err.message };
     }
   },
 });
@@ -285,6 +316,10 @@ export const finishAbandonedGame = internalMutation({
       }
       return { completed, filled };
     } catch (error) {
+      // Report without rethrowing — a throw would roll back this Canary
+      // report along with the lines committed above. Keeping partial fills is
+      // safe (commitFallbackLine is idempotent) and the next sweep tick
+      // re-derives state and resumes.
       const err = error instanceof Error ? error : new Error(String(error));
       logError('finishAbandonedGame failed', err, { gameId });
       await ctx.scheduler.runAfter(
@@ -298,7 +333,7 @@ export const finishAbandonedGame = internalMutation({
           gameId,
         }
       );
-      throw error;
+      return { completed: false, filled: 0, error: err.message };
     }
   },
 });

--- a/convex/health.ts
+++ b/convex/health.ts
@@ -1,8 +1,15 @@
 import { query } from './_generated/server';
+import { getConvexEnvHealthReport } from './lib/env';
 
-export const ping = query({
+/**
+ * One round trip for app-side health: resolving this query proves the
+ * deployment is reachable, and the payload reports whether every required
+ * capability (guest token verification, AI line generation) has its env
+ * configured. app/api/health/route.ts folds `ok` into its own verdict, so a
+ * prod deployment missing a required env var turns the public health route —
+ * and the scheduled Production Health Monitor — red instead of staying green.
+ */
+export const capabilities = query({
   args: {},
-  handler: async () => {
-    return 'pong';
-  },
+  handler: async () => getConvexEnvHealthReport(),
 });

--- a/convex/lib/env.ts
+++ b/convex/lib/env.ts
@@ -15,7 +15,7 @@ export type ConvexRuntimeConfig = {
   openRouterApiKey?: string;
 };
 
-type ConvexEnvHealthReport = {
+export type ConvexEnvHealthReport = {
   ok: boolean;
   status: 200 | 500;
   environment: ConvexEnvironment;

--- a/tests/app/api/health.test.ts
+++ b/tests/app/api/health.test.ts
@@ -135,6 +135,43 @@ describe('/api/health', () => {
       expect(mockQuery).toHaveBeenCalled();
     });
 
+    it('returns 503 when Convex is reachable but a required capability is unconfigured', async () => {
+      // Regression: 2026-07-09 incident. Prod Convex was missing
+      // OPENROUTER_API_KEY for days while this route stayed green because it
+      // only proved connectivity. The capabilities report must gate health.
+      mockQuery.mockResolvedValue({
+        ok: false,
+        status: 500,
+        environment: 'production',
+        capabilities: {
+          guestTokenVerification: {
+            status: 'ready',
+            available: true,
+            required: true,
+          },
+          aiLineGeneration: {
+            status: 'missing_required',
+            available: false,
+            required: true,
+          },
+        },
+      });
+      const consoleLogSpy = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => {});
+
+      const response = await GET();
+      const data = await response.json();
+      consoleLogSpy.mockRestore();
+
+      expect(response.status).toBe(503);
+      expect(data.status).toBe('unhealthy');
+      expect(data.convex).toBe('connected');
+      expect(data.convexEnv).toMatchObject({
+        aiLineGeneration: { status: 'missing_required' },
+      });
+    });
+
     it('returns unhealthy when Convex ping fails', async () => {
       mockQuery.mockRejectedValue(new Error('Connection refused'));
       const consoleLogSpy = vi

--- a/tests/convex/abandonment.test.ts
+++ b/tests/convex/abandonment.test.ts
@@ -403,6 +403,45 @@ describe('abandonment cron (child 3 / oracle 5b)', () => {
     expect(sweep).toEqual({ scheduled: 3, scanned: 3 });
   });
 
+  it('caps finishers per tick and drains the backlog across ticks', async () => {
+    // Regression: 2026-07-09 incident. With ≥1000 abandoned games, an
+    // unbounded sweep exceeded Convex's 1000-scheduled-functions limit,
+    // threw, rolled back every finisher, and completed nothing forever. The
+    // cap bounds each tick; the every-minute cron drains the rest.
+    const t = setupConvexTest();
+    const seeded: Id<'games'>[] = [];
+    for (let i = 0; i < 3; i++) {
+      const { gameId } = await seedClassicGame(t, {
+        players: [
+          { name: `Ada${i}`, lastSeenAt: staleStamp() },
+          { name: `Bo${i}`, lastSeenAt: staleStamp() },
+        ],
+        roundStartedAt: staleStamp() - i * 1_000,
+        createdAt: staleStamp() - i * 1_000,
+      });
+      seeded.push(gameId);
+    }
+
+    const first = await t.mutation(internal.abandonment.sweepAbandonedGames, {
+      limit: 2,
+    });
+    expect(first).toEqual({ scheduled: 2, scanned: 3 });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // The two finished games leave the idle index; the next tick reaches the
+    // remaining one — a capped tick can only delay completion, never lose it.
+    const second = await t.mutation(internal.abandonment.sweepAbandonedGames, {
+      limit: 2,
+    });
+    expect(second).toEqual({ scheduled: 1, scanned: 1 });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    for (const gameId of seeded) {
+      const game = await t.run((ctx) => ctx.db.get(gameId));
+      expect(game?.status).toBe('COMPLETED');
+    }
+  });
+
   it('excludes still-active games from the scan so they cannot starve abandoned ones', async () => {
     const t = setupConvexTest();
     // Several fresh, actively-advancing games (recent roundStartedAt) plus one


### PR DESCRIPTION
## Incident

Prod on 2026-07-09: the Convex production deployment was missing `OPENROUTER_API_KEY` and `CANARY_API_KEY` (module-load stamp says since at least 2026-07-07 18:19 UTC). Effects:

1. **Entire AI surface silently degraded** — every AI-player/ghostwriter line came from the canned fallback wordlist instead of Gemini. Verified live (room IXSL: "whisper", "hollow deepens", "brittle lichen listens" — all from `fallbacks.ts`).
2. **`abandonment:sweepAbandonedGames` failed every minute** — ≥1000 stranded games meant the unbounded sweep exceeded Convex's 1000-scheduled-functions-per-mutation limit, threw, and the rollback erased every finisher it had scheduled. Zero games completed per tick, forever.
3. **Nobody was paged** — backend Canary reporting needs the missing `CANARY_API_KEY`, *and* both mutations scheduled their error report then rethrew (a throwing mutation rolls back its scheduled functions, so the report could never fire even with the key). Meanwhile `/api/health` only proved Convex connectivity, so the 5-minute health monitor stayed green while the deployment's own env-health endpoint (`amiable-bulldog-848.convex.site/api/health`) returned 500 with nobody polling it.

Env keys were restored out-of-band (mitigation, verified: env-health 200, live `AI response received` from `google/gemini-2.5-flash-lite`). This PR fixes the two code root causes.

## Changes

- **`convex/abandonment.ts`** — cap finishers scheduled per sweep tick (`MAX_FINISHERS_PER_SWEEP = 200`, drained by the every-minute cron) and bound scan reads (`take(1000)`, oldest-first so the queue drains front-to-back). Stop rethrowing after scheduling the Canary error report in both `sweepAbandonedGames` and `finishAbandonedGame` — everything is idempotent and the cron retries; rethrowing only destroyed partial progress and the report itself.
- **`convex/health.ts`** — replace `ping` (single consumer) with `capabilities`: one round trip proves reachability and returns the required-capability env report.
- **`app/api/health/route.ts`** — return 503 when a required Convex capability is unconfigured, so the Production Health Monitor pages on missing prod env instead of staying green.

## Verification

- `pnpm ci:prepush` green: 1288 tests passed.
- New regression tests: capped sweep drains a backlog across ticks to COMPLETED; `/api/health` returns 503 on `missing_required` capability.
- Post-merge: watch prod logs for `Abandonment sweep scheduled stranded games for completion` counts draining the ≥1000-game backlog at ≤200/min to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)