### PR TITLE
feat: game-screen spine from design lab-001 (mobile-first, theme-agnostic)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,57 @@
+# Linejam Design Contract
+
+The repo-owned visual contract. Agents doing visual work read this first.
+Provenance: design lab-001 (`explorations/lab-001/`, three operator verdict
+rounds, 2026-07) and its `SYNTHESIS.md`. Tokens live in `lib/themes/`;
+this file owns the spine — the layout system every theme wears.
+
+## Product truth
+
+A party game played by 4-6 friends on phones in the same room, 99% mobile.
+Rounds of 1-2-3-4-5-4-3-2-1 word lines; you see only the previous line; the
+finale is a reading circle where each player reads one whole poem aloud.
+
+## Laws (operator-locked, non-negotiable)
+
+1. Mobile-first at 390x844. Primary action lives in the thumb zone: anchored
+   to the bottom of the viewport on phones, >=44px tall.
+2. Word slots always grow with their word. Clipping a word can never happen.
+3. On reveal/read surfaces the poem line text starts at one consistent
+   horizontal position and vertical rhythm; line numbers and author bylines
+   never shift it.
+4. Button labels are plain verbs ("Done", "Submit", "Start"). Context copy
+   sits near the button, never inside it.
+5. The read view shows the WHOLE poem at once. There is no line-by-line
+   reveal and no phone handoff.
+6. Every visual value comes from theme tokens (`var(--color-*)`, fonts,
+   radius, shadow, durations). Structure is theme-agnostic; ten themes wear
+   one spine. No hardcoded colors or font families in screen components.
+7. WCAG AA floor (enforced by tests/lib/themeContrast.test.ts); honor
+   prefers-reduced-motion; motion only on game moments, never ambient.
+8. `lib/e2eTestIds.ts` is a load-bearing contract: every existing testid and
+   aria pattern survives any reshape (hosted E2E depends on them).
+
+## Spine anatomy (per screen)
+
+- **Home**: brand moment + two stacked CTAs (Start a game primary, Join a
+  room secondary) in the thumb zone.
+- **Host/Join**: one field (+ code field on join), one CTA, zero ceremony.
+- **Lobby**: the party warm-up. Room code is the hero, legible across a
+  table. Players listed with presence, host, and bot marks. Host's start CTA
+  bottom-anchored; non-hosts see who they're waiting for.
+- **Write**: the received line is the only context, displayed large. The
+  word-count constraint renders as growing word chips (the typed words
+  themselves, each chip sized to its word) plus remaining empty slots.
+  Submit bottom-anchored.
+- **Wait**: "line delivered" state; who is still writing, with presence;
+  round progress. Keeps the party's energy, never feels like an error.
+- **Reveal**: the reading circle. One ordered list with per-reader status
+  (read / reading now / up next / to come); your assignment is the hero
+  when it is your turn ("Reveal & Read").
+- **Read**: the whole poem, aligned per law 3, bylines with lines, then a
+  plain "Done".
+
+## Voice
+
+Short, warm, party-toned. No meta-copy, no em-dashes in UI strings, no
+prescriptive button labels.

