### PR TITLE
fix(themes): hydration-safe theme state in the picker hook

### DIFF
--- a/hooks/useThemeRadioNav.ts
+++ b/hooks/useThemeRadioNav.ts
@@ -1,7 +1,9 @@
 'use client';
 
-import { useCallback, useRef } from 'react';
-import { useTheme, visibleThemeIds } from '@/lib/themes';
+import { useCallback, useRef, useSyncExternalStore } from 'react';
+import { useTheme, visibleThemeIds, defaultThemeId } from '@/lib/themes';
+
+const emptySubscribe = () => () => {};
 
 /**
  * Shared roving-radiogroup behavior for theme pickers (/themes page and the
@@ -10,9 +12,21 @@ import { useTheme, visibleThemeIds } from '@/lib/themes';
  * is retired (which renders no card, so nothing else would be tabbable).
  */
 export function useThemeRadioNav(options?: { onEscape?: () => void }) {
-  const { themeId, mode, setTheme } = useTheme();
+  const { themeId: storedThemeId, mode: storedMode, setTheme } = useTheme();
   const listRef = useRef<HTMLDivElement>(null);
   const onEscape = options?.onEscape;
+
+  // Hydration safety: the server renders the default theme in light mode
+  // (localStorage is client-only), so the first client render must match it
+  // exactly or React throws a hydration mismatch (seen live as error #418 on
+  // /themes). Swap to the visitor's saved theme/mode right after mount.
+  const hydrated = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  );
+  const themeId = hydrated ? storedThemeId : defaultThemeId;
+  const mode = hydrated ? storedMode : 'light';
 
   const tabAnchorId = visibleThemeIds.includes(themeId)
     ? themeId


### PR DESCRIPTION
Fix-forward from PR #333's post-deploy live QA: React error #418 (hydration text mismatch) on /themes for visitors with a saved non-default theme or dark mode. The shared picker hook now renders server-matching defaults on the first client render (useSyncExternalStore hydration gate) and swaps to saved values after mount. pnpm ci:prepush green; live prod re-QA follows merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)