### PR TITLE
chore: update Canary integration receipt

### DIFF
--- a/.canary/integration.json
+++ b/.canary/integration.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "service": "linejam",
   "environment": "production",
-  "canary_endpoint": "https://canary-obs.fly.dev",
+  "canary_endpoint": "https://canary.mistystep.io",
   "health_url": "https://www.linejam.app/api/health",
   "target_id": "TGT-l1uqvd03m5tz",
   "monitor_ids": [


### PR DESCRIPTION
## Summary

- point the checked-in Canary production integration receipt at `https://canary.mistystep.io`
- remove the final tracked reference to the retired Canary Fly hostname

## Verification

- `jq empty .canary/integration.json`
- `git diff --check`
- repository-wide `rg --no-ignore --hidden` stale-endpoint oracle: zero matches
- pre-push: lint, typecheck, 1,325 tests passed (1 skipped)

This is configuration metadata only; runtime behavior is unchanged.