--- a/app/host/page.tsx
+++ b/app/host/page.tsx
@@ -92,7 +92,7 @@ export default function HostPage() {
             </div>
 
             {/* Thumb-zone on phones; settles inline on tablet/desktop */}
-            <div className="fixed inset-x-0 bottom-0 p-6 space-y-4 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[var(--shadow-lg)] md:static md:p-0 md:pt-4 md:bg-transparent md:backdrop-blur-none md:border-0 md:shadow-none">
+            <div className="fixed inset-x-0 bottom-0 p-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] space-y-4 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[var(--shadow-lg)] md:static md:p-0 md:pt-4 md:bg-transparent md:backdrop-blur-none md:border-0 md:shadow-none">
               {error && (
                 <Alert
                   variant="error"

--- a/app/host/page.tsx
+++ b/app/host/page.tsx
@@ -61,9 +61,12 @@ export default function HostPage() {
   }
 
   return (
-    <div className="min-h-screen bg-[var(--color-background)] p-6 md:p-12 lg:p-20 flex flex-col">
+    <div className="min-h-screen bg-[var(--color-background)] p-6 pb-32 md:p-12 lg:p-20 flex flex-col">
       <div className="max-w-xl w-full">
-        <h1 className="text-5xl md:text-6xl font-[var(--font-display)] mb-8">
+        <p className="text-xs font-mono uppercase tracking-[0.32em] text-text-muted mb-3">
+          New game
+        </p>
+        <h1 className="text-4xl md:text-6xl font-[var(--font-display)] leading-tight mb-8">
           Host Session
         </h1>
 
@@ -88,17 +91,17 @@ export default function HostPage() {
               />
             </div>
 
-            {error && (
-              <Alert
-                variant="error"
-                data-testid={E2E_TEST_IDS.hostErrorAlert}
-                className="mt-4"
-              >
-                {error}
-              </Alert>
-            )}
+            {/* Thumb-zone on phones; settles inline on tablet/desktop */}
+            <div className="fixed inset-x-0 bottom-0 p-6 space-y-4 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[var(--shadow-lg)] md:static md:p-0 md:pt-4 md:bg-transparent md:backdrop-blur-none md:border-0 md:shadow-none">
+              {error && (
+                <Alert
+                  variant="error"
+                  data-testid={E2E_TEST_IDS.hostErrorAlert}
+                >
+                  {error}
+                </Alert>
+              )}
 
-            <div className="pt-4">
               <Button
                 type="submit"
                 data-testid={E2E_TEST_IDS.hostCreateRoomButton}

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -132,7 +132,7 @@ function JoinForm() {
           </div>
 
           {/* Thumb-zone on phones; settles inline on tablet/desktop */}
-          <div className="fixed inset-x-0 bottom-0 p-6 space-y-4 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[var(--shadow-lg)] md:static md:p-0 md:pt-4 md:bg-transparent md:backdrop-blur-none md:border-0 md:shadow-none">
+          <div className="fixed inset-x-0 bottom-0 p-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] space-y-4 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[var(--shadow-lg)] md:static md:p-0 md:pt-4 md:bg-transparent md:backdrop-blur-none md:border-0 md:shadow-none">
             {error && (
               <Alert variant="error" data-testid={E2E_TEST_IDS.joinErrorAlert}>
                 {error}

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -72,7 +72,10 @@ function JoinForm() {
 
   return (
     <div className="max-w-xl w-full ml-auto">
-      <h1 className="text-5xl md:text-6xl font-[var(--font-display)] mb-8 text-right">
+      <p className="text-xs font-mono uppercase tracking-[0.32em] text-text-muted mb-3 text-right">
+        Join game
+      </p>
+      <h1 className="text-4xl md:text-6xl font-[var(--font-display)] leading-tight mb-8 text-right">
         Join Session
       </h1>
 
@@ -128,17 +131,14 @@ function JoinForm() {
             />
           </div>
 
-          {error && (
-            <Alert
-              variant="error"
-              data-testid={E2E_TEST_IDS.joinErrorAlert}
-              className="mt-4"
-            >
-              {error}
-            </Alert>
-          )}
+          {/* Thumb-zone on phones; settles inline on tablet/desktop */}
+          <div className="fixed inset-x-0 bottom-0 p-6 space-y-4 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[var(--shadow-lg)] md:static md:p-0 md:pt-4 md:bg-transparent md:backdrop-blur-none md:border-0 md:shadow-none">
+            {error && (
+              <Alert variant="error" data-testid={E2E_TEST_IDS.joinErrorAlert}>
+                {error}
+              </Alert>
+            )}
 
-          <div className="pt-4">
             <Button
               type="submit"
               data-testid={E2E_TEST_IDS.joinRoomButton}
@@ -156,7 +156,7 @@ function JoinForm() {
 
 export default function JoinPage() {
   return (
-    <div className="min-h-screen bg-[var(--color-background)] p-6 md:p-12 lg:p-20 flex flex-col">
+    <div className="min-h-screen bg-[var(--color-background)] p-6 pb-32 md:p-12 lg:p-20 flex flex-col">
       <Suspense fallback={<div>Loading...</div>}>
         <JoinForm />
       </Suspense>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,10 +4,33 @@ import Link from 'next/link';
 import { Button } from '../components/ui/Button';
 
 export default function Home() {
+  const renderActions = () => (
+    <div className="space-y-4 max-w-md">
+      <Link href="/host" className="block w-full">
+        <Button
+          className="w-full h-16 text-xl font-[var(--font-sans)] font-medium"
+          size="lg"
+        >
+          Start a Game
+        </Button>
+      </Link>
+
+      <Link href="/join" className="block w-full">
+        <Button
+          variant="secondary"
+          className="w-full h-14 text-lg font-[var(--font-sans)]"
+          size="lg"
+        >
+          Join a Room
+        </Button>
+      </Link>
+    </div>
+  );
+
   return (
-    <div className="flex flex-col bg-[var(--color-background)] relative">
-      <main className="max-w-4xl mx-auto p-6 md:p-12 lg:p-24">
-        <div className="space-y-16">
+    <div className="min-h-screen bg-[var(--color-background)] relative">
+      <main className="max-w-4xl mx-auto p-6 pb-32 md:p-12 lg:p-24">
+        <div className="space-y-8 md:space-y-16">
           {/* Title */}
           <h1 className="text-7xl md:text-9xl font-[var(--font-display)] font-bold leading-[0.85] text-[var(--color-text-primary)]">
             Linejam
@@ -24,29 +47,15 @@ export default function Home() {
             aloud.
           </p>
 
-          {/* Action Buttons */}
-          <div className="space-y-4 max-w-md">
-            <Link href="/host" className="block w-full">
-              <Button
-                className="w-full h-16 text-xl font-[var(--font-sans)] font-medium"
-                size="lg"
-              >
-                Start a Game
-              </Button>
-            </Link>
-
-            <Link href="/join" className="block w-full">
-              <Button
-                variant="secondary"
-                className="w-full h-14 text-lg font-[var(--font-sans)]"
-                size="lg"
-              >
-                Join a Room
-              </Button>
-            </Link>
-          </div>
+          {/* Action Buttons - inline on tablet/desktop */}
+          <div className="hidden md:block">{renderActions()}</div>
         </div>
       </main>
+
+      {/* Thumb-zone action bar on phones */}
+      <div className="md:hidden fixed bottom-0 left-0 right-0 p-6 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[var(--shadow-lg)]">
+        {renderActions()}
+      </div>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,7 +53,7 @@ export default function Home() {
       </main>
 
       {/* Thumb-zone action bar on phones */}
-      <div className="md:hidden fixed bottom-0 left-0 right-0 p-6 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[var(--shadow-lg)]">
+      <div className="md:hidden fixed bottom-0 left-0 right-0 p-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[var(--shadow-lg)]">
         {renderActions()}
       </div>
     </div>

--- a/components/Lobby.tsx
+++ b/components/Lobby.tsx
@@ -7,6 +7,7 @@ import { api } from '../convex/_generated/api';
 import { useUser } from '../lib/auth';
 import { E2E_TEST_IDS } from '../lib/e2eTestIds';
 import { errorToFeedback } from '../lib/errorFeedback';
+import { formatRoomCode } from '../lib/roomCode';
 import { Alert } from './ui/Alert';
 import { Avatar } from './ui/Avatar';
 import { Button } from './ui/Button';
@@ -206,22 +207,20 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
         />
       )}
 
-      <div className="min-h-screen bg-background p-6 md:p-12">
-        <div className="w-full max-w-6xl mx-auto">
-          <div className="grid md:grid-cols-[auto_1fr] gap-12 md:gap-24">
-            <div className="flex flex-col items-center md:items-start space-y-8 md:self-start">
-              <div className="max-w-md space-y-4 text-center md:text-left">
-                <p className="text-xs font-mono uppercase tracking-[0.32em] text-text-muted">
-                  Room actions
-                </p>
-                <h2 className="text-2xl md:text-3xl font-[var(--font-display)] leading-tight text-text-primary">
-                  Start when everyone is here.
-                </h2>
-                <p className="text-base leading-relaxed text-text-secondary">
-                  Share the code from the top bar. Add an AI player if needed.
-                </p>
-              </div>
+      <div className="min-h-screen bg-background px-6 pt-6 pb-56 md:px-12 md:pt-12 md:pb-12">
+        <div className="w-full max-w-6xl mx-auto space-y-10 md:space-y-16">
+          {/* Room code hero — legible across the table, the party's rallying point */}
+          <div className="text-center space-y-2">
+            <p className="text-xs font-mono uppercase tracking-[0.32em] text-text-muted">
+              Share this code
+            </p>
+            <p className="font-[var(--font-display)] text-5xl sm:text-6xl md:text-7xl font-medium tracking-[0.08em] text-text-primary">
+              {formatRoomCode(room.code)}
+            </p>
+          </div>
 
+          <div className="grid md:grid-cols-[auto_1fr] gap-12 md:gap-24">
+            <div className="flex flex-col items-center md:items-start space-y-4 md:self-start">
               {canAddAi && (
                 <Button
                   onClick={handleAddAi}
@@ -262,7 +261,7 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
             </div>
 
             <div className="relative order-first md:order-none">
-              <ul className="space-y-6 pb-24 md:pb-0">
+              <ul className="space-y-6 pb-8 md:pb-0">
                 {players.map((player, i) => (
                   <StampAnimation key={player._id} delay={i * 150}>
                     <li className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 py-2">
@@ -305,7 +304,12 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
                 ))}
               </ul>
 
-              <div className="md:hidden fixed bottom-0 left-0 right-0 p-6 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[var(--shadow-lg)]">
+              <div
+                className="md:hidden fixed bottom-0 left-0 right-0 p-6 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[var(--shadow-lg)]"
+                style={{
+                  paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom))',
+                }}
+              >
                 {error && (
                   <Alert variant="error" className="mb-4">
                     {error}

--- a/components/PoemDisplay.tsx
+++ b/components/PoemDisplay.tsx
@@ -90,6 +90,11 @@ export function PoemDisplay({
     typeof line === 'string' ? { text: line } : line
   );
   const firstLineText = normalizedLines[0]?.text ?? metadata?.firstLine ?? '';
+  // Law 3: line number gutter is one fixed width for every line (ch units,
+  // sized to the poem's line count) so line text always starts at the same
+  // x — no line's number or author dot can nudge the text that follows it.
+  const lineNumberGutterWidth = `${String(normalizedLines.length).length + 1}ch`;
+  const lineGridTemplate = `${lineNumberGutterWidth} 2.75rem 1fr`;
   const { isMuted, prefersReducedMotion, punctuate, toggleMuted } =
     useCeremonyEffects();
 
@@ -215,6 +220,14 @@ export function PoemDisplay({
               </div>
             )}
 
+            {/* Performance-toned kicker — the ceremony read is a group
+                moment, not silent reading. */}
+            {!isArchive && (
+              <p className="mb-2 text-xs font-mono uppercase tracking-widest text-primary">
+                Read it aloud
+              </p>
+            )}
+
             {/* Date + Favorite */}
             <div className="flex justify-between items-center mb-2">
               <span className="text-sm font-mono text-text-muted uppercase tracking-wider">
@@ -301,7 +314,20 @@ export function PoemDisplay({
 
             return (
               <Fragment key={index}>
-                <div className="grid grid-cols-[2.75rem_1fr] items-center">
+                <div
+                  className="grid items-center"
+                  style={{ gridTemplateColumns: lineGridTemplate }}
+                >
+                  {/* Line number — fixed gutter, same width on every line
+                      (Law 3). Decorative: the reading order is already
+                      conveyed by document order. */}
+                  <span
+                    className="pr-2 text-right font-mono text-xs tabular-nums text-text-muted"
+                    aria-hidden="true"
+                  >
+                    {index + 1}
+                  </span>
+
                   {/* Author Dot (Hanko) — 8px ink mark inside a 44px tap target */}
                   <button
                     type="button"
@@ -438,7 +464,7 @@ export function PoemDisplay({
               size="lg"
               className="min-w-[100px] h-12 text-text-muted hover:text-text-primary"
             >
-              Close
+              Done
             </Button>
           )}
         </div>

--- a/components/RevealPhase.tsx
+++ b/components/RevealPhase.tsx
@@ -322,8 +322,11 @@ export function RevealPhase({
                   return (
                     <div
                       key={poem._id}
+                      aria-current={
+                        status === 'reading-now' ? 'true' : undefined
+                      }
                       className={cn(
-                        'flex items-center justify-between gap-3 py-3 px-3 -mx-3 border-b border-border-subtle transition-colors',
+                        'flex items-center justify-between gap-3 py-3 px-3 -mx-3 border-b border-border-subtle transition-colors motion-reduce:transition-none',
                         status === 'reading-now' &&
                           'border-l-2 border-l-primary bg-primary/5'
                       )}

--- a/components/RevealPhase.tsx
+++ b/components/RevealPhase.tsx
@@ -10,7 +10,6 @@ import { captureError } from '../lib/error';
 import { errorToFeedback } from '../lib/errorFeedback';
 import { Alert } from './ui/Alert';
 import { Button } from './ui/Button';
-import { Label } from './ui/Label';
 import { PoemDisplay } from './PoemDisplay';
 import { LoadingState, LoadingMessages } from './ui/LoadingState';
 import { Avatar } from './ui/Avatar';
@@ -21,7 +20,18 @@ import { RoomChrome } from './RoomChrome';
 import { buildRevealChromeCopy } from '../lib/roomChromeCopy';
 import { SessionRecapHub } from './SessionRecapHub';
 import { RevealStage } from './stage/RevealStage';
-import { Presentation } from 'lucide-react';
+import { Presentation, Check } from 'lucide-react';
+
+type ReadingCircleStatus = 'read' | 'reading-now' | 'up-next' | null;
+
+const READING_CIRCLE_STATUS_LABEL: Record<
+  Exclude<ReadingCircleStatus, null>,
+  string
+> = {
+  read: 'Read',
+  'reading-now': 'Reading now',
+  'up-next': 'Up next',
+};
 
 interface RevealPhaseProps {
   roomCode: string;
@@ -280,72 +290,88 @@ export function RevealPhase({
             </section>
           )}
 
-          {/* 2b. UP NEXT - reader spotlight (the running order's on-deck poet) */}
-          {!allRevealed &&
-            (() => {
-              const upNext = [...poems]
-                .sort((a, b) => a.indexInRoom - b.indexInRoom)
-                .find((p) => !p.isRevealed);
-              if (!upNext) return null;
-              return (
-                <section className="flex items-center gap-4 border border-border-subtle bg-surface/60 p-5">
-                  <Avatar
-                    stableId={upNext.readerStableId}
-                    displayName={upNext.readerName}
-                    allStableIds={allStableIds}
-                    size="md"
-                  />
-                  <div>
-                    <p className="text-[10px] font-mono uppercase tracking-widest text-primary">
-                      Up next on the mic
-                    </p>
-                    <p className="text-lg font-medium text-text-primary">
-                      {upNext.readerName} reads Poem{' '}
-                      {(upNext.indexInRoom + 1).toString().padStart(2, '0')}
-                    </p>
-                  </div>
-                </section>
-              );
-            })()}
-
-          {/* 3. STATUS - Poem Status list (the running order) */}
+          {/* 2b. THE READING CIRCLE - the running order, one row per reader,
+              each carrying a status chip driven by reveal state. */}
           <section className="space-y-4">
-            <Label className="block">Running order</Label>
+            <div className="space-y-1">
+              <h2 className="text-2xl md:text-3xl font-[var(--font-display)] leading-tight text-text-primary">
+                The reading circle
+              </h2>
+              <p className="text-sm text-text-muted">
+                Everyone reads one poem aloud.
+              </p>
+            </div>
             <div className="border-t border-border-subtle">
-              {poems
-                .sort((a, b) => a.indexInRoom - b.indexInRoom)
-                .map((poem, i) => (
-                  <div
-                    key={poem._id}
-                    className="flex items-center justify-between py-3 border-b border-border-subtle"
-                  >
-                    <div className="flex items-center gap-3">
-                      <span className="font-mono text-xs text-text-muted w-6">
-                        {(i + 1).toString().padStart(2, '0')}
-                      </span>
-                      <Avatar
-                        stableId={poem.readerStableId}
-                        displayName={poem.readerName}
-                        allStableIds={allStableIds}
-                        size="sm"
-                        outlined={!poem.isRevealed}
-                      />
-                      <span
-                        className={cn(
-                          'text-sm font-medium',
-                          poem.isRevealed && 'opacity-50'
-                        )}
-                      >
-                        {poem.readerName}
-                      </span>
+              {(() => {
+                const sortedPoems = [...poems].sort(
+                  (a, b) => a.indexInRoom - b.indexInRoom
+                );
+                const unrevealed = sortedPoems.filter((p) => !p.isRevealed);
+                const readingNowId = unrevealed[0]?._id;
+                const upNextId = unrevealed[1]?._id;
+
+                return sortedPoems.map((poem, i) => {
+                  const status: ReadingCircleStatus = poem.isRevealed
+                    ? 'read'
+                    : poem._id === readingNowId
+                      ? 'reading-now'
+                      : poem._id === upNextId
+                        ? 'up-next'
+                        : null;
+
+                  return (
+                    <div
+                      key={poem._id}
+                      className={cn(
+                        'flex items-center justify-between gap-3 py-3 px-3 -mx-3 border-b border-border-subtle transition-colors',
+                        status === 'reading-now' &&
+                          'border-l-2 border-l-primary bg-primary/5'
+                      )}
+                    >
+                      <div className="flex min-w-0 items-center gap-3">
+                        <span className="w-6 shrink-0 font-mono text-xs text-text-muted">
+                          {(i + 1).toString().padStart(2, '0')}
+                        </span>
+                        <Avatar
+                          stableId={poem.readerStableId}
+                          displayName={poem.readerName}
+                          allStableIds={allStableIds}
+                          size="sm"
+                          outlined={!poem.isRevealed}
+                        />
+                        <div className="min-w-0">
+                          <span
+                            className={cn(
+                              'block truncate text-sm font-medium text-text-primary',
+                              poem.isRevealed && 'opacity-50'
+                            )}
+                          >
+                            {poem.readerName}
+                          </span>
+                          <span className="block text-[10px] font-mono uppercase tracking-widest text-text-muted">
+                            Poem {(i + 1).toString().padStart(2, '0')}
+                          </span>
+                        </div>
+                      </div>
+                      {status && (
+                        <span
+                          className={cn(
+                            'inline-flex shrink-0 items-center gap-1 text-[10px] font-mono uppercase tracking-widest',
+                            status === 'read' && 'text-text-muted opacity-50',
+                            status === 'reading-now' && 'text-primary',
+                            status === 'up-next' && 'text-text-secondary'
+                          )}
+                        >
+                          {status === 'read' && (
+                            <Check className="h-3 w-3" aria-hidden="true" />
+                          )}
+                          {READING_CIRCLE_STATUS_LABEL[status]}
+                        </span>
+                      )}
                     </div>
-                    {poem.isRevealed && (
-                      <span className="text-[10px] font-mono uppercase tracking-widest text-text-muted">
-                        READ
-                      </span>
-                    )}
-                  </div>
-                ))}
+                  );
+                });
+              })()}
             </div>
           </section>
 

--- a/components/WaitingScreen.tsx
+++ b/components/WaitingScreen.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { useMutation, useQuery } from 'convex/react';
 import { api } from '../convex/_generated/api';
-import { GHOSTWRITER_OVERTIME_MS } from '../convex/lib/gameRules';
+import { GHOSTWRITER_OVERTIME_MS, WORD_COUNTS } from '../convex/lib/gameRules';
 import { useRoomQueryArgs } from '../hooks/useRoomQueryArgs';
 import { captureError } from '../lib/error';
 import { E2E_TEST_IDS } from '../lib/e2eTestIds';
 import { errorToFeedback } from '../lib/errorFeedback';
+import { cn } from '../lib/utils';
 import { Alert } from './ui/Alert';
 import { Button } from './ui/Button';
 import { LoadingState, LoadingMessages } from './ui/LoadingState';
@@ -141,13 +142,35 @@ export function WaitingScreen({
 
         {/* Center: Headline */}
         <div className="flex-none mb-24 md:mb-28 text-center space-y-6">
-          <h2 className="text-6xl md:text-8xl font-[var(--font-display)] leading-[1.05]">
+          <h2 className="text-4xl md:text-6xl font-[var(--font-display)] leading-tight">
             {allSubmitted
               ? 'Ready'
               : isOvertime
                 ? 'Still writing…'
-                : 'Others are writing...'}
+                : "It's around the table now."}
           </h2>
+
+          {/* Round progress — nine segments, the current round lit */}
+          <div
+            className="mx-auto flex max-w-xs justify-center gap-1.5"
+            role="presentation"
+            aria-hidden="true"
+          >
+            {WORD_COUNTS.map((_, segmentIndex) => (
+              <div
+                key={segmentIndex}
+                className={cn(
+                  'h-1 flex-1 rounded-full transition-colors duration-[var(--duration-normal)]',
+                  segmentIndex === round
+                    ? 'bg-[var(--color-primary)]'
+                    : segmentIndex < round
+                      ? 'bg-[var(--color-text-muted)]/40'
+                      : 'bg-[var(--color-border-subtle)]'
+                )}
+              />
+            ))}
+          </div>
+
           {!allSubmitted && (
             <div className="space-y-3">
               <p className="text-[var(--text-lg)] font-mono text-[var(--color-text-secondary)]">

--- a/components/WaitingScreen.tsx
+++ b/components/WaitingScreen.tsx
@@ -160,7 +160,7 @@ export function WaitingScreen({
               <div
                 key={segmentIndex}
                 className={cn(
-                  'h-1 flex-1 rounded-full transition-colors duration-[var(--duration-normal)]',
+                  'h-1 flex-1 rounded-full transition-colors motion-reduce:transition-none duration-[var(--duration-normal)]',
                   segmentIndex === round
                     ? 'bg-[var(--color-primary)]'
                     : segmentIndex < round

--- a/components/WritingScreen.tsx
+++ b/components/WritingScreen.tsx
@@ -187,6 +187,42 @@ function WritingComposer({
     }
   };
 
+  const isSubmitDisabled =
+    !isValid ||
+    submissionState === 'submitting' ||
+    submissionState === 'confirmed';
+
+  // Shared Ready label + Button markup rendered in two places: in-flow on
+  // md+ (Law 1 only requires bottom-anchoring on phones), and inside the
+  // thumb-zone bar on mobile.
+  const submitBlock = (
+    <>
+      {isReady && (
+        <p className="text-xs font-mono uppercase tracking-widest text-primary animate-fade-in-up">
+          Ready
+        </p>
+      )}
+      <Button
+        onClick={handleSubmit}
+        data-testid={E2E_TEST_IDS.writingSubmitLineButton}
+        data-ready={isReady ? 'true' : undefined}
+        size="lg"
+        disabled={isSubmitDisabled}
+        stampAnimate={submissionState === 'confirmed'}
+        className={cn(
+          'min-w-[240px] text-xl h-16 md:h-20',
+          isReady && 'animate-ready-seal shadow-md'
+        )}
+      >
+        {submissionState === 'submitting'
+          ? 'Submitting…'
+          : submissionState === 'confirmed'
+            ? 'Submitted'
+            : 'Submit'}
+      </Button>
+    </>
+  );
+
   return (
     <div
       data-testid={E2E_TEST_IDS.writingPhase}
@@ -260,7 +296,7 @@ function WritingComposer({
             ref={textareaRef}
             data-testid={E2E_TEST_IDS.writingLineInput}
             className={cn(
-              'w-full min-h-[110px] md:min-h-[320px] lg:min-h-[360px] field-sizing-content bg-transparent border-none outline-none resize-none',
+              'w-full min-h-[64px] md:min-h-[320px] lg:min-h-[360px] field-sizing-content bg-transparent border-none outline-none resize-none',
               'text-3xl md:text-5xl lg:text-6xl font-[var(--font-display)] leading-tight',
               'text-text-primary',
               'placeholder:text-text-muted/20',
@@ -280,10 +316,22 @@ function WritingComposer({
             aria-invalid={!isValid}
             aria-describedby="word-slots"
           />
-        </div>
 
-        <div className="flex justify-center">
-          <WordSlots current={currentWordCount} target={targetCount} />
+          {/*
+            Word chips sit tight against the line, left-aligned with the
+            textarea's own `pl-6` — not centered in a full-width row, which
+            reads as one lonely floating box for short targets. Pulling this
+            out of the outer `space-y-*` stack (it's nested in the canvas,
+            not a sibling of it) is what removes the dead gap under the
+            textarea.
+          */}
+          <div className="mt-2 pl-6 md:mt-4">
+            <WordSlots
+              current={currentWordCount}
+              target={targetCount}
+              text={text}
+            />
+          </div>
         </div>
 
         {/* Error Display */}
@@ -293,35 +341,39 @@ function WritingComposer({
           </Alert>
         )}
 
-        {/* The Seal - Submit Button */}
-        <div className="mt-6 md:mt-16 flex flex-col items-center gap-3">
-          {isReady && (
-            <p className="text-xs font-mono uppercase tracking-widest text-primary animate-fade-in-up">
-              Ready
-            </p>
+        {/*
+          The Seal - Submit Button. One instance (not a duplicated mobile
+          copy) so `writingSubmitLineButton` stays a single, strict-mode-safe
+          element for Playwright — DESIGN.md Law 1 (bottom-anchored thumb
+          zone on phones, >=44px tall) is applied purely with responsive
+          classes, flipping to in-flow at md+.
+
+          `sticky` (not `fixed`): it stays in normal document flow and
+          reserves its own box height, so it is structurally impossible for
+          it to clip content above it (RoomChrome uses the same `sticky`
+          pattern for the top bar). `-mx-6`/`md:mx-0` bleeds it back out to
+          the viewport edges past the page's own `px-6` padding.
+          `env(safe-area-inset-bottom)` keeps it clear of the iOS/Android
+          home indicator on mobile; the background lets received-line and
+          canvas content scroll underneath it legibly.
+
+          Keyboard note: mobile browsers reposition sticky/fixed elements
+          against the *visual* viewport, so this bar sits just above the
+          on-screen keyboard rather than being covered by it. The
+          textarea's `scrollIntoView({ block: 'nearest' })` on focus (see
+          handleTextareaFocus above) only scrolls the minimum distance
+          needed to keep the caret visible, so it doesn't fight this bar
+          for space.
+        */}
+        <div
+          className={cn(
+            'sticky bottom-0 z-30 -mx-6 flex flex-col items-center gap-3',
+            'border-t-2 border-primary/20 bg-background/95 backdrop-blur-md shadow-[var(--shadow-lg)]',
+            'px-6 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))]',
+            'md:static md:mx-0 md:mt-16 md:border-none md:bg-transparent md:p-0 md:shadow-none md:backdrop-blur-none'
           )}
-          <Button
-            onClick={handleSubmit}
-            data-testid={E2E_TEST_IDS.writingSubmitLineButton}
-            data-ready={isReady ? 'true' : undefined}
-            size="lg"
-            disabled={
-              !isValid ||
-              submissionState === 'submitting' ||
-              submissionState === 'confirmed'
-            }
-            stampAnimate={submissionState === 'confirmed'}
-            className={cn(
-              'min-w-[240px] text-xl h-16 md:h-20',
-              isReady && 'animate-ready-seal shadow-md'
-            )}
-          >
-            {submissionState === 'submitting'
-              ? 'Submitting…'
-              : submissionState === 'confirmed'
-                ? 'Submitted'
-                : 'Submit'}
-          </Button>
+        >
+          {submitBlock}
         </div>
       </div>
     </div>

--- a/components/ui/WordSlots.tsx
+++ b/components/ui/WordSlots.tsx
@@ -6,21 +6,54 @@ import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
 interface WordSlotsProps {
   current: number;
   target: number;
+  /**
+   * The text currently being composed. When provided, filled slots render
+   * as chips sized to their actual word (DESIGN.md Law 2: word slots
+   * always grow with their word, clipping can never happen). Omit to fall
+   * back to the legacy fixed-square rendering for callers that only track
+   * a count.
+   */
+  text?: string;
   className?: string;
 }
+
+const MAX_OVERFLOW_DISPLAY = 10;
+
+// Mirrors lib/wordCount's countWords tokenization so chips match the count
+// exactly (same words, same order, same total).
+function splitWords(text: string): string[] {
+  return text.trim().split(/\s+/).filter(Boolean);
+}
+
+// Chips are the signature element (DESIGN.md Law 2) — sized to read at
+// arm's length, not a quiet caption next to the line being written.
+const chipBase =
+  'inline-flex items-center whitespace-nowrap rounded-md border px-3 md:px-4 h-8 md:h-10 text-sm md:text-base font-medium transition-colors duration-[var(--duration-fast)] motion-reduce:transition-none';
+
+const emptySlotClasses =
+  'h-8 md:h-10 min-w-8 md:min-w-10 shrink-0 rounded-md border border-[var(--color-border)] bg-transparent';
 
 /**
  * Genkoyoushi (原稿用紙) word counter
  *
- * Displays word count as a row of manuscript squares that fill with "ink"
- * as words are typed. Inspired by Japanese manuscript paper.
+ * Displays the word-count constraint as a row of manuscript slots that fill
+ * with "ink" as words are typed. When the composed text is known, filled
+ * slots render as chips containing the actual word — sized to its content,
+ * never clipped or truncated — with remaining slots staying small fixed
+ * squares. Overflow words render as error-styled chips (capped for
+ * performance, with a +N indicator beyond the cap).
  */
-const MAX_OVERFLOW_DISPLAY = 10;
-
-export function WordSlots({ current, target, className }: WordSlotsProps) {
-  const isValid = current === target;
-  const isOver = current > target;
-  const overflowCount = isOver ? current - target : 0;
+export function WordSlots({
+  current,
+  target,
+  text,
+  className,
+}: WordSlotsProps) {
+  const words = text !== undefined ? splitWords(text) : null;
+  const activeCount = words ? words.length : current;
+  const isValid = activeCount === target;
+  const isOver = activeCount > target;
+  const overflowCount = isOver ? activeCount - target : 0;
   const displayedOverflow = Math.min(overflowCount, MAX_OVERFLOW_DISPLAY);
   const extraOverflow = overflowCount - displayedOverflow;
 
@@ -28,56 +61,101 @@ export function WordSlots({ current, target, className }: WordSlotsProps) {
     <div
       id="word-slots"
       data-testid={E2E_TEST_IDS.writingWordSlots}
-      className={cn('flex items-center gap-1', className)}
+      className={cn('flex flex-wrap items-center gap-1.5 md:gap-2', className)}
       role="status"
-      aria-label={`${current} of ${target} words`}
+      aria-label={`${activeCount} of ${target} words`}
     >
-      {/* Target slots */}
-      {Array.from({ length: target }).map((_, i) => {
-        const isFilled = i < current && i < target;
-        return (
-          <div
-            key={i}
-            className={cn(
-              'w-3 h-3 md:w-4 md:h-4 border transition-all',
-              'duration-[var(--duration-fast)]',
-              isFilled
-                ? isValid
-                  ? 'bg-[var(--color-primary)] border-[var(--color-primary)]'
-                  : 'bg-[var(--color-foreground)] border-[var(--color-foreground)]'
-                : 'bg-transparent border-[var(--color-border)]'
-            )}
-            style={{
-              transitionDelay: isFilled ? `${i * 30}ms` : '0ms',
-            }}
-          />
-        );
-      })}
+      {words ? (
+        <>
+          {/* Target slots — filled ones show the typed word, sized to it */}
+          {Array.from({ length: target }).map((_, i) => {
+            const word = words[i];
+            if (word === undefined) {
+              return (
+                <span key={i} data-slot="empty" className={emptySlotClasses} />
+              );
+            }
+            return (
+              <span
+                key={i}
+                data-slot="filled"
+                className={cn(
+                  chipBase,
+                  isValid
+                    ? 'bg-[var(--color-primary)] border-[var(--color-primary)] text-[var(--color-text-inverse)]'
+                    : 'bg-[var(--color-foreground)] border-[var(--color-foreground)] text-[var(--color-text-inverse)]'
+                )}
+              >
+                {word}
+              </span>
+            );
+          })}
 
-      {/* Overflow slots (if over limit, capped for performance) */}
-      {displayedOverflow > 0 &&
-        Array.from({ length: displayedOverflow }).map((_, i) => (
-          <div
-            key={`over-${i}`}
-            className={cn(
-              'w-3 h-3 md:w-4 md:h-4',
-              'border border-dashed',
-              'border-[var(--color-error)] bg-[var(--color-error)]/10'
-            )}
-          />
-        ))}
+          {/* Overflow words (if over limit, capped for performance) */}
+          {displayedOverflow > 0 &&
+            words.slice(target, target + displayedOverflow).map((word, i) => (
+              <span
+                key={`over-${i}`}
+                data-slot="overflow"
+                className={cn(
+                  chipBase,
+                  'border-dashed border-[var(--color-error)] bg-[var(--color-error)]/10 text-[var(--color-error)]'
+                )}
+              >
+                {word}
+              </span>
+            ))}
+        </>
+      ) : (
+        <>
+          {/* Legacy count-only rendering (no `text` supplied) */}
+          {Array.from({ length: target }).map((_, i) => {
+            const isFilled = i < current && i < target;
+            return (
+              <div
+                key={i}
+                className={cn(
+                  'w-3 h-3 md:w-4 md:h-4 border transition-all',
+                  'duration-[var(--duration-fast)] motion-reduce:transition-none',
+                  isFilled
+                    ? isValid
+                      ? 'bg-[var(--color-primary)] border-[var(--color-primary)]'
+                      : 'bg-[var(--color-foreground)] border-[var(--color-foreground)]'
+                    : 'bg-transparent border-[var(--color-border)]'
+                )}
+                style={{
+                  transitionDelay: isFilled ? `${i * 30}ms` : '0ms',
+                }}
+              />
+            );
+          })}
 
-      {/* +N indicator if overflow exceeds cap */}
+          {/* Overflow slots (if over limit, capped for performance) */}
+          {displayedOverflow > 0 &&
+            Array.from({ length: displayedOverflow }).map((_, i) => (
+              <div
+                key={`over-${i}`}
+                className={cn(
+                  'w-3 h-3 md:w-4 md:h-4',
+                  'border border-dashed',
+                  'border-[var(--color-error)] bg-[var(--color-error)]/10'
+                )}
+              />
+            ))}
+        </>
+      )}
+
+      {/* +N indicator if overflow exceeds the display cap */}
       {extraOverflow > 0 && (
-        <span className="ml-0.5 text-[9px] md:text-[10px] font-mono text-[var(--color-error)]">
+        <span className="ml-0.5 text-xs font-mono text-[var(--color-error)]">
           +{extraOverflow}
         </span>
       )}
 
-      {/* "words" label */}
+      {/* "words" label — stays a quiet caption next to the loud chips */}
       <span
         className={cn(
-          'ml-1.5 text-[9px] md:text-[10px]',
+          'ml-1.5 text-[10px] md:text-xs',
           'font-mono uppercase tracking-wider',
           'text-[var(--color-text-muted)]'
         )}

--- a/tests/components/Lobby.test.tsx
+++ b/tests/components/Lobby.test.tsx
@@ -107,13 +107,12 @@ describe('Lobby component', () => {
     global.fetch = originalFetch;
   });
 
-  it('renders the control-desk introduction', () => {
+  it('renders the room code as the lobby hero', () => {
     // Arrange & Act
     render(<Lobby room={mockRoom} players={mockPlayers} isHost={true} />);
 
-    expect(
-      screen.getByText(/start when everyone is here/i)
-    ).toBeInTheDocument();
+    // Room code "ABCD" is formatted as "AB CD" and shown as the in-body hero
+    expect(screen.getByText('AB CD')).toBeInTheDocument();
   });
 
   it('renders player list from room state', () => {

--- a/tests/components/PoemDisplay.test.tsx
+++ b/tests/components/PoemDisplay.test.tsx
@@ -482,7 +482,7 @@ describe('PoemDisplay component', () => {
       expect(screen.getByText('Poem link copied.')).toBeInTheDocument();
     });
 
-    it('calls onDone when Close button clicked', async () => {
+    it('calls onDone when Done button clicked', async () => {
       render(
         <PoemDisplay
           poemId={mockPoemId}
@@ -493,9 +493,48 @@ describe('PoemDisplay component', () => {
       );
 
       await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: /Close/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^Done$/i }));
       });
       expect(mockOnDone).toHaveBeenCalled();
+    });
+  });
+
+  describe('line alignment (DESIGN.md Law 3)', () => {
+    it('gives every line the same fixed-width number gutter so line text always starts at the same x', () => {
+      render(
+        <PoemDisplay
+          poemId={mockPoemId}
+          lines={mockLines}
+          onDone={mockOnDone}
+          alreadyRevealed={true}
+        />
+      );
+
+      // Each line's number+dot+text row shares one grid template — the
+      // gutter width can never differ line to line, so text can never shift.
+      const lineDots = screen.getAllByRole('button', { name: /Show author/i });
+      const rows = lineDots.map((dot) => dot.parentElement as HTMLElement);
+      const templates = rows.map((row) => row.style.gridTemplateColumns);
+
+      expect(templates).toHaveLength(mockLines.length);
+      expect(new Set(templates).size).toBe(1);
+      expect(templates[0]).toMatch(/^\d+ch /);
+    });
+
+    it('renders a visible line number ahead of every line, sized to the poem length', () => {
+      render(
+        <PoemDisplay
+          poemId={mockPoemId}
+          lines={mockLines}
+          onDone={mockOnDone}
+          alreadyRevealed={true}
+        />
+      );
+
+      // mockLines has 9 lines, so numbers 1-9 should each appear once.
+      for (let i = 1; i <= mockLines.length; i += 1) {
+        expect(screen.getByText(String(i))).toBeInTheDocument();
+      }
     });
   });
 

--- a/tests/components/RevealPhase.test.tsx
+++ b/tests/components/RevealPhase.test.tsx
@@ -258,22 +258,102 @@ describe('RevealPhase component', () => {
     expect(screen.getByText('Bob')).toBeInTheDocument();
   });
 
-  it('shows revealed status with READ label for revealed poems', () => {
+  it('shows a Read chip for revealed poems in the reading circle', () => {
     // Arrange & Act
     render(<RevealPhase roomCode="ABCD" />);
 
-    // Assert - Bob's poem is revealed, should have READ label
-    const bobRow = screen.getByText('Bob').closest('div');
-    expect(bobRow?.parentElement?.textContent).toContain('READ');
+    // Assert - Bob's poem is revealed, should carry the Read chip. The row
+    // is the nearest ancestor carrying the shared row border, since the
+    // name sits inside a nested name/poem-label wrapper.
+    const bobRow = screen.getByText('Bob').closest('.border-b');
+    expect(bobRow?.textContent).toContain('Read');
   });
 
-  it('shows unrevealed status without READ label for unrevealed poems', () => {
+  it('shows a Reading now chip for the sole unrevealed poem in the reading circle', () => {
     // Arrange & Act
     render(<RevealPhase roomCode="ABCD" />);
 
-    // Assert - Alice's poem is not revealed, should not have READ label
-    const aliceRow = screen.getByText('Alice').closest('div');
-    expect(aliceRow?.parentElement?.textContent).not.toContain('READ');
+    // Assert - Alice's poem is the only unrevealed poem, so it is up now
+    const aliceRow = screen.getByText('Alice').closest('.border-b');
+    expect(aliceRow?.textContent).toContain('Reading now');
+  });
+
+  it('shows the reading-circle heading and explainer', () => {
+    render(<RevealPhase roomCode="ABCD" />);
+
+    expect(
+      screen.getByRole('heading', { name: /The reading circle/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Everyone reads one poem aloud\./i)
+    ).toBeInTheDocument();
+  });
+
+  it('drives all four reading-circle chip states off reveal order', () => {
+    // Arrange: 4 poems — one read, one reading now, one up next, one quiet.
+    // Names deliberately avoid the substring "Read" so the chip assertions
+    // below can't accidentally match the reader's own name.
+    const fourPoems = [
+      {
+        _id: 'poem_read' as Id<'poems'>,
+        indexInRoom: 0,
+        createdAt: 1000,
+        preview: 'Already read',
+        readerName: 'Ann',
+        readerStableId: 'stable_1',
+        isRevealed: true,
+      },
+      {
+        _id: 'poem_now' as Id<'poems'>,
+        indexInRoom: 1,
+        createdAt: 1000,
+        preview: 'Reading currently',
+        readerName: 'Ben',
+        readerStableId: 'stable_2',
+        isRevealed: false,
+      },
+      {
+        _id: 'poem_next' as Id<'poems'>,
+        indexInRoom: 2,
+        createdAt: 1000,
+        preview: 'On deck',
+        readerName: 'Cara',
+        readerStableId: 'stable_3',
+        isRevealed: false,
+      },
+      {
+        _id: 'poem_quiet' as Id<'poems'>,
+        indexInRoom: 3,
+        createdAt: 1000,
+        preview: 'Waiting quietly',
+        readerName: 'Dee',
+        readerStableId: 'stable_4',
+        isRevealed: false,
+      },
+    ];
+
+    mockUseQuery.mockReturnValue({
+      ...mockStateNotRevealed,
+      myPoems: [],
+      poems: fourPoems,
+    });
+
+    // Act
+    render(<RevealPhase roomCode="ABCD" />);
+
+    // Assert
+    const annRow = screen.getByText('Ann').closest('.border-b');
+    const benRow = screen.getByText('Ben').closest('.border-b');
+    const caraRow = screen.getByText('Cara').closest('.border-b');
+    const deeRow = screen.getByText('Dee').closest('.border-b');
+
+    expect(annRow?.textContent).toContain('Read');
+    expect(benRow?.textContent).toContain('Reading now');
+    expect(caraRow?.textContent).toContain('Up next');
+    // The quiet row carries no status chip at all.
+    expect(deeRow?.textContent).not.toContain('Read');
+    expect(deeRow?.textContent).not.toContain('Reading now');
+    expect(deeRow?.textContent).not.toContain('Up next');
   });
 
   it('displays my poem preview when not revealed', () => {

--- a/tests/components/WaitingScreen.test.tsx
+++ b/tests/components/WaitingScreen.test.tsx
@@ -127,7 +127,7 @@ describe('WaitingScreen component', () => {
     expect(screen.getByText(/Round 3/)).toBeInTheDocument();
   });
 
-  it('shows "Others are writing..." when not all players submitted', () => {
+  it('shows "It\'s around the table now." when not all players submitted', () => {
     mockUseQuery.mockReturnValue({
       round: 0,
       players: [
@@ -150,7 +150,7 @@ describe('WaitingScreen component', () => {
 
     render(<WaitingScreen roomCode="ABCD" />);
 
-    expect(screen.getByText('Others are writing...')).toBeInTheDocument();
+    expect(screen.getByText("It's around the table now.")).toBeInTheDocument();
     expect(screen.getByText(/Round 1 · 1 of 2 ready/i)).toBeInTheDocument();
   });
 
@@ -209,7 +209,7 @@ describe('WaitingScreen component', () => {
     );
 
     expect(mockUseQuery).toHaveBeenCalledWith(expect.anything(), 'skip');
-    expect(screen.getByText('Others are writing...')).toBeInTheDocument();
+    expect(screen.getByText("It's around the table now.")).toBeInTheDocument();
     expect(screen.getByText(/Round 2 · 1 of 2 ready/i)).toBeInTheDocument();
   });
 

--- a/tests/components/ui/WordSlots.test.tsx
+++ b/tests/components/ui/WordSlots.test.tsx
@@ -75,4 +75,86 @@ describe('WordSlots component', () => {
       expect(screen.queryByText(/\+\d+/)).not.toBeInTheDocument();
     });
   });
+
+  describe('growing word chips (text supplied)', () => {
+    it('renders each typed word as a chip and pads remaining target slots empty', () => {
+      const { container } = render(
+        <WordSlots current={2} target={5} text="brave new" />
+      );
+
+      expect(screen.getByText('brave')).toBeInTheDocument();
+      expect(screen.getByText('new')).toBeInTheDocument();
+
+      // 5 target slots total: 2 word chips + 3 empty squares
+      const slots = container.querySelectorAll('#word-slots > [data-slot]');
+      expect(slots).toHaveLength(5);
+      expect(container.querySelectorAll('[data-slot="filled"]')).toHaveLength(
+        2
+      );
+      expect(container.querySelectorAll('[data-slot="empty"]')).toHaveLength(3);
+    });
+
+    it('derives the aria-label word count from the text, not the current prop', () => {
+      render(<WordSlots current={0} target={5} text="brave new" />);
+
+      const status = screen.getByRole('status');
+      expect(status).toHaveAttribute('aria-label', '2 of 5 words');
+    });
+
+    it('renders a long word fully, unclipped, with no fixed-width style', () => {
+      render(<WordSlots current={1} target={1} text="extraordinarily" />);
+
+      const chip = screen.getByText('extraordinarily');
+      // The exact word, not truncated with an ellipsis or cut off.
+      expect(chip).toHaveTextContent('extraordinarily');
+      // Sized to content — no fixed-width utility class or inline width style.
+      expect(chip.className).not.toMatch(/(^|\s)w-\d/);
+      expect(chip.style.width).toBe('');
+      expect(chip.className).not.toContain('truncate');
+      expect(chip.className).not.toContain('overflow-hidden');
+    });
+
+    it('colors filled chips primary once the word count reaches target', () => {
+      render(<WordSlots current={2} target={2} text="right there" />);
+
+      const chip = screen.getByText('right');
+      expect(chip.className).toContain('bg-[var(--color-primary)]');
+    });
+
+    it('renders overflow words as error-styled chips showing the actual word', () => {
+      render(
+        <WordSlots
+          current={7}
+          target={5}
+          text="one two three four five six seven"
+        />
+      );
+
+      const overflowChip = screen.getByText('six');
+      expect(overflowChip.className).toContain('border-[var(--color-error)]');
+      expect(screen.getByText('seven')).toBeInTheDocument();
+    });
+
+    it('caps displayed overflow chips and shows a +N indicator beyond the cap', () => {
+      // 18 total words: 5 fill the target, 13 overflow.
+      const allWords = Array.from({ length: 18 }, (_, i) => `w${i}`).join(' ');
+      render(<WordSlots current={18} target={5} text={allWords} />);
+
+      // 13 overflow, capped at 10 displayed chips, so +3 extra
+      expect(
+        screen
+          .getByTestId('writing-word-slots')
+          .querySelectorAll('[data-slot="overflow"]')
+      ).toHaveLength(10);
+      expect(screen.getByText('+3')).toBeInTheDocument();
+    });
+
+    it('falls back to legacy square rendering when text is omitted', () => {
+      const { container } = render(<WordSlots current={2} target={5} />);
+
+      // No word text is rendered, only empty/filled squares.
+      const slots = container.querySelectorAll('#word-slots > div');
+      expect(slots).toHaveLength(5);
+    });
+  });
 });

--- a/tests/e2e/reveal-share.spec.ts
+++ b/tests/e2e/reveal-share.spec.ts
@@ -5,6 +5,7 @@ import {
   CANONICAL_GUEST_FLOW_LINES,
   GuestFlowSession,
 } from '@/tests/e2e/support/guestFlow';
+import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
 
 const missingGuestTokenSecret =
   !process.env.GUEST_TOKEN_SECRET && !process.env.E2E_BASE_URL;
@@ -62,7 +63,9 @@ test('mobile reveal ceremony produces a one-tap shareable recap artifact', async
     await session.hostPage
       .getByRole('button', { name: /Favorite this poem/i })
       .click();
-    await session.hostPage.getByRole('button', { name: /Close/i }).click();
+    // "Close" became the plain-verb "Done" (DESIGN.md Law 4); target the
+    // stable testid so future copy changes can't strand this spec.
+    await session.hostPage.getByTestId(E2E_TEST_IDS.poemDoneButton).click();
 
     await session.revealAssignedPoem('guest', CANONICAL_GUEST_FLOW_LINES);
 


### PR DESCRIPTION
## What

The structural half of the design-lab convergence (themes shipped in #333/#336; this is the spine they wear):

- **DESIGN.md** added as the repo's design contract: eight operator-locked laws (thumb-zone CTAs, growing word slots, poem-alignment law, plain-verb buttons, whole-poem read, token-only styling, AA floor, e2e-testid contract) + per-screen spine anatomy.
- **Write**: typed words render as growing chips (never clipped) with empty slots for the remainder; submit in a sticky thumb-zone bar (single element — Playwright strict-mode safe).
- **Lobby**: room code as the across-the-table hero; presence/host/bot marks; host actions bottom-anchored.
- **Wait**: "It's around the table now." + nine-segment round strip + who's still writing.
- **Reveal**: reading circle with read / reading now / up next states; assignment hero and Present-reveal stage functionally untouched.
- **Read (PoemDisplay)**: fixed number gutter (line starts never shift), plain "Done".
- **Home/host/join**: thumb-zone CTAs, spine typography.

Markup/style surgery only — hooks, mutations, queries, and every `lib/e2eTestIds.ts` id preserved.

## Verification

- `pnpm ci:prepush`: 1425 passed / 131 files.
- Live: early smoke green; full two-player mobile game (390x844) played through every screen via Playwright with screenshot evidence; two visual defects found in evidence review (bar clipping, oversized wait headline) were fixed and re-verified; ready-state submit styling probed live (vermillion, enabled, data-ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed mobile-first layouts with thumb-zone actions for starting, joining, submitting, and viewing errors.
  * Added a prominent, formatted room code display in the lobby.
  * Added round progress indicators to the waiting screen.
  * Introduced word chips that show typed words, remaining slots, and overflow.
  * Added a reading-circle view with clear statuses such as Read, Reading now, and Up next.
  * Improved poem line alignment and updated completion actions to use “Done.”

* **Documentation**
  * Added visual and accessibility guidelines covering responsive layouts, themes, motion, and UI copy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->