### PR TITLE
fix(gameplay): preserve rematch assignments

### DIFF
--- a/convex/game.ts
+++ b/convex/game.ts
@@ -208,8 +208,11 @@ export const getCurrentAssignment = query({
 
     const poem = await ctx.db
       .query('poems')
-      .withIndex('by_room_index', (q) =>
-        q.eq('roomId', room._id).eq('indexInRoom', poemIndex)
+      .withIndex('by_room_game_index', (q) =>
+        q
+          .eq('roomId', room._id)
+          .eq('gameId', game._id)
+          .eq('indexInRoom', poemIndex)
       )
       .first();
     if (!poem) return null;

--- a/tests/convex/game.test.ts
+++ b/tests/convex/game.test.ts
@@ -102,6 +102,7 @@ async function seedCompletedRoom(
       code,
       hostUserId: hostId,
       status: 'COMPLETED',
+      currentCycle: 1,
       createdAt: 0,
     });
     await ctx.db.insert('roomPlayers', {
@@ -864,6 +865,165 @@ describe('getCurrentAssignment', () => {
     expect(result!.totalRounds).toBe(9);
     expect(result!.isFinalRound).toBe(false);
     expect(result!.previousLineText).toBe('one two');
+  });
+
+  it('stores every rematch submission in the active game poems', async () => {
+    const t = setupConvexTest();
+    const { code, roomId, gameId, hostId, guestId } = await seedCompletedRoom(
+      t,
+      'CA06'
+    );
+
+    const { oldPoemIds, oldPoemsBefore, oldLinesBefore } = await t.run(
+      async (ctx) => {
+        const poemIds = await Promise.all(
+          [0, 1].map((indexInRoom) =>
+            ctx.db.insert('poems', {
+              roomId,
+              gameId,
+              indexInRoom,
+              createdAt: 0,
+            })
+          )
+        );
+
+        await Promise.all(
+          poemIds.flatMap((poemId, poemIndex) =>
+            WORD_COUNTS.map((wordCount, lineIndex) =>
+              ctx.db.insert('lines', {
+                poemId,
+                indexInPoem: lineIndex,
+                text: Array.from(
+                  { length: wordCount },
+                  (_, wordIndex) => `old${poemIndex}${lineIndex}${wordIndex}`
+                ).join(' '),
+                wordCount,
+                authorUserId:
+                  (lineIndex + poemIndex) % 2 === 0 ? hostId : guestId,
+                createdAt: lineIndex,
+              })
+            )
+          )
+        );
+
+        const oldPoems = await Promise.all(
+          poemIds.map((poemId) => ctx.db.get(poemId))
+        );
+        const oldLines = await Promise.all(
+          poemIds.map((poemId) =>
+            ctx.db
+              .query('lines')
+              .withIndex('by_poem', (q) => q.eq('poemId', poemId))
+              .collect()
+          )
+        );
+
+        return {
+          oldPoemIds: poemIds,
+          oldPoemsBefore: oldPoems,
+          oldLinesBefore: oldLines,
+        };
+      }
+    );
+
+    await asUser(t, 'hostCA06').mutation(api.game.startGame, { code });
+
+    const activeGameId = await t.run(async (ctx) => {
+      const room = await ctx.db.get(roomId);
+      expect(room?.currentCycle).toBe(2);
+      return room!.currentGameId!;
+    });
+    const expectedTextByCell = new Map<string, string>();
+
+    for (let round = 0; round < WORD_COUNTS.length; round += 1) {
+      const [hostAssignment, guestAssignment] = await Promise.all([
+        asUser(t, 'hostCA06').query(api.game.getCurrentAssignment, {
+          roomCode: code,
+        }),
+        asUser(t, 'guestCA06').query(api.game.getCurrentAssignment, {
+          roomCode: code,
+        }),
+      ]);
+
+      expect(hostAssignment?.lineIndex).toBe(round);
+      expect(guestAssignment?.lineIndex).toBe(round);
+
+      const assignments = [
+        {
+          identity: 'hostCA06',
+          assignment: hostAssignment!,
+          prefix: 'host',
+        },
+        {
+          identity: 'guestCA06',
+          assignment: guestAssignment!,
+          prefix: 'guest',
+        },
+      ];
+
+      for (const { assignment } of assignments) {
+        const poem = await t.run((ctx) => ctx.db.get(assignment.poemId));
+        expect(poem?.gameId).toBe(activeGameId);
+      }
+
+      await Promise.all(
+        assignments.map(async ({ identity, assignment, prefix }) => {
+          const text = Array.from(
+            { length: WORD_COUNTS[round] },
+            (_, wordIndex) => `${prefix}${round}${wordIndex}`
+          ).join(' ');
+          expectedTextByCell.set(`${assignment.poemId}:${round}`, text);
+          await asUser(t, identity).mutation(api.game.submitLine, {
+            poemId: assignment.poemId,
+            lineIndex: round,
+            text,
+          });
+        })
+      );
+    }
+
+    const result = await t.run(async (ctx) => {
+      const [activeGame, activePoems, oldPoems, oldLines] = await Promise.all([
+        ctx.db.get(activeGameId),
+        ctx.db
+          .query('poems')
+          .withIndex('by_game', (q) => q.eq('gameId', activeGameId))
+          .collect(),
+        Promise.all(oldPoemIds.map((poemId) => ctx.db.get(poemId))),
+        Promise.all(
+          oldPoemIds.map((poemId) =>
+            ctx.db
+              .query('lines')
+              .withIndex('by_poem', (q) => q.eq('poemId', poemId))
+              .collect()
+          )
+        ),
+      ]);
+      const activeLines = await Promise.all(
+        activePoems.map(async (poem) => ({
+          poemId: poem._id,
+          lines: await ctx.db
+            .query('lines')
+            .withIndex('by_poem', (q) => q.eq('poemId', poem._id))
+            .collect(),
+        }))
+      );
+      return { activeGame, activeLines, oldPoems, oldLines };
+    });
+
+    expect(result.activeGame?.status).toBe('COMPLETED');
+    expect(result.oldPoems).toEqual(oldPoemsBefore);
+    expect(result.oldLines).toEqual(oldLinesBefore);
+    expect(result.activeLines.flatMap(({ lines }) => lines)).toHaveLength(
+      2 * WORD_COUNTS.length
+    );
+    for (const { poemId, lines } of result.activeLines) {
+      for (const line of lines) {
+        expect(line.text).toBe(
+          expectedTextByCell.get(`${poemId}:${line.indexInPoem}`)
+        );
+      }
+    }
   });
 });
 

--- a/tests/e2e/game-flow.spec.ts
+++ b/tests/e2e/game-flow.spec.ts
@@ -5,6 +5,18 @@ import {
   GuestFlowSession,
 } from '@/tests/e2e/support/guestFlow';
 
+const REMATCH_GUEST_FLOW_LINES = [
+  'rematch',
+  'fresh verse',
+  'new human lines',
+  'players write these words',
+  'second cycle keeps every word',
+  'mobile poets stay present',
+  'fresh lines remain',
+  'still human',
+  'preserved',
+] as const;
+
 /**
  * E2E Test: Complete Game Flow
  *
@@ -79,5 +91,11 @@ test.describe('Complete Game Flow', () => {
   test('complete 9-round game and reveal poems', async () => {
     await activeSession().playCanonicalGame(CANONICAL_GUEST_FLOW_LINES);
     await activeSession().revealAllPoems(CANONICAL_GUEST_FLOW_LINES);
+  });
+
+  test('play again completes a second game with its human lines intact', async () => {
+    await activeSession().startNextRound();
+    await activeSession().playCanonicalGame(REMATCH_GUEST_FLOW_LINES);
+    await activeSession().revealAllPoems(REMATCH_GUEST_FLOW_LINES);
   });
 });

--- a/tests/e2e/support/guestFlow.ts
+++ b/tests/e2e/support/guestFlow.ts
@@ -541,10 +541,11 @@ export class GuestFlowSession {
     const page = this.page(actor);
 
     await page.getByTestId(E2E_TEST_IDS.revealPoemButton).first().click();
-    await expect(page.getByText(lines[0])).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText(lines.at(-1) ?? '')).toBeVisible({
-      timeout: 12000,
-    });
+    for (const line of lines) {
+      await expect(page.getByText(line, { exact: true })).toBeVisible({
+        timeout: 12000,
+      });
+    }
     await page.getByTestId(E2E_TEST_IDS.poemDoneButton).click();
   }
 
@@ -561,6 +562,14 @@ export class GuestFlowSession {
     await expect(
       this.guestPage.getByTestId(E2E_TEST_IDS.sessionComplete)
     ).toBeVisible({ timeout: 15000 });
+  }
+
+  async startNextRound() {
+    await this.hostPage
+      .getByRole('button', { name: 'Start Next Round', exact: true })
+      .click();
+    await this.expectRound(1);
+    await this.expectWritingUi();
   }
 
   async capture(actor: Actor, path: string) {


### PR DESCRIPTION
## Summary

- scope `getCurrentAssignment` poem lookup to the room's active game, preventing rematches from resolving completed-cycle poems
- add a two-cycle Convex regression that submits all 18 human lines, verifies the second game completes with every exact line, and deep-compares the completed first game
- add a real Playwright `Start Next Round` journey that plays and reveals the full rematch, asserting all nine human lines in both poems

## Verification

- `pnpm ci:prepush` — 135 files passed; 1,474 tests passed; 1 skipped
- focused Convex red/green regression
- independent Cerberus review and follow-up: `/Users/phaedrus/.local/state/roster/receipts/20260715T021655.881Z-88458-cerberus.yaml`
- hosted merge gate and production smoke required before completion

Powder: `linejam-982`
