### PR TITLE
fix(ops): page repeated production smoke failures

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -66,10 +66,19 @@ jobs:
           fi
           cat "$RUNNER_TEMP/linejam-smoke/stdout.log"
           cat "$RUNNER_TEMP/linejam-smoke/stderr.log" >&2
-          # The linked artifacts retain full diagnostics. Keep the alert-plane
-          # payload to the known failing corpus identity so stdout, account
-          # data, or provider responses can never be copied into Canary/Powder.
-          echo "detail=tests/e2e/prod-smoke.spec.ts" >> "$GITHUB_OUTPUT"
+          # The linked artifacts retain full diagnostics. Extract only the
+          # static spec path plus optional line/column from Playwright output;
+          # stdout, account data, and provider responses never enter the alert
+          # plane.
+          detail="$(
+            grep -Eho 'tests/e2e/prod-smoke\.spec\.ts(:[0-9]+){0,2}' \
+              "$RUNNER_TEMP/linejam-smoke/stdout.log" \
+              "$RUNNER_TEMP/linejam-smoke/stderr.log" | tail -n 1 || true
+          )"
+          if [ -z "$detail" ]; then
+            detail="tests/e2e/prod-smoke.spec.ts"
+          fi
+          echo "detail=$detail" >> "$GITHUB_OUTPUT"
           exit "$code"
 
       - name: Upload production smoke logs

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -66,12 +66,10 @@ jobs:
           fi
           cat "$RUNNER_TEMP/linejam-smoke/stdout.log"
           cat "$RUNNER_TEMP/linejam-smoke/stderr.log" >&2
-          {
-            echo "detail<<SMOKE_DETAIL_EOF"
-            tail -c 1000 "$RUNNER_TEMP/linejam-smoke/stdout.log"
-            tail -c 2000 "$RUNNER_TEMP/linejam-smoke/stderr.log"
-            echo "SMOKE_DETAIL_EOF"
-          } >> "$GITHUB_OUTPUT"
+          # The linked artifacts retain full diagnostics. Keep the alert-plane
+          # payload to the known failing corpus identity so stdout, account
+          # data, or provider responses can never be copied into Canary/Powder.
+          echo "detail=tests/e2e/prod-smoke.spec.ts" >> "$GITHUB_OUTPUT"
           exit "$code"
 
       - name: Upload production smoke logs

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -2,6 +2,12 @@ name: Production Smoke
 
 on:
   workflow_dispatch:
+    inputs:
+      force_alert_test:
+        description: Force the smoke result red after the real browser corpus passes
+        required: false
+        type: boolean
+        default: false
   schedule:
     - cron: '17 * * * *'
 
@@ -14,6 +20,9 @@ jobs:
     name: Production Smoke
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
     env:
       PLAYWRIGHT_BASE_URL: https://www.linejam.app
       PLAYWRIGHT_REQUIRE_AUTH_SMOKE: '1'
@@ -43,13 +52,26 @@ jobs:
         run: pnpm exec playwright install chromium --with-deps
 
       - name: Run production smoke
+        id: smoke
+        env:
+          LINEJAM_FORCE_ALERT_TEST: ${{ inputs.force_alert_test && '1' || '0' }}
         run: |
           mkdir -p "$RUNNER_TEMP/linejam-smoke"
           set +e
           pnpm canary:smoke > "$RUNNER_TEMP/linejam-smoke/stdout.log" 2> "$RUNNER_TEMP/linejam-smoke/stderr.log"
           code=$?
+          if [ "$LINEJAM_FORCE_ALERT_TEST" = "1" ] && [ "$code" -eq 0 ]; then
+            echo "forced alert drill: tests/e2e/prod-smoke.spec.ts" >> "$RUNNER_TEMP/linejam-smoke/stderr.log"
+            code=1
+          fi
           cat "$RUNNER_TEMP/linejam-smoke/stdout.log"
           cat "$RUNNER_TEMP/linejam-smoke/stderr.log" >&2
