### PR TITLE
fix(ops): classify production Convex rate limits

### DIFF
--- a/app/api/guest/session/route.ts
+++ b/app/api/guest/session/route.ts
@@ -267,26 +267,30 @@ function getClientIp(request: NextRequest): string {
 }
 
 function isRateLimitError(error: unknown) {
-  if (!error) return false;
-  const message =
-    error instanceof Error
-      ? error.message
-      : typeof error === 'string'
-        ? error
-        : String(error);
-  return /rate limit exceeded/i.test(message);
+  return /rate limit exceeded/i.test(extractErrorMessage(error));
 }
 
 function isMissingThrottleFunctionError(error: unknown) {
-  const message =
-    error instanceof Error
-      ? error.message
-      : typeof error === 'string'
-        ? error
-        : String(error);
   return /Could not find public function for 'guestSessions:checkGuestSessionThrottle'/i.test(
-    message
+    extractErrorMessage(error)
   );
+}
+
+function extractErrorMessage(error: unknown) {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'name' in error &&
+    (error as { name: unknown }).name === 'ConvexError' &&
+    'data' in error &&
+    typeof (error as { data: unknown }).data === 'string'
+  ) {
+    return (error as { data: string }).data;
+  }
+
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return String(error);
 }
 
 function allowUnsyncedConvexThrottle() {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,8 +3,10 @@ import { useConvexAuth } from 'convex/react';
 import { useCallback, useEffect, useState } from 'react';
 import { captureError } from '@/lib/error';
 import {
+  GUEST_SESSION_RATE_LIMIT_MESSAGE,
   GuestSessionFetcher,
   defaultGuestSessionFetcher,
+  isGuestSessionRateLimitError,
 } from '@/lib/guestSession';
 
 const CLERK_GUEST_FALLBACK_MS = 5_000;
@@ -107,10 +109,14 @@ export function useUser(
       })
       .catch((error) => {
         if (isStale) return;
-        captureError(error, { operation: 'fetchGuestSession' });
         setGuestId(null);
         setGuestToken(null);
-        setAuthError('Unable to connect. Please check your connection.');
+        if (isGuestSessionRateLimitError(error)) {
+          setAuthError(GUEST_SESSION_RATE_LIMIT_MESSAGE);
+        } else {
+          captureError(error, { operation: 'fetchGuestSession' });
+          setAuthError('Unable to connect. Please check your connection.');
+        }
         setIsLoaded(true);
       });
     return () => {

--- a/lib/canaryCore.ts
+++ b/lib/canaryCore.ts
@@ -61,7 +61,7 @@ export function normalizeError(error: unknown): {
   if (error instanceof Error) {
     return {
       errorClass: error.name || error.constructor.name || 'Error',
-      message: error.message || 'Unknown error',
+      message: extractStructuredErrorMessage(error) || 'Unknown error',
       stackTrace: error.stack,
     };
   }
@@ -77,6 +77,18 @@ export function normalizeError(error: unknown): {
     errorClass: 'UnknownError',
     message: String(error),
   };
+}
+
+function extractStructuredErrorMessage(error: Error): string {
+  if (
+    error.name === 'ConvexError' &&
+    'data' in error &&
+    typeof (error as Error & { data: unknown }).data === 'string'
+  ) {
+    return (error as Error & { data: string }).data;
+  }
+
+  return error.message;
 }
 
 export function scrubCanaryContext(

--- a/lib/guestSession.ts
+++ b/lib/guestSession.ts
@@ -17,6 +17,22 @@ export interface GuestSessionFetcher {
   fetch(): Promise<GuestSessionData>;
 }
 
+export const GUEST_SESSION_RATE_LIMIT_MESSAGE =
+  'Too many guest sessions. Please wait a few minutes before trying again.';
+
+export class GuestSessionHttpError extends Error {
+  constructor(readonly status: number) {
+    super(`Guest session API returned ${status}`);
+    this.name = 'GuestSessionHttpError';
+  }
+}
+
+export function isGuestSessionRateLimitError(
+  error: unknown
+): error is GuestSessionHttpError {
+  return error instanceof GuestSessionHttpError && error.status === 429;
+}
+
 const LEGACY_STORAGE_KEY = 'linejam_guest_token';
 
 const clearLegacyGuestTokenMirror = () => {
@@ -44,7 +60,7 @@ async function fetchGuestSession(url: string): Promise<GuestSessionData> {
 
   const res = await fetch(url);
   if (!res.ok) {
-    throw new Error(`Guest session API returned ${res.status}`);
+    throw new GuestSessionHttpError(res.status);
   }
   const data = await res.json();
   const guestId = typeof data.guestId === 'string' ? data.guestId : null;
@@ -62,6 +78,8 @@ export const defaultGuestSessionFetcher: GuestSessionFetcher = {
     try {
       return await fetchGuestSession('/api/guest/session');
     } catch (error) {
+      if (isGuestSessionRateLimitError(error)) throw error;
+
       throw new Error(
         `Failed to fetch guest session: ${error instanceof Error ? error.message : 'Unknown error'}`
       );

--- a/tests/app/api/guest-session.test.ts
+++ b/tests/app/api/guest-session.test.ts
@@ -10,6 +10,7 @@ import {
   vi,
 } from 'vitest';
 import { NextRequest } from 'next/server';
+import { ConvexError } from 'convex/values';
 
 vi.mock('server-only', () => ({}));
 
@@ -451,12 +452,12 @@ describe('GET /api/guest/session', () => {
   describe('with guest-session throttle', () => {
     let GET: typeof import('@/app/api/guest/session/route').GET;
     let mockMutation: ReturnType<typeof vi.fn>;
+    let mockCaptureServerError: ReturnType<typeof vi.fn>;
     const originalEnv = { ...process.env };
 
     beforeAll(async () => {
       vi.resetModules();
       vi.doUnmock('@/lib/guestToken');
-      vi.doUnmock('@/lib/errorServer');
       process.env = {
         ...originalEnv,
         NEXT_PUBLIC_CONVEX_URL: 'https://test.convex.cloud',
@@ -470,6 +471,10 @@ describe('GET /api/guest/session', () => {
           mutation = mockMutation;
         },
       }));
+      mockCaptureServerError = vi.fn();
+      vi.doMock('@/lib/errorServer', () => ({
+        captureServerError: mockCaptureServerError,
+      }));
 
       const mod = await import('@/app/api/guest/session/route');
       GET = mod.GET;
@@ -477,11 +482,13 @@ describe('GET /api/guest/session', () => {
 
     beforeEach(() => {
       mockMutation.mockClear();
+      mockCaptureServerError.mockClear();
     });
 
     afterAll(() => {
       process.env = originalEnv;
       vi.doUnmock('convex/browser');
+      vi.doUnmock('@/lib/errorServer');
       vi.restoreAllMocks();
     });
 
@@ -511,6 +518,29 @@ describe('GET /api/guest/session', () => {
         '203.0.113.7'
       );
       expect(response.cookies.get('linejam_guest_token')).toBeUndefined();
+    });
+
+    it('returns 429 when production Convex redacts the rate-limit message', async () => {
+      const error = new ConvexError(
+        'Rate limit exceeded. Please try again later.'
+      );
+      error.message = '[Request ID: production-request] Server Error';
+      mockMutation.mockRejectedValueOnce(error);
+
+      const response = await GET(
+        new NextRequest('https://www.linejam.app/api/guest/session', {
+          headers: {
+            'x-forwarded-for': '203.0.113.8',
+          },
+        })
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(429);
+      expect(response.headers.get('Retry-After')).toBe('600');
+      expect(data.error).toBe('Too many guest sessions. Try again later.');
+      expect(response.cookies.get('linejam_guest_token')).toBeUndefined();
+      expect(mockCaptureServerError).not.toHaveBeenCalled();
     });
 
     it.each([

--- a/tests/lib/auth.test.ts
+++ b/tests/lib/auth.test.ts
@@ -331,6 +331,23 @@ describe('useUser hook', () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it('shows expected guest throttling without reporting it to Canary', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 429 });
+
+    const { result } = renderHook(() => useUser());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.authError).toBe(
+      'Too many guest sessions. Please wait a few minutes before trying again.'
+    );
+    expect(mockCaptureError).not.toHaveBeenCalled();
+    expect(result.current.guestId).toBeNull();
+    expect(result.current.guestToken).toBeNull();
+  });
+
   it('removes stale localStorage guest token when guest bootstrap fails', async () => {
     localStorage.setItem('linejam_guest_token', 'stale-token');
     mockFetch.mockRejectedValue(new Error('Network error'));

--- a/tests/lib/canary.test.ts
+++ b/tests/lib/canary.test.ts
@@ -1,5 +1,6 @@
 /** @vitest-environment node */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConvexError } from 'convex/values';
 
 const fetchMock = vi.fn();
 
@@ -84,6 +85,31 @@ describe('canary helpers', () => {
     expect(normalizeError(error)).toMatchObject({
       errorClass: 'Error',
       message: 'Unknown error',
+    });
+  });
+
+  it('uses ConvexError data when production redacts the public message', async () => {
+    const { normalizeError } = await import('@/lib/canaryCore');
+    const error = new ConvexError(
+      'Rate limit exceeded. Please try again later.'
+    );
+    error.message = '[Request ID: production-request] Server Error';
+
+    expect(normalizeError(error)).toMatchObject({
+      errorClass: 'ConvexError',
+      message: 'Rate limit exceeded. Please try again later.',
+    });
+  });
+
+  it('does not treat unrelated Error data as a Canary message', async () => {
+    const { normalizeError } = await import('@/lib/canaryCore');
+    const error = Object.assign(new Error('safe boundary message'), {
+      data: 'vendor response body',
+    });
+
+    expect(normalizeError(error)).toMatchObject({
+      errorClass: 'Error',
+      message: 'safe boundary message',
     });
   });
 

--- a/tests/lib/guestSession.test.ts
+++ b/tests/lib/guestSession.test.ts
@@ -4,6 +4,7 @@ import {
   defaultGuestSessionFetcher,
   getExistingGuestSession,
   clearGuestSession,
+  GuestSessionHttpError,
 } from '@/lib/guestSession';
 
 describe('defaultGuestSessionFetcher', () => {
@@ -46,6 +47,18 @@ describe('defaultGuestSessionFetcher', () => {
     await expect(defaultGuestSessionFetcher.fetch()).rejects.toThrow(
       'Failed to fetch guest session: Guest session API returned 500'
     );
+  });
+
+  it('preserves a status-bearing error for guest-session rate limits', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+    });
+
+    const request = defaultGuestSessionFetcher.fetch();
+
+    await expect(request).rejects.toBeInstanceOf(GuestSessionHttpError);
+    await expect(request).rejects.toMatchObject({ status: 429 });
   });
 
   it('returns null for non-string guestId', async () => {


### PR DESCRIPTION
## Summary
- classify production-redacted Convex rate-limit data as an expected guest-session 429
- suppress expected guest throttles from browser Canary reporting and show a retry message
- normalize Canary ConvexError messages from structured data without widening that boundary to unrelated errors

## Live incident evidence
- Canary incident `INC-gdfqgzyup43d` is active and blocks the Vercel retirement soak
- production Convex logs show `guestSessions:checkGuestSessionThrottle` failures are `ConvexError: Rate limit exceeded`
- DigitalOcean was converting those expected failures into guest-session 500s because only the redacted public message was inspected

## Verification
- `pnpm ci:prepush` — 130 test files passed; 1,319 tests passed; 1 skipped
- focused production-shape tests cover server 429, client suppression/UI, and Canary structured-data safety
- fresh-context critic: PASS

Agent: linejam-closeout
Agent-Surface: Codex CLI
Agent-Model: openai/gpt-5
Agent-Reasoning: high
Agent-Task: linejam-913,linejam-vercel-retirement