### PR TITLE
fix(security): remove unsigned throttle rollout endpoint

### DIFF
--- a/convex/guestSessions.ts
+++ b/convex/guestSessions.ts
@@ -6,37 +6,9 @@ import { verifyGuestSessionThrottleProof } from '../lib/guestSessionThrottleProo
 
 const GUEST_SESSION_THROTTLE_MAX = 20;
 const GUEST_SESSION_THROTTLE_WINDOW_MS = 10 * 60 * 1000;
-const LEGACY_ROLLOUT_THROTTLE_KEY = 'guestSession:legacy-rollout-global';
-const LEGACY_ROLLOUT_THROTTLE_MAX = 200;
 // Resolve once at module load so a production deployment without the shared
 // secret cannot expose the public mutation with a guessable fallback key.
 const guestSessionThrottleSecret = getConvexGuestTokenSecret();
-
-// Staged-rollout compatibility only. The production build deploys Convex
-// before replacing the web process, so the previous web release needs its
-// existing export until the signed caller is live. Since callers cannot prove
-// their supplied key, collapse all legacy traffic into one bounded rollout
-// bucket rather than allowing arbitrary durable row creation. New code must
-// never call this mutation; remove it in the cleanup deploy immediately after
-// rollout.
-export const checkGuestSessionThrottle = mutation({
-  args: {
-    key: v.string(),
-  },
-  handler: async (ctx, { key }) => {
-    if (!/^guestSession:[A-Za-z0-9_-]{16,64}$/.test(key)) {
-      throw new ConvexError('Invalid guest session rate-limit key');
-    }
-
-    await checkRateLimit(ctx, {
-      key: LEGACY_ROLLOUT_THROTTLE_KEY,
-      max: LEGACY_ROLLOUT_THROTTLE_MAX,
-      windowMs: GUEST_SESSION_THROTTLE_WINDOW_MS,
-    });
-
-    return { ok: true as const };
-  },
-});
 
 export const checkSignedGuestSessionThrottle = mutation({
   args: {

--- a/tests/convex/guestSessions.test.ts
+++ b/tests/convex/guestSessions.test.ts
@@ -1,44 +1,20 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { makeFunctionReference } from 'convex/server';
 import { api } from '../../convex/_generated/api';
 import { signGuestSessionThrottleProof } from '../../lib/guestSessionThrottleProof';
 import { setupConvexTest } from '../helpers/convexTest';
 
 const DEV_FALLBACK_SECRET = 'dev-only-insecure-secret-change-in-production';
-const legacyGuestSessionThrottle = makeFunctionReference<
-  'mutation',
-  { key: string },
-  { ok: true }
->('guestSessions:checkGuestSessionThrottle');
-
 describe('guest session throttle', () => {
-  it('keeps the legacy endpoint available during the compatibility rollout', async () => {
-    const t = setupConvexTest();
-
-    await expect(
-      t.mutation(legacyGuestSessionThrottle, {
-        key: 'guestSession:0123456789abcdef',
-      })
-    ).resolves.toEqual({ ok: true });
-  });
-
-  it('collapses arbitrary legacy keys into one bounded rollout bucket', async () => {
-    const t = setupConvexTest();
-
-    await Promise.all(
-      Array.from({ length: 25 }, (_, index) =>
-        t.mutation(legacyGuestSessionThrottle, {
-          key: `guestSession:${index.toString().padStart(16, '0')}`,
-        })
-      )
+  it('does not expose the unsigned rollout endpoint after production cutover', () => {
+    const source = readFileSync(
+      new URL('../../convex/guestSessions.ts', import.meta.url),
+      'utf8'
     );
 
-    const rows = await t.run((ctx) => ctx.db.query('rateLimits').collect());
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({
-      key: 'guestSession:legacy-rollout-global',
-      hits: 25,
-    });
+    expect(source).not.toMatch(
+      /export const checkGuestSessionThrottle\s*=\s*mutation/
+    );
   });
 
   it('accepts a server-signed bucket and keeps repeated writes to one row', async () => {

--- a/tests/convex/guestSessions.test.ts
+++ b/tests/convex/guestSessions.test.ts
@@ -1,20 +1,15 @@
-import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { api } from '../../convex/_generated/api';
+import * as guestSessionFunctions from '../../convex/guestSessions';
 import { signGuestSessionThrottleProof } from '../../lib/guestSessionThrottleProof';
 import { setupConvexTest } from '../helpers/convexTest';
 
 const DEV_FALLBACK_SECRET = 'dev-only-insecure-secret-change-in-production';
 describe('guest session throttle', () => {
   it('does not expose the unsigned rollout endpoint after production cutover', () => {
-    const source = readFileSync(
-      new URL('../../convex/guestSessions.ts', import.meta.url),
-      'utf8'
-    );
-
-    expect(source).not.toMatch(
-      /export const checkGuestSessionThrottle\s*=\s*mutation/
-    );
+    expect(
+      Object.hasOwn(guestSessionFunctions, 'checkGuestSessionThrottle')
+    ).toBe(false);
   });
 
   it('accepts a server-signed bucket and keeps repeated writes to one row', async () => {


### PR DESCRIPTION
## Summary
- remove the temporary unsigned guest-session throttle mutation now that the signed web client is active in production
- remove its compatibility-only bucket and tests
- add a permanent source guard preventing the unsigned export from returning

## Rollout evidence
- production web and responder are ACTIVE on e1784a0
- production Convex exposes the signed throttle and public privacy queries
- anonymous browser: explicit public poem visible; private completed poem blocked
- production smoke 29376693814 passed with Canary reporting
- fresh runtime scan: 0 fatal/panic/uncaught/5xx signals

## Verification
- red: unsigned-endpoint absence guard failed against the compatibility export
- focused: 32 tests passed
- pnpm ci:prepush: 134 files, 1,460 passed, 1 skipped
- normal push hook repeated typecheck, lint, and the full 1,460-test suite successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the deprecated unsigned guest-session throttling endpoint.
  * Guest-session throttling now requires a valid signed proof.
  * Improved validation for malformed or forged throttling proofs.
  * Updated readiness checks to work without creating persistent state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->