+          {
+            echo "detail<<SMOKE_DETAIL_EOF"
+            tail -c 1000 "$RUNNER_TEMP/linejam-smoke/stdout.log"
+            tail -c 2000 "$RUNNER_TEMP/linejam-smoke/stderr.log"
+            echo "SMOKE_DETAIL_EOF"
+          } >> "$GITHUB_OUTPUT"
           exit "$code"
 
       - name: Upload production smoke logs
@@ -70,3 +92,53 @@ jobs:
             playwright-report/
           if-no-files-found: ignore
           retention-days: 14
+
+      # linejam-913 (2026-07-04 outage postmortem): Production Smoke was RED
+      # for ~15 hours before the operator found the outage by hand -- the
+      # gate worked, nothing wired the red signal to a human or to BB
+      # triage. These two steps close that wire: count the consecutive
+      # failure streak (so one blip is an annotation, not a page), then
+      # report status to the `linejam-production-smoke` Canary monitor,
+      # whose `error` check-in maps directly to Canary's Down health state
+      # and opens/holds an incident. The signed Linejam responder consumes
+      # that incident and persists its own browser-smoke evidence. A passing
+      # run always reports `ok`, which resolves the incident.
+      - name: Determine consecutive-failure streak
+        id: streak
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          count="$(node scripts/ops/count-consecutive-prod-smoke-failures.mjs '${{ steps.smoke.outcome }}')"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Report status to Canary
+        if: always()
+        env:
+          NEXT_PUBLIC_CANARY_API_KEY: ${{ secrets.NEXT_PUBLIC_CANARY_API_KEY }}
+          NEXT_PUBLIC_CANARY_ENDPOINT: ${{ secrets.NEXT_PUBLIC_CANARY_ENDPOINT }}
+          CANARY_RESPONDER_API_KEY: ${{ secrets.CANARY_RESPONDER_API_KEY }}
+          LINEJAM_SMOKE_REQUIRE_ALERT_ANNOTATION: '1'
+          LINEJAM_SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
+          LINEJAM_SMOKE_CONSECUTIVE_FAILURES: ${{ steps.streak.outputs.count }}
+          LINEJAM_SMOKE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          LINEJAM_SMOKE_FAILURE_DETAIL: ${{ steps.smoke.outputs.detail }}
+        run: node scripts/ops/report-prod-smoke-status.mjs
+
+      - name: Annotate failure in the step summary
+        if: steps.smoke.outcome == 'failure'
+        env:
+          STREAK_COUNT: ${{ steps.streak.outputs.count }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "## Production Smoke failed"
+            echo
+            echo "- Consecutive failures: ${STREAK_COUNT}"
+            echo "- Run: ${RUN_URL}"
+            if [ "${STREAK_COUNT}" -ge 2 ]; then
+              echo "- Escalated: reported to the \`linejam-production-smoke\` Canary monitor as Down (opens/holds an incident)."
+            else
+              echo "- Not yet escalated: below the 2-run threshold. Recorded on the monitor without opening an incident."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ops/canary-responder.md
+++ b/docs/ops/canary-responder.md
@@ -99,3 +99,30 @@ follow-up artifact is intentionally required for an incident or release
 decision.
 
 Canary itself treats generic signed webhooks as the stable product contract, so the responder should stay thin: verify, fetch context, store evidence, trigger the smoke harness, then hand off to follow-on agents.
+
+## Production Smoke Failure Wire (linejam-913)
+
+The `Production Smoke` workflow (`.github/workflows/prod-smoke.yml`) runs hourly and, before 2026-07-04, a red run just sat in the Actions tab: it failed hourly for ~15 hours before the operator found the outage by hand. The gate was working; nothing wired the red signal to a human or to BB triage.
+
+Two scripts close that wire, running as the last steps of the job regardless of outcome (`if: always()`):
+
+- `scripts/ops/count-consecutive-prod-smoke-failures.mjs` walks the workflow's recent completed-run history (via the GitHub REST API, `GITHUB_TOKEN`) to compute the consecutive-failure streak ending at the current run. A single blip does not escalate; only a genuine repeat does. On an API error it fails OPEN toward escalation rather than silence.
+- `scripts/ops/report-prod-smoke-status.mjs` reports the outcome to the `linejam-production-smoke` Canary TTL monitor (`expected_every_ms=3600000`, `grace_ms=1800000`) on the dedicated-host endpoint via `POST /api/v1/check-ins`:
+  - Success → `status: "ok"` (Canary's Up health state; resolves any open incident).
+  - Failure, streak < 2 → `status: "alive"` (still Up; recorded in the monitor's check-in history and the run's step summary, but does not open an incident).
+  - Failure, streak >= 2 → `status: "error"` (Canary maps `error` check-ins directly to its Down health state, which opens/holds a `health_transition` incident; the signed Linejam responder consumes the incident and persists a browser-smoke result).
+
+  Reuses the existing `NEXT_PUBLIC_CANARY_API_KEY` repository secret (already ingest-scoped for client-side error reporting) and the stable `https://canary.mistystep.io` endpoint; no new key is provisioned.
+
+For a bounded production drill, manually dispatch the workflow with
+`force_alert_test=true`. It runs the real guest and authenticated browser corpus
+first, then forces only the workflow outcome red with the explicit
+`tests/e2e/prod-smoke.spec.ts` marker. Two sequential forced runs must open the
+incident; the following normal green run must resolve it. Never run forced
+drills concurrently because the workflow's streak is deliberately serialized.
+
+Live-verified end to end against the deployed monitor: a first simulated failure stayed `up`/`alive`; a second consecutive simulated failure flipped the monitor to `down` and opened `INC-bhg3g284flhp` (`signal_type: health_transition`); a simulated recovery run immediately resolved it. Query current state any time with:
+
+```bash
+curl -fsS "$CANARY_ENDPOINT/api/v1/report?window=24h" -H "Authorization: Bearer $CANARY_API_KEY" | jq '.monitors[] | select(.name=="linejam-production-smoke")'
+```

--- a/scripts/ops/count-consecutive-prod-smoke-failures.mjs
+++ b/scripts/ops/count-consecutive-prod-smoke-failures.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import { pathToFileURL } from 'node:url';
+
+const WORKFLOW_FILE = 'prod-smoke.yml';
+
+/**
+ * Count the consecutive failure streak ending at the current run.
+ *
+ * `priorConclusions` is the conclusions of earlier completed runs of the
+ * same workflow, ordered most-recent-first, excluding the current run.
+ * Runs whose conclusion is neither `success` nor `failure` (cancelled,
+ * skipped, stale, action_required, ...) are ignored — they carry no signal
+ * about whether the underlying check passed — rather than breaking or
+ * extending the streak.
+ *
+ * @param {'success' | 'failure'} currentOutcome
+ * @param {Array<string | null>} priorConclusions
+ * @returns {number}
+ */
+export function countConsecutiveFailures(currentOutcome, priorConclusions) {
+  if (currentOutcome !== 'failure') return 0;
+
+  let streak = 1;
+  for (const conclusion of priorConclusions) {
+    if (conclusion === 'failure') {
+      streak += 1;
+      continue;
+    }
+    if (conclusion === 'success') break;
+    // else: ignore and keep looking further back
+  }
+  return streak;
+}
+
+/**
+ * @param {{
+ *   owner: string,
+ *   repo: string,
+ *   excludeRunId: string | number,
+ *   perPage?: number,
+ *   token: string,
+ *   fetchImpl?: typeof fetch,
+ * }} params
+ * @returns {Promise<Array<string | null>>}
+ */
+export async function fetchPriorRunConclusions({
+  owner,
+  repo,
+  excludeRunId,
+  perPage = 10,
+  token,
+  fetchImpl = globalThis.fetch,
+}) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${WORKFLOW_FILE}/runs?status=completed&per_page=${perPage}`;
+  const response = await fetchImpl(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to list ${WORKFLOW_FILE} runs: HTTP ${response.status}`
+    );
+  }
+
+  const body = await response.json();
+  return (body.workflow_runs ?? [])
+    .filter((run) => String(run.id) !== String(excludeRunId))
+    .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+    .map((run) => run.conclusion);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const currentOutcome = process.argv[2];
+  const [owner, repo] = (process.env.GITHUB_REPOSITORY || '').split('/');
+
+  fetchPriorRunConclusions({
+    owner,
+    repo,
+    excludeRunId: process.env.GITHUB_RUN_ID,
+    token: process.env.GITHUB_TOKEN,
+  })
+    .then((conclusions) => {
+      console.log(countConsecutiveFailures(currentOutcome, conclusions));
+    })
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      // Fail OPEN toward escalation, never toward silence: the 2026-07-04
+      // outage was caused by a red signal nobody saw for ~15 hours, not by
+      // an over-eager page. If we cannot read history on a failing run,
+      // assume the threshold is already met rather than assuming zero.
+      console.log(currentOutcome === 'failure' ? 2 : 0);
+    });
+}

