### PR TITLE
fix(observability): suppress expected Convex throttles

### DIFF
--- a/convex/lib/rateLimit.ts
+++ b/convex/lib/rateLimit.ts
@@ -1,8 +1,6 @@
 import { MutationCtx } from '../_generated/server';
 import { ConvexError } from 'convex/values';
-
-export const RATE_LIMIT_EXCEEDED_MESSAGE =
-  'Rate limit exceeded. Please try again later.';
+import { RATE_LIMIT_EXCEEDED_MESSAGE } from '../../lib/rateLimit';
 
 export async function checkRateLimit(
   ctx: MutationCtx,

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -4,6 +4,7 @@ import {
   scrubCanaryContext,
 } from '@/lib/canary';
 import { captureReportedError } from '@/lib/errorCore';
+import { isExpectedConvexRateLimitError } from '@/lib/errorFeedback';
 
 /**
  * Capture an error to Canary with optional context.
@@ -18,6 +19,8 @@ export function captureError(
   error: unknown,
   context?: Record<string, unknown>
 ) {
+  if (isExpectedConvexRateLimitError(error)) return;
+
   captureReportedError(
     { captureCanaryException, isCanaryEnabled, scrubCanaryContext },
     error,

--- a/lib/errorFeedback.ts
+++ b/lib/errorFeedback.ts
@@ -1,3 +1,6 @@
+import { ConvexError } from 'convex/values';
+import { RATE_LIMIT_EXCEEDED_MESSAGE } from '@/lib/rateLimit';
+
 /**
  * Error Feedback System — Deep Module for User-Facing Error Communication
  *
@@ -17,6 +20,20 @@ export interface ErrorFeedback {
   message: string;
   /** Visual variant for Alert component */
   variant: 'error' | 'warning' | 'info';
+}
+
+/**
+ * Return true only for an expected Convex rate-limit rejection.
+ *
+ * Convex production clients receive the actionable message in `data` while
+ * `message` is redacted. Requiring a genuine ConvexError instance and the
+ * exact canonical payload prevents generic failures that merely mention rate
+ * limits from being hidden from observability.
+ */
+export function isExpectedConvexRateLimitError(error: unknown): boolean {
+  return (
+    error instanceof ConvexError && error.data === RATE_LIMIT_EXCEEDED_MESSAGE
+  );
 }
 
 /**

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -1,0 +1,2 @@
+export const RATE_LIMIT_EXCEEDED_MESSAGE =
+  'Rate limit exceeded. Please try again later.';

--- a/tests/lib/error.test.ts
+++ b/tests/lib/error.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConvexError } from 'convex/values';
 import { captureError } from '@/lib/error';
 import { captureReportedError } from '@/lib/errorCore';
 
@@ -63,6 +64,75 @@ describe('captureError', () => {
     captureError(new Error('Prod error'));
 
     expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('does not report expected Convex rate-limit rejections', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_CANARY_API_KEY', 'sk_test_canary');
+    vi.stubEnv('NEXT_PUBLIC_CANARY_ENDPOINT', 'https://canary.test/');
+    fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
+    const error = new ConvexError(
+      'Rate limit exceeded. Please try again later.'
+    );
+    error.message = '[Request ID: prod123] Server Error';
+
+    captureError(error, { operation: 'createRoom', route: '/host' });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('still reports unexpected Convex failures', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_CANARY_API_KEY', 'sk_test_canary');
+    vi.stubEnv('NEXT_PUBLIC_CANARY_ENDPOINT', 'https://canary.test/');
+    fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
+    const error = new ConvexError('Unexpected storage failure');
+    error.message = '[Request ID: prod456] Server Error';
+
+    captureError(error, { operation: 'createRoom', route: '/host' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reports noncanonical Convex errors that mention rate limits', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_CANARY_API_KEY', 'sk_test_canary');
+    vi.stubEnv('NEXT_PUBLIC_CANARY_ENDPOINT', 'https://canary.test/');
+    fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
+    const error = new ConvexError('Rate limit subsystem unavailable');
+    error.message = '[Request ID: prod789] Server Error';
+
+    captureError(error, { operation: 'createRoom', route: '/host' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reports objects that only look like Convex errors', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_CANARY_API_KEY', 'sk_test_canary');
+    vi.stubEnv('NEXT_PUBLIC_CANARY_ENDPOINT', 'https://canary.test/');
+    fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
+    const error = {
+      name: 'ConvexError',
+      message: '[Request ID: lookalike] Server Error',
+      data: 'Rate limit exceeded. Please try again later.',
+    };
+
+    captureError(error, { operation: 'createRoom', route: '/host' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reports generic errors that merely mention rate limits', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_CANARY_API_KEY', 'sk_test_canary');
+    vi.stubEnv('NEXT_PUBLIC_CANARY_ENDPOINT', 'https://canary.test/');
+    fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
+
+    captureError(new Error('Rate limit exceeded'));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('logs to console when Canary is disabled', () => {


### PR DESCRIPTION
Closes the remaining Linejam migration observability false positive: the canonical Convex rate-limit rejection remains user-facing but no longer reaches Canary. Unknown Convex failures, look-alike objects, and generic errors remain reportable.

Verification:
- pnpm ci:prepush: 130 files passed, 1324 passed, 1 skipped
- focused regression replay: 36 passed
- prior unrelated flaky test replay: 31 passed
- fresh read-only critic: PASS

Vercel remains retained as rollback; this PR does not start the retirement soak.