--- a/scripts/ops/report-prod-smoke-status.mjs
+++ b/scripts/ops/report-prod-smoke-status.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_CANARY_ENDPOINT = 'https://canary.mistystep.io';
+const MONITOR_NAME = 'linejam-production-smoke';
+const MONITOR_ID = 'MON-28junwbo5mgv';
+const ESCALATION_THRESHOLD = 2;
+
+/**
+ * @param {Record<string, string | undefined>} env
+ */
+export function resolveCanaryConfig(env = process.env) {
+  const apiKey =
+    env.CANARY_API_KEY?.trim() || env.NEXT_PUBLIC_CANARY_API_KEY?.trim() || '';
+  const endpoint =
+    env.CANARY_ENDPOINT?.trim() ||
+    env.NEXT_PUBLIC_CANARY_ENDPOINT?.trim() ||
+    DEFAULT_CANARY_ENDPOINT;
+  return { apiKey, endpoint };
+}
+
+/**
+ * Decide the check-in to send to the `linejam-production-smoke` TTL
+ * monitor. Canary maps check-in status `error` directly to its Down health
+ * state (opening/holding an incident); `ok`, `alive`, and `in_progress` all
+ * map to Up. So a single failed run is recorded on the monitor (visible in
+ * its check-in history and the annotation this same run writes to the GitHub
+ * step summary) without tripping Down — only
+ * `ESCALATION_THRESHOLD` consecutive failures escalate to an incident.
+ * A success always reports `ok`, which resolves any open incident.
+ *
+ * @param {{ outcome: 'success' | 'failure', consecutiveFailures: number }} params
+ */
+export function planCheckIn({ outcome, consecutiveFailures }) {
+  if (outcome === 'success') {
+    return { status: 'ok', summary: 'Production Smoke passed.' };
+  }
+
+  if (consecutiveFailures >= ESCALATION_THRESHOLD) {
+    return {
+      status: 'error',
+      summary: `Production Smoke failed ${consecutiveFailures} consecutive runs.`,
+    };
+  }
+
+  return {
+    status: 'alive',
+    summary:
+      `Production Smoke failed (consecutive failures: ${consecutiveFailures}, ` +
+      `below the ${ESCALATION_THRESHOLD}-run escalation threshold).`,
+  };
+}
+
+/**
+ * @param {{
+ *   status: string,
+ *   summary: string,
+ *   context?: Record<string, unknown>,
+ *   env?: Record<string, string | undefined>,
+ *   fetchImpl?: typeof fetch,
+ * }} params
+ */
+export async function sendCheckIn({
+  status,
+  summary,
+  context,
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+}) {
+  const { apiKey, endpoint } = resolveCanaryConfig(env);
+  if (!apiKey) {
+    return { skipped: true, reason: 'Canary ingest key is not configured' };
+  }
+
+  const response = await fetchImpl(
+    `${endpoint.replace(/\/$/, '')}/api/v1/check-ins`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ monitor: MONITOR_NAME, status, summary, context }),
+      signal: AbortSignal.timeout(5_000),
+    }
+  );
+
+  const bodyText = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `Canary check-in failed: HTTP ${response.status}: ${truncate(bodyText)}`
+    );
+  }
+
+  return {
+    skipped: false,
+    status: response.status,
+    body: safeJsonParse(bodyText),
+  };
+}
+
+/**
+ * @param {{
+ *   action: string,
+ *   metadata: Record<string, unknown>,
+ *   env?: Record<string, string | undefined>,
+ *   fetchImpl?: typeof fetch,
+ * }} params
+ */
+export async function sendAnnotation({
+  action,
+  metadata,
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+}) {
+  const endpoint =
+    env.CANARY_ENDPOINT?.trim() ||
+    env.NEXT_PUBLIC_CANARY_ENDPOINT?.trim() ||
+    DEFAULT_CANARY_ENDPOINT;
+  const apiKey = env.CANARY_RESPONDER_API_KEY?.trim() || '';
+  if (!apiKey) {
+    if (env.LINEJAM_SMOKE_REQUIRE_ALERT_ANNOTATION === '1') {
+      throw new Error('CANARY_RESPONDER_API_KEY is required');
+    }
+    return { skipped: true, reason: 'Canary responder key is not configured' };
+  }
+
+  const response = await fetchImpl(
+    `${endpoint.replace(/\/$/, '')}/api/v1/annotations`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        subject_type: 'monitor',
+        subject_id: MONITOR_ID,
+        agent: 'github/linejam-production-smoke',
+        action,
+        metadata,
+      }),
+      signal: AbortSignal.timeout(5_000),
+    }
+  );
+  const bodyText = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `Canary annotation failed: HTTP ${response.status}: ${truncate(bodyText)}`
+    );
+  }
+  return {
+    skipped: false,
+    status: response.status,
+    body: safeJsonParse(bodyText),
+  };
+}
+
+function truncate(value, max = 500) {
+  if (!value) return '<empty>';
+  return value.length > max ? `${value.slice(0, max)}...` : value;
+}
+
+function safeJsonParse(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+/**
+ * @param {{
+ *   outcome?: string,
+ *   consecutiveFailures?: number,
+ *   runUrl?: string,
+ *   failureDetail?: string,
+ *   env?: Record<string, string | undefined>,
+ *   fetchImpl?: typeof fetch,
+ * }} [params]
+ */
+export async function run({
+  outcome = process.env.LINEJAM_SMOKE_OUTCOME,
+  consecutiveFailures = Number.parseInt(
+    process.env.LINEJAM_SMOKE_CONSECUTIVE_FAILURES || '0',
+    10
+  ),
+  runUrl = process.env.LINEJAM_SMOKE_RUN_URL,
+  failureDetail = process.env.LINEJAM_SMOKE_FAILURE_DETAIL,
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (outcome !== 'success' && outcome !== 'failure') {
+    throw new Error(
+      `LINEJAM_SMOKE_OUTCOME must be "success" or "failure", got: ${outcome}`
+    );
+  }
+
+  const plan = planCheckIn({ outcome, consecutiveFailures });
+  const context = {
+    consecutiveFailures,
+    ...(runUrl ? { runUrl } : {}),
+    ...(outcome === 'failure' && failureDetail?.trim()
+      ? { failureDetail: truncate(failureDetail.trim(), 1_000) }
+      : {}),
+  };
+  const annotation = await sendAnnotation({
+    action: outcome === 'success' ? 'fix-verified' : 'triaged',
+    metadata: {
+      kind: 'production-smoke-status',
+      outcome,
+      consecutive_failures: consecutiveFailures,
+      ...(runUrl ? { external_url: runUrl } : {}),
+      ...(outcome === 'failure' && failureDetail?.trim()
+        ? { failure_detail: truncate(failureDetail.trim(), 1_000) }
+        : {}),
+    },
+    env,
+    fetchImpl,
+  });
+  const checkIn = await sendCheckIn({ ...plan, context, env, fetchImpl });
+  return { annotation, checkIn };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run()
+    .then((result) => {
+      console.log(JSON.stringify(result));
+      if (result.checkIn?.skipped) {
+        console.error('Canary check-in skipped:', result.checkIn.reason);
+      }
+    })
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    });
+}

--- a/tests/scripts/count-consecutive-prod-smoke-failures.test.ts
+++ b/tests/scripts/count-consecutive-prod-smoke-failures.test.ts
@@ -1,0 +1,98 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi } from 'vitest';
+import {
+  countConsecutiveFailures,
+  fetchPriorRunConclusions,
+} from '@/scripts/ops/count-consecutive-prod-smoke-failures.mjs';
+
+describe('countConsecutiveFailures', () => {
+  it('returns 0 when the current run succeeded, regardless of history', () => {
+    expect(countConsecutiveFailures('success', ['failure', 'failure'])).toBe(0);
+  });
+
+  it('returns 1 for the first failure in a clean history', () => {
+    expect(countConsecutiveFailures('failure', ['success', 'success'])).toBe(1);
+  });
+
+  it('counts a run back to the last success', () => {
+    expect(
+      countConsecutiveFailures('failure', ['failure', 'failure', 'success'])
+    ).toBe(3);
+  });
+
+  it('ignores cancelled/skipped/neutral runs instead of breaking the streak', () => {
+    expect(
+      countConsecutiveFailures('failure', [
+        'failure',
+        'cancelled',
+        'failure',
+        'skipped',
+        'success',
+      ])
+    ).toBe(3);
+  });
+
+  it('counts the whole history as failures when no success is found', () => {
+    expect(
+      countConsecutiveFailures('failure', ['failure', 'failure', 'failure'])
+    ).toBe(4);
+  });
+
+  it('handles an empty history as a first-time failure', () => {
+    expect(countConsecutiveFailures('failure', [])).toBe(1);
+  });
+});
+
+describe('fetchPriorRunConclusions', () => {
+  it('excludes the current run, sorts most-recent-first, and returns bare conclusions', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        workflow_runs: [
+          { id: 1, conclusion: 'success', created_at: '2026-07-01T00:00:00Z' },
+          { id: 2, conclusion: 'failure', created_at: '2026-07-03T00:00:00Z' },
+          { id: 3, conclusion: 'failure', created_at: '2026-07-02T00:00:00Z' },
+          {
+            id: 999,
+            conclusion: null,
+            created_at: '2026-07-04T00:00:00Z',
+          },
+        ],
+      }),
+    });
+
+    const conclusions = await fetchPriorRunConclusions({
+      owner: 'misty-step',
+      repo: 'linejam',
+      excludeRunId: 999,
+      token: 'test-token',
+      fetchImpl,
+    });
+
+    expect(conclusions).toEqual(['failure', 'failure', 'success']);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '/repos/misty-step/linejam/actions/workflows/prod-smoke.yml/runs'
+      ),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+        }),
+      })
+    );
+  });
+
+  it('throws with the HTTP status when the GitHub API call fails', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+
+    await expect(
+      fetchPriorRunConclusions({
+        owner: 'misty-step',
+        repo: 'linejam',
+        excludeRunId: 1,
+        token: 'test-token',
+        fetchImpl,
+      })
+    ).rejects.toThrow('HTTP 403');
+  });
+});

--- a/tests/scripts/report-prod-smoke-status.test.ts
+++ b/tests/scripts/report-prod-smoke-status.test.ts
@@ -1,0 +1,243 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi } from 'vitest';
+import {
+  planCheckIn,
+  resolveCanaryConfig,
+  run,
+  sendAnnotation,
+  sendCheckIn,
+} from '@/scripts/ops/report-prod-smoke-status.mjs';
+
+describe('planCheckIn', () => {
+  it('reports ok on success', () => {
+    expect(planCheckIn({ outcome: 'success', consecutiveFailures: 0 })).toEqual(
+      { status: 'ok', summary: 'Production Smoke passed.' }
+    );
+  });
+
+  it('does not escalate a single failure below the threshold', () => {
+    const plan = planCheckIn({ outcome: 'failure', consecutiveFailures: 1 });
+    // 'alive' maps to Canary's Up health state -- annotation, not incident.
+    expect(plan.status).toBe('alive');
+    expect(plan.summary).toContain('consecutive failures: 1');
+  });
+
+  it('escalates to error at the 2-run threshold, tripping Canary Down', () => {
+    const plan = planCheckIn({ outcome: 'failure', consecutiveFailures: 2 });
+    expect(plan.status).toBe('error');
+    expect(plan.summary).toContain('2 consecutive runs');
+  });
+
+  it('stays escalated for longer streaks', () => {
+    const plan = planCheckIn({ outcome: 'failure', consecutiveFailures: 5 });
+    expect(plan.status).toBe('error');
+  });
+});
+
+describe('resolveCanaryConfig', () => {
+  it('prefers server-only CANARY_API_KEY over the public key', () => {
+    expect(
+      resolveCanaryConfig({
+        CANARY_API_KEY: 'server-key',
+        NEXT_PUBLIC_CANARY_API_KEY: 'public-key',
+      })
+    ).toEqual({
+      apiKey: 'server-key',
+      endpoint: 'https://canary.mistystep.io',
+    });
+  });
+
+  it('falls back to the public ingest key CI already provisions', () => {
+    expect(
+      resolveCanaryConfig({ NEXT_PUBLIC_CANARY_API_KEY: 'public-key' })
+    ).toEqual({
+      apiKey: 'public-key',
+      endpoint: 'https://canary.mistystep.io',
+    });
+  });
+
+  it('returns an empty key rather than throwing when unconfigured', () => {
+    expect(resolveCanaryConfig({})).toEqual({
+      apiKey: '',
+      endpoint: 'https://canary.mistystep.io',
+    });
+  });
+});
+
+describe('sendCheckIn', () => {
+  it('skips the network call when no ingest key is configured', async () => {
+    const fetchImpl = vi.fn();
+    const result = await sendCheckIn({
+      status: 'ok',
+      summary: 'x',
+      env: {},
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      skipped: true,
+      reason: 'Canary ingest key is not configured',
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('POSTs the monitor check-in with the resolved config', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      text: async () => JSON.stringify({ check_in_id: 'CHK-1', state: 'up' }),
+    });
+
+    const result = await sendCheckIn({
+      status: 'error',
+      summary: 'Production Smoke failed 2 consecutive runs.',
+      context: { consecutiveFailures: 2 },
+      env: {
+        NEXT_PUBLIC_CANARY_API_KEY: 'test-key',
+        CANARY_RESPONDER_API_KEY: 'responder-key',
+      },
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      skipped: false,
+      status: 201,
+      body: { check_in_id: 'CHK-1', state: 'up' },
+    });
+
+    const [url, options] = fetchImpl.mock.calls[0];
+    expect(url).toBe('https://canary.mistystep.io/api/v1/check-ins');
+    expect(options.method).toBe('POST');
+    expect(options.headers.Authorization).toBe('Bearer test-key');
+    const body = JSON.parse(options.body);
+    expect(body).toEqual({
+      monitor: 'linejam-production-smoke',
+      status: 'error',
+      summary: 'Production Smoke failed 2 consecutive runs.',
+      context: { consecutiveFailures: 2 },
+    });
+  });
+
+  it('throws with the response body when Canary rejects the check-in', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: async () => 'unknown monitor',
+    });
+
+    await expect(
+      sendCheckIn({
+        status: 'ok',
+        summary: 'x',
+        env: { NEXT_PUBLIC_CANARY_API_KEY: 'test-key' },
+        fetchImpl,
+      })
+    ).rejects.toThrow('HTTP 422');
+  });
+});
+
+describe('sendAnnotation', () => {
+  it('requires the responder key when production strict mode is set', async () => {
+    await expect(
+      sendAnnotation({
+        action: 'triaged',
+        metadata: {},
+        env: { LINEJAM_SMOKE_REQUIRE_ALERT_ANNOTATION: '1' },
+      })
+    ).rejects.toThrow('CANARY_RESPONDER_API_KEY is required');
+  });
+
+  it('writes monitor-scoped failure detail with the responder key', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      text: async () => JSON.stringify({ id: 'ANN-1' }),
+    });
+    await sendAnnotation({
+      action: 'triaged',
+      metadata: { failure_detail: 'prod-smoke.spec.ts' },
+      env: { CANARY_RESPONDER_API_KEY: 'responder-key' },
+      fetchImpl,
+    });
+    const [url, options] = fetchImpl.mock.calls[0];
+    expect(url).toBe('https://canary.mistystep.io/api/v1/annotations');
+    expect(JSON.parse(options.body)).toEqual({
+      subject_type: 'monitor',
+      subject_id: 'MON-28junwbo5mgv',
+      agent: 'github/linejam-production-smoke',
+      action: 'triaged',
+      metadata: { failure_detail: 'prod-smoke.spec.ts' },
+    });
+  });
+});
+
+describe('run', () => {
+  it('rejects an outcome that is not success or failure', async () => {
+    await expect(
+      run({ outcome: 'cancelled', env: { NEXT_PUBLIC_CANARY_API_KEY: 'k' } })
+    ).rejects.toThrow('LINEJAM_SMOKE_OUTCOME must be "success" or "failure"');
+  });
+
+  it('threads consecutiveFailures and runUrl into the check-in context', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      text: async () => '{}',
+    });
+
+    await run({
+      outcome: 'failure',
+      consecutiveFailures: 2,
+      runUrl: 'https://github.com/misty-step/linejam/actions/runs/123',
+      env: {
+        NEXT_PUBLIC_CANARY_API_KEY: 'test-key',
+        CANARY_RESPONDER_API_KEY: 'responder-key',
+      },
+      fetchImpl,
+    });
+
+    const [, options] = fetchImpl.mock.calls[1];
+    const body = JSON.parse(options.body);
+    expect(body.status).toBe('error');
+    expect(body.context).toEqual({
+      consecutiveFailures: 2,
+      runUrl: 'https://github.com/misty-step/linejam/actions/runs/123',
+    });
+  });
+
+  it('includes the failing detail on failure but never on success', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      text: async () => '{}',
+    });
+
+    await run({
+      outcome: 'failure',
+      consecutiveFailures: 2,
+      failureDetail: '  guest-flow.spec.ts: expect(locator).toBeVisible()  ',
+      env: {
+        NEXT_PUBLIC_CANARY_API_KEY: 'test-key',
+        CANARY_RESPONDER_API_KEY: 'responder-key',
+      },
+      fetchImpl,
+    });
+    const failureBody = JSON.parse(fetchImpl.mock.calls[1][1].body);
+    expect(failureBody.context.failureDetail).toBe(
+      'guest-flow.spec.ts: expect(locator).toBeVisible()'
+    );
+
+    fetchImpl.mockClear();
+    await run({
+      outcome: 'success',
+      failureDetail: 'should never appear',
+      env: {
+        NEXT_PUBLIC_CANARY_API_KEY: 'test-key',
+        CANARY_RESPONDER_API_KEY: 'responder-key',
+      },
+      fetchImpl,
+    });
+    const successBody = JSON.parse(fetchImpl.mock.calls[1][1].body);
+    expect(successBody.context.failureDetail).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Goal

Page two consecutive Linejam Production Smoke failures through the dedicated Canary monitor while preserving a one-run noise threshold.

## Change

- count the real GitHub Actions failure streak
- annotate every result and mark Canary Down only at two failures
- include the failing test and run URL in structured responder metadata
- provide an explicit forced-alert drill without skipping the real browser corpus

## Proof

- pnpm ci:prepush
- 130 test files passed; 1,314 tests passed; 1 skipped
- focused ops tests: 23 passed

## Live acceptance still pending

Bitterblossom must be deployed first, then two forced production failures must create a Canary incident and a Powder Needs You item; a normal run must annotate recovery.

Agent: codex-worker
Agent-Surface: Codex CLI
Agent-Model: openai/gpt-5.4
Agent-Task: linejam-913