### PR TITLE
fix(reveal): recover from absent readers

### DIFF
--- a/components/RevealPhase.tsx
+++ b/components/RevealPhase.tsx
@@ -151,7 +151,9 @@ export function RevealPhase({
   const allStableIds = poems.map((p) => p.readerStableId);
 
   const displayingPoem = showingPoemId
-    ? myPoems?.find((p) => p._id === showingPoemId)
+    ? [...(myPoems ?? []), ...(state.revealedPoems ?? [])].find(
+        (poem) => poem._id === showingPoemId
+      )
     : null;
   const chrome = showChrome ? (
     <RoomChrome
@@ -239,9 +241,11 @@ export function RevealPhase({
                     <div>
                       <div className="flex items-center gap-3 mb-2">
                         <p className="text-xs font-mono uppercase tracking-widest text-primary">
-                          {poem.isForAi
-                            ? `Read for ${poem.aiPersonaName}`
-                            : 'Your Assignment'}
+                          {poem.isFallbackReader
+                            ? `Step in for ${poem.readerName}`
+                            : poem.isForAi
+                              ? `Read for ${poem.aiPersonaName}`
+                              : 'Your Assignment'}
                         </p>
                         {poem.isForAi && <BotBadge />}
                       </div>
@@ -259,7 +263,9 @@ export function RevealPhase({
                     >
                       {isRevealingId === poem._id
                         ? 'Unsealing...'
-                        : 'Reveal & Read'}
+                        : poem.isFallbackReader
+                          ? 'Step In & Read'
+                          : 'Reveal & Read'}
                     </Button>
                   </div>
                 ))}

--- a/components/stage/RevealStage.tsx
+++ b/components/stage/RevealStage.tsx
@@ -34,6 +34,7 @@ interface RevealStageReadablePoem extends RevealStagePoemSummary {
 interface RevealStageAssignedPoem extends RevealStageReadablePoem {
   isForAi?: boolean;
   aiPersonaName?: string;
+  isFallbackReader?: boolean;
 }
 
 interface RevealStageProps {
@@ -173,9 +174,11 @@ export function RevealStage({
               ) : readablePoem ? (
                 <div className="max-w-5xl space-y-5">
                   <p className="text-xs font-mono uppercase tracking-[0.28em] text-text-muted">
-                    {readableAssignedPoem
-                      ? 'Ready on this device'
-                      : 'Ready on stage'}
+                    {readableAssignedPoem?.isFallbackReader
+                      ? `Step in for ${readableAssignedPoem.readerName}`
+                      : readableAssignedPoem
+                        ? 'Ready on this device'
+                        : 'Ready on stage'}
                   </p>
                   <p className="font-[var(--font-display)] text-[clamp(2.25rem,5vw,5.5rem)] italic leading-[1.1] text-text-secondary">
                     &ldquo;{readablePoem.preview}...&rdquo;
@@ -227,9 +230,11 @@ export function RevealStage({
                 {readableAssignedPoem &&
                 isRevealingId === readableAssignedPoem._id
                   ? 'Unsealing...'
-                  : readableAssignedPoem
-                    ? 'Reveal on stage'
-                    : 'Read on stage'}
+                  : readableAssignedPoem?.isFallbackReader
+                    ? 'Step in on stage'
+                    : readableAssignedPoem
+                      ? 'Reveal on stage'
+                      : 'Read on stage'}
               </Button>
             ) : null}
           </div>

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -30,6 +30,10 @@ import {
   isRevealReady,
 } from './lib/sessionLifecycle';
 import { checkMutationAbuseRateLimit } from './lib/abuseRateLimit';
+import {
+  buildRevealParticipants,
+  selectRevealAuthority,
+} from './lib/revealAuthorization';
 
 const MAX_LINE_LENGTH = 500; // More than enough for 5 words
 
@@ -469,10 +473,21 @@ export const getRevealPhaseState = query({
     const userRecordById = new Map(
       players.map((p, i) => [p.userId, playerUserRecords[i]])
     );
+    const now = Date.now();
+    const revealParticipants = buildRevealParticipants(
+      players,
+      playerUserRecords
+    );
 
     // Get first line of each poem for preview
     const poemsWithPreview = await Promise.all(
       poems.map(async (poem) => {
+        const revealAuthority = selectRevealAuthority(
+          revealParticipants,
+          poem.assignedReaderId,
+          room.hostUserId,
+          now
+        );
         const firstLine = await ctx.db
           .query('lines')
           .withIndex('by_poem_index', (q) =>
@@ -499,13 +514,22 @@ export const getRevealPhaseState = query({
             '',
           revealedAt: poem.revealedAt,
           isRevealed: !!poem.revealedAt,
+          canReveal:
+            poem.assignedReaderId === user._id ||
+            revealAuthority?.userId === user._id,
+          isFallbackReader:
+            poem.assignedReaderId !== user._id &&
+            revealAuthority?.userId === user._id,
         };
       })
     );
 
-    // Find ALL poems assigned to current user (host may have multiple if AI reassigned)
+    // Full lines stay scoped to poems this device may reveal, plus the current
+    // user's already-revealed assignments for re-reading.
     const myPoemsRaw = poemsWithPreview.filter(
-      (p) => p.assignedReaderId === user._id
+      (poem) =>
+        (!poem.isRevealed && poem.canReveal) ||
+        (poem.isRevealed && poem.assignedReaderId === user._id)
     );
 
     // Find current user's seat
@@ -618,17 +642,47 @@ export const revealPoem = mutation({
     const poem = await ctx.db.get(poemId);
     if (!poem) throw new ConvexError('Poem not found');
 
-    if (poem.assignedReaderId !== user._id) {
-      throw new ConvexError('This poem is not assigned to you');
+    const [room, game, players] = await Promise.all([
+      ctx.db.get(poem.roomId),
+      ctx.db.get(poem.gameId),
+      ctx.db
+        .query('roomPlayers')
+        .withIndex('by_room', (q) => q.eq('roomId', poem.roomId))
+        .collect(),
+    ]);
+    if (!room) throw new ConvexError('Room not found');
+    if (!isRevealReady(game)) {
+      throw new ConvexError('Poem is not ready to reveal');
     }
 
+    const currentPlayer = players.find((player) => player.userId === user._id);
+    if (!currentPlayer) throw new ConvexError('Not a room participant');
+
     if (poem.revealedAt) {
-      throw new ConvexError('Poem already revealed');
+      return { revealed: false };
+    }
+
+    const playerUsers = await Promise.all(
+      players.map((player) => ctx.db.get(player.userId))
+    );
+    const revealAuthority = selectRevealAuthority(
+      buildRevealParticipants(players, playerUsers),
+      poem.assignedReaderId,
+      room.hostUserId,
+      Date.now()
+    );
+
+    if (
+      poem.assignedReaderId !== user._id &&
+      revealAuthority?.userId !== user._id
+    ) {
+      throw new ConvexError('This poem is not assigned to you');
     }
 
     await ctx.db.patch(poemId, {
       revealedAt: Date.now(),
     });
+    return { revealed: true };
   },
 });
 

--- a/convex/lib/revealAuthorization.ts
+++ b/convex/lib/revealAuthorization.ts
@@ -1,0 +1,69 @@
+import type { Doc, Id } from '../_generated/dataModel';
+import { PRESENCE_AWAY_MS, isPresenceStale } from './gameRules';
+import { selectNextHostId } from './room';
+
+export type RevealAuthorityReason =
+  'assigned-reader' | 'host-fallback' | 'participant-fallback';
+
+export interface RevealParticipant {
+  userId: Id<'users'>;
+  seatIndex?: number;
+  lastSeenAt?: number;
+  isHuman: boolean;
+}
+
+export interface RevealAuthority {
+  userId: Id<'users'>;
+  reason: RevealAuthorityReason;
+}
+
+export function buildRevealParticipants(
+  players: readonly Pick<
+    Doc<'roomPlayers'>,
+    'userId' | 'seatIndex' | 'lastSeenAt'
+  >[],
+  users: readonly (Pick<Doc<'users'>, 'kind'> | null)[]
+): RevealParticipant[] {
+  return players.map((player, index) => ({
+    userId: player.userId,
+    seatIndex: player.seatIndex,
+    lastSeenAt: player.lastSeenAt,
+    isHuman: users[index]?.kind !== 'AI',
+  }));
+}
+
+/**
+ * Select the one participant whose device may take over an unrevealed poem.
+ * A fresh assigned reader always wins. Once that reader is away, a fresh host
+ * wins; otherwise the lowest-seat fresh human is the deterministic fallback.
+ * No fresh humans means no authority until somebody returns and heartbeats.
+ */
+export function selectRevealAuthority(
+  participants: readonly RevealParticipant[],
+  assignedReaderId: Id<'users'> | undefined,
+  hostUserId: Id<'users'>,
+  now: number,
+  staleMs = PRESENCE_AWAY_MS
+): RevealAuthority | null {
+  const humans = participants.filter((participant) => participant.isHuman);
+  const assignedReader = humans.find(
+    (participant) => participant.userId === assignedReaderId
+  );
+
+  if (
+    assignedReader &&
+    !isPresenceStale(assignedReader.lastSeenAt, now, staleMs)
+  ) {
+    return { userId: assignedReader.userId, reason: 'assigned-reader' };
+  }
+
+  const host = humans.find((participant) => participant.userId === hostUserId);
+  if (host && !isPresenceStale(host.lastSeenAt, now, staleMs)) {
+    return { userId: host.userId, reason: 'host-fallback' };
+  }
+
+  const fallbackId = selectNextHostId(humans, now, staleMs);
+  return fallbackId
+    ? { userId: fallbackId, reason: 'participant-fallback' }
+    : null;
+}

--- a/tests/components/RevealPhase.test.tsx
+++ b/tests/components/RevealPhase.test.tsx
@@ -484,6 +484,38 @@ describe('RevealPhase component', () => {
     });
   });
 
+  it('makes an absent reader fallback explicit before revealing', async () => {
+    mockRevealPoemMutation.mockResolvedValue(undefined);
+    mockUseQuery.mockReturnValue({
+      ...mockStateNotRevealed,
+      myPoem: {
+        ...mockMyPoem,
+        readerName: 'Reader Away',
+        isFallbackReader: true,
+      },
+      myPoems: [
+        {
+          ...mockMyPoem,
+          readerName: 'Reader Away',
+          isFallbackReader: true,
+        },
+      ],
+    });
+    const user = userEvent.setup();
+
+    render(<RevealPhase roomCode="ABCD" />);
+
+    expect(screen.getByText('Step in for Reader Away')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Step In & Read' }));
+
+    await waitFor(() => {
+      expect(mockRevealPoemMutation).toHaveBeenCalledWith({
+        poemId: 'poem_123',
+        guestToken: 'mock-token',
+      });
+    });
+  });
+
   it('shows Unsealing... during reveal mutation', async () => {
     // Arrange - Make mutation take time
     mockRevealPoemMutation.mockImplementation(

--- a/tests/components/RevealStage.test.tsx
+++ b/tests/components/RevealStage.test.tsx
@@ -101,6 +101,38 @@ describe('RevealStage', () => {
     expect(screen.getByRole('button', { name: /Unsealing/i })).toBeDisabled();
   });
 
+  it('labels a fallback reveal without pretending the poem was reassigned', () => {
+    const onRevealPoem = vi.fn().mockResolvedValue(undefined);
+    const fallbackPoem = {
+      _id: 'poem_fallback' as Id<'poems'>,
+      indexInRoom: 0,
+      readerName: 'Reader Away',
+      readerStableId: 'stable_away',
+      preview: 'Someone keeps the circle moving',
+      isRevealed: false,
+      isFallbackReader: true,
+      lines: [{ text: 'Someone', authorName: 'Host' }],
+    };
+
+    render(
+      <RevealStage
+        poems={[fallbackPoem]}
+        myPoems={[fallbackPoem]}
+        revealedPoems={[]}
+        allStableIds={['stable_away']}
+        error={null}
+        isRevealingId={null}
+        onExit={vi.fn()}
+        onRevealPoem={onRevealPoem}
+      />
+    );
+
+    expect(screen.getByText('Step in for Reader Away')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Step in on stage' })
+    ).toBeInTheDocument();
+  });
+
   it('renders an empty stage state when no poems are ready', () => {
     render(
       <RevealStage

--- a/tests/convex/game.test.ts
+++ b/tests/convex/game.test.ts
@@ -18,6 +18,7 @@ import { type T, asUser, seedClerkUser, seedUser } from '../helpers/convexSeed';
 import {
   WORD_COUNTS,
   GHOSTWRITER_OVERTIME_MS,
+  PRESENCE_AWAY_MS,
 } from '../../convex/lib/gameRules';
 import { signGuestToken } from '../../lib/guestToken';
 import {
@@ -132,6 +133,86 @@ async function seedCompletedRoom(
       createdAt: 0,
     });
     return { roomId, gameId, hostId, guestId, code };
+  });
+}
+
+async function seedRevealFallbackRoom(
+  t: T,
+  suffix: string,
+  lastSeenAt: {
+    host: number;
+    reader: number;
+    fallback: number;
+  }
+): Promise<{
+  code: string;
+  poemId: Id<'poems'>;
+  hostId: Id<'users'>;
+  readerId: Id<'users'>;
+  fallbackId: Id<'users'>;
+}> {
+  const code = suffix
+    .toUpperCase()
+    .replace(/[^A-Z]/g, 'X')
+    .slice(0, 4);
+
+  return t.run(async (ctx) => {
+    const [hostId, readerId, fallbackId] = await Promise.all(
+      ['host', 'reader', 'fallback'].map((role) =>
+        ctx.db.insert('users', {
+          displayName: `${role}${suffix}`,
+          kind: 'human',
+          clerkUserId: `clerk_${role}${suffix}`,
+          createdAt: 0,
+        })
+      )
+    );
+    const roomId = await ctx.db.insert('rooms', {
+      code,
+      hostUserId: hostId,
+      status: 'COMPLETED',
+      createdAt: 0,
+    });
+
+    await Promise.all(
+      [
+        { userId: hostId, role: 'host' as const, seatIndex: 0 },
+        { userId: readerId, role: 'reader' as const, seatIndex: 1 },
+        { userId: fallbackId, role: 'fallback' as const, seatIndex: 2 },
+      ].map(({ userId, role, seatIndex }) =>
+        ctx.db.insert('roomPlayers', {
+          roomId,
+          userId,
+          displayName: `${role}${suffix}`,
+          seatIndex,
+          joinedAt: 0,
+          lastSeenAt: lastSeenAt[role],
+        })
+      )
+    );
+
+    const gameId = await ctx.db.insert('games', {
+      roomId,
+      status: 'COMPLETED',
+      cycle: 1,
+      currentRound: WORD_COUNTS.length - 1,
+      assignmentMatrix: Array.from({ length: WORD_COUNTS.length }, () => [
+        hostId,
+        readerId,
+        fallbackId,
+      ]),
+      createdAt: 0,
+      completedAt: 1,
+    });
+    const poemId = await ctx.db.insert('poems', {
+      roomId,
+      gameId,
+      indexInRoom: 0,
+      createdAt: 0,
+      assignedReaderId: readerId,
+    });
+
+    return { code, poemId, hostId, readerId, fallbackId };
   });
 }
 
@@ -1467,6 +1548,62 @@ describe('getRevealPhaseState', () => {
     expect(result!.myPoem!.lines).toBeDefined();
   });
 
+  it('exposes a stale-reader poem only to the deterministic fallback device', async () => {
+    const t = setupConvexTest();
+    const now = Date.now();
+    const stale = now - PRESENCE_AWAY_MS - 1;
+    const { code, poemId, readerId } = await seedRevealFallbackRoom(t, 'RV08', {
+      host: now,
+      reader: stale,
+      fallback: now,
+    });
+    await t.run((ctx) =>
+      ctx.db.insert('lines', {
+        poemId,
+        indexInPoem: 0,
+        text: 'opening',
+        wordCount: 1,
+        authorUserId: readerId,
+        createdAt: 0,
+      })
+    );
+
+    const [hostState, fallbackState] = await Promise.all([
+      asUser(t, 'hostRV08').query(api.game.getRevealPhaseState, {
+        roomCode: code,
+      }),
+      asUser(t, 'fallbackRV08').query(api.game.getRevealPhaseState, {
+        roomCode: code,
+      }),
+    ]);
+
+    expect(hostState?.myPoem).toMatchObject({
+      _id: poemId,
+      canReveal: true,
+      isFallbackReader: true,
+      readerName: 'readerRV08',
+    });
+    expect(hostState?.myPoem?.lines.map((line) => line.text)).toEqual([
+      'opening',
+    ]);
+    expect(fallbackState?.myPoem).toBeNull();
+    expect(fallbackState?.poems[0]).toMatchObject({
+      _id: poemId,
+      canReveal: false,
+      isFallbackReader: false,
+    });
+
+    await asUser(t, 'hostRV08').mutation(api.game.revealPoem, { poemId });
+    const hostStateAfterReveal = await asUser(t, 'hostRV08').query(
+      api.game.getRevealPhaseState,
+      { roomCode: code }
+    );
+    expect(hostStateAfterReveal?.myPoem).toBeNull();
+    expect(hostStateAfterReveal?.revealedPoems).toEqual([
+      expect.objectContaining({ _id: poemId, isRevealed: true }),
+    ]);
+  });
+
   it('returns full lines for revealed poems without leaking unrevealed poems', async () => {
     const t = setupConvexTest();
     const { code, hostId, guestId, gameId, roomId } = await seedCompletedRoom(
@@ -1556,6 +1693,33 @@ describe('getRevealPhaseState', () => {
 // ─── revealPoem ───────────────────────────────────────────────────────────────
 
 describe('revealPoem', () => {
+  it('rejects fallback reveal attempts before the game is complete', async () => {
+    const t = setupConvexTest();
+    const { poemIds, roomId, userIds } = await seedInProgressGame(t, {
+      code: 'RP00',
+      players: [
+        { name: 'Host', clerkUserId: 'clerk_hostRP00' },
+        { name: 'Guest', clerkUserId: 'clerk_guestRP00' },
+      ],
+    });
+    await t.run(async (ctx) => {
+      const hostPlayer = await ctx.db
+        .query('roomPlayers')
+        .withIndex('by_room_user', (q) =>
+          q.eq('roomId', roomId).eq('userId', userIds[0])
+        )
+        .unique();
+      if (!hostPlayer) throw new Error('Seeded host player missing');
+      await ctx.db.patch(hostPlayer._id, { lastSeenAt: Date.now() });
+    });
+
+    await expect(
+      asUser(t, 'hostRP00').mutation(api.game.revealPoem, {
+        poemId: poemIds[0],
+      })
+    ).rejects.toThrow('Poem is not ready to reveal');
+  });
+
   it('reveals poem successfully — sets revealedAt timestamp', async () => {
     const t = setupConvexTest();
     const { hostId, gameId, roomId } = await seedCompletedRoom(t, 'RP01');
@@ -1641,7 +1805,7 @@ describe('revealPoem', () => {
     ).rejects.toThrow('This poem is not assigned to you');
   });
 
-  it('throws if poem already revealed', async () => {
+  it('treats an already revealed poem as an idempotent success', async () => {
     const t = setupConvexTest();
     const { hostId, gameId, roomId } = await seedCompletedRoom(t, 'RP05');
 
@@ -1658,7 +1822,64 @@ describe('revealPoem', () => {
 
     await expect(
       asUser(t, 'hostRP05').mutation(api.game.revealPoem, { poemId })
-    ).rejects.toThrow('Poem already revealed');
+    ).resolves.toEqual({ revealed: false });
+  });
+
+  it('keeps reveal agency exclusive to a present assigned reader', async () => {
+    const t = setupConvexTest();
+    const now = Date.now();
+    const { poemId } = await seedRevealFallbackRoom(t, 'RP06', {
+      host: now,
+      reader: now,
+      fallback: now,
+    });
+
+    await expect(
+      asUser(t, 'hostRP06').mutation(api.game.revealPoem, { poemId })
+    ).rejects.toThrow('This poem is not assigned to you');
+  });
+
+  it('lets the present host reveal for a stale reader idempotently', async () => {
+    const t = setupConvexTest();
+    const now = Date.now();
+    const stale = now - PRESENCE_AWAY_MS - 1;
+    const { poemId } = await seedRevealFallbackRoom(t, 'RP07', {
+      host: now,
+      reader: stale,
+      fallback: now,
+    });
+
+    await expect(
+      asUser(t, 'hostRP07').mutation(api.game.revealPoem, { poemId })
+    ).resolves.toEqual({ revealed: true });
+    await expect(
+      asUser(t, 'hostRP07').mutation(api.game.revealPoem, { poemId })
+    ).resolves.toEqual({ revealed: false });
+
+    const poem = await t.run((ctx) => ctx.db.get(poemId));
+    expect(poem?.revealedAt).toBeDefined();
+  });
+
+  it('becomes recoverable when one participant returns to an empty reveal', async () => {
+    const t = setupConvexTest();
+    const stale = Date.now() - PRESENCE_AWAY_MS - 1;
+    const { code, poemId } = await seedRevealFallbackRoom(t, 'RP08', {
+      host: stale,
+      reader: stale,
+      fallback: stale,
+    });
+
+    await expect(
+      asUser(t, 'fallbackRP08').mutation(api.game.revealPoem, { poemId })
+    ).rejects.toThrow('This poem is not assigned to you');
+
+    await asUser(t, 'fallbackRP08').mutation(api.presence.heartbeat, {
+      roomCode: code,
+    });
+
+    await expect(
+      asUser(t, 'fallbackRP08').mutation(api.game.revealPoem, { poemId })
+    ).resolves.toEqual({ revealed: true });
   });
 });
 

--- a/tests/convex/lib/revealAuthorization.test.ts
+++ b/tests/convex/lib/revealAuthorization.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import type { Id } from '../../../convex/_generated/dataModel';
+import { PRESENCE_AWAY_MS } from '../../../convex/lib/gameRules';
+import { selectRevealAuthority } from '../../../convex/lib/revealAuthorization';
+
+const userId = (value: string) => value as Id<'users'>;
+const now = 1_000_000;
+const fresh = now;
+const stale = now - PRESENCE_AWAY_MS - 1;
+
+describe('selectRevealAuthority', () => {
+  it('keeps a fresh assigned reader in control', () => {
+    expect(
+      selectRevealAuthority(
+        [
+          {
+            userId: userId('host'),
+            seatIndex: 0,
+            lastSeenAt: fresh,
+            isHuman: true,
+          },
+          {
+            userId: userId('reader'),
+            seatIndex: 1,
+            lastSeenAt: fresh,
+            isHuman: true,
+          },
+        ],
+        userId('reader'),
+        userId('host'),
+        now
+      )
+    ).toEqual({ userId: userId('reader'), reason: 'assigned-reader' });
+  });
+
+  it('gives a fresh host first fallback when the reader is stale', () => {
+    expect(
+      selectRevealAuthority(
+        [
+          {
+            userId: userId('host'),
+            seatIndex: 2,
+            lastSeenAt: fresh,
+            isHuman: true,
+          },
+          {
+            userId: userId('reader'),
+            seatIndex: 0,
+            lastSeenAt: stale,
+            isHuman: true,
+          },
+          {
+            userId: userId('other'),
+            seatIndex: 1,
+            lastSeenAt: fresh,
+            isHuman: true,
+          },
+        ],
+        userId('reader'),
+        userId('host'),
+        now
+      )
+    ).toEqual({ userId: userId('host'), reason: 'host-fallback' });
+  });
+
+  it('chooses the lowest-seat fresh human when reader and host are stale', () => {
+    expect(
+      selectRevealAuthority(
+        [
+          {
+            userId: userId('host'),
+            seatIndex: 0,
+            lastSeenAt: stale,
+            isHuman: true,
+          },
+          {
+            userId: userId('reader'),
+            seatIndex: 1,
+            lastSeenAt: stale,
+            isHuman: true,
+          },
+          {
+            userId: userId('later'),
+            seatIndex: 3,
+            lastSeenAt: fresh,
+            isHuman: true,
+          },
+          {
+            userId: userId('winner'),
+            seatIndex: 2,
+            lastSeenAt: fresh,
+            isHuman: true,
+          },
+          {
+            userId: userId('bot'),
+            seatIndex: -1,
+            lastSeenAt: fresh,
+            isHuman: false,
+          },
+        ],
+        userId('reader'),
+        userId('host'),
+        now
+      )
+    ).toEqual({
+      userId: userId('winner'),
+      reason: 'participant-fallback',
+    });
+  });
+
+  it('waits when every human is stale', () => {
+    expect(
+      selectRevealAuthority(
+        [
+          {
+            userId: userId('host'),
+            seatIndex: 0,
+            lastSeenAt: stale,
+            isHuman: true,
+          },
+          {
+            userId: userId('reader'),
+            seatIndex: 1,
+            lastSeenAt: stale,
+            isHuman: true,
+          },
+        ],
+        userId('reader'),
+        userId('host'),
+        now
+      )
+    ).toBeNull();
+  });
+});

--- a/tests/e2e/reveal-reader-leaver.spec.ts
+++ b/tests/e2e/reveal-reader-leaver.spec.ts
@@ -1,0 +1,162 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+
+import { PRESENCE_AWAY_MS } from '@/convex/lib/gameRules';
+import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
+import {
+  CANONICAL_GUEST_FLOW_LINES,
+  isolateGuestSessionIp,
+} from '@/tests/e2e/support/guestFlow';
+
+test.describe.configure({ mode: 'serial' });
+
+const missingGuestTokenSecret =
+  !process.env.GUEST_TOKEN_SECRET && !process.env.E2E_BASE_URL;
+test.skip(
+  missingGuestTokenSecret,
+  'Set GUEST_TOKEN_SECRET for local E2E, or E2E_BASE_URL for a remote target'
+);
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+
+function visibleTestId(page: Page, testId: string) {
+  return page.getByTestId(testId).filter({ visible: true });
+}
+
+async function createRoom(page: Page, hostName: string) {
+  await page.goto('/host');
+  await visibleTestId(page, E2E_TEST_IDS.hostNameInput).fill(hostName);
+  await visibleTestId(page, E2E_TEST_IDS.hostCreateRoomButton).click();
+  await page.waitForURL(/\/room\/[A-Z]{4}$/);
+
+  const roomCode = new URL(page.url()).pathname.split('/').pop() ?? '';
+  expect(roomCode).toMatch(/^[A-Z]{4}$/);
+  return roomCode;
+}
+
+async function joinRoom(page: Page, roomCode: string, name: string) {
+  await page.goto(`/join?code=${roomCode}`);
+  await visibleTestId(page, E2E_TEST_IDS.joinNameInput).fill(name);
+  await visibleTestId(page, E2E_TEST_IDS.joinRoomButton).click();
+  await page.waitForURL(`/room/${roomCode}`);
+}
+
+async function submitLine(page: Page, line: string) {
+  await visibleTestId(page, E2E_TEST_IDS.writingLineInput).fill(line);
+  await visibleTestId(page, E2E_TEST_IDS.writingSubmitLineButton).click();
+}
+
+async function revealAssignedPoem(page: Page) {
+  await visibleTestId(page, E2E_TEST_IDS.revealPoemButton).click();
+  await expect(visibleTestId(page, E2E_TEST_IDS.poemDoneButton)).toBeVisible();
+  await visibleTestId(page, E2E_TEST_IDS.poemDoneButton).click();
+}
+
+test('three-player reveal survives an assigned reader disconnect on mobile', async ({
+  browser,
+}, testInfo) => {
+  test.setTimeout(240_000);
+
+  const contexts: BrowserContext[] = [];
+  let departedContext: BrowserContext | null = null;
+
+  try {
+    const [hostContext, presentReaderContext, departedReaderContext] =
+      await Promise.all(
+        Array.from({ length: 3 }, () =>
+          browser.newContext({ viewport: MOBILE_VIEWPORT })
+        )
+      );
+    contexts.push(hostContext, presentReaderContext);
+    departedContext = departedReaderContext;
+
+    await Promise.all([
+      isolateGuestSessionIp(hostContext),
+      isolateGuestSessionIp(presentReaderContext),
+      isolateGuestSessionIp(departedReaderContext),
+    ]);
+
+    const [hostPage, presentReaderPage, departedReaderPage] = await Promise.all(
+      [
+        hostContext.newPage(),
+        presentReaderContext.newPage(),
+        departedReaderContext.newPage(),
+      ]
+    );
+
+    const roomCode = await createRoom(hostPage, 'Reveal Host');
+    await joinRoom(presentReaderPage, roomCode, 'Reader Here');
+    await joinRoom(departedReaderPage, roomCode, 'Reader Away');
+
+    await expect(
+      hostPage.getByText('Reader Away', { exact: true })
+    ).toBeVisible();
+    await visibleTestId(hostPage, E2E_TEST_IDS.lobbyStartGameButton).click();
+
+    for (
+      let roundIndex = 0;
+      roundIndex < CANONICAL_GUEST_FLOW_LINES.length;
+      roundIndex += 1
+    ) {
+      const line = CANONICAL_GUEST_FLOW_LINES[roundIndex];
+      await Promise.all([
+        submitLine(hostPage, line),
+        submitLine(presentReaderPage, line),
+        submitLine(departedReaderPage, line),
+      ]);
+
+      if (roundIndex < CANONICAL_GUEST_FLOW_LINES.length - 1) {
+        await expect(
+          visibleTestId(hostPage, E2E_TEST_IDS.writingPhase)
+        ).toHaveAttribute('data-round', String(roundIndex + 2), {
+          timeout: 15_000,
+        });
+      }
+    }
+
+    await Promise.all(
+      [hostPage, presentReaderPage, departedReaderPage].map((page) =>
+        expect(visibleTestId(page, E2E_TEST_IDS.revealPoemButton)).toBeVisible({
+          timeout: 30_000,
+        })
+      )
+    );
+
+    await departedReaderContext.close();
+    departedContext = null;
+
+    await revealAssignedPoem(hostPage);
+    await revealAssignedPoem(presentReaderPage);
+
+    const fallbackButton = visibleTestId(
+      hostPage,
+      E2E_TEST_IDS.revealPoemButton
+    );
+    await expect(fallbackButton).toBeVisible({
+      timeout: PRESENCE_AWAY_MS + 30_000,
+    });
+    await expect(fallbackButton).toHaveAccessibleName('Step In & Read');
+    await expect(hostPage.getByText('Step in for Reader Away')).toBeVisible();
+
+    await hostPage.screenshot({
+      path: testInfo.outputPath('reveal-reader-fallback-mobile.png'),
+      fullPage: true,
+    });
+
+    await fallbackButton.click();
+    await expect(
+      visibleTestId(hostPage, E2E_TEST_IDS.poemDoneButton)
+    ).toBeVisible();
+    await visibleTestId(hostPage, E2E_TEST_IDS.poemDoneButton).click();
+
+    await Promise.all(
+      [hostPage, presentReaderPage].map((page) =>
+        expect(visibleTestId(page, E2E_TEST_IDS.sessionComplete)).toBeVisible({
+          timeout: 15_000,
+        })
+      )
+    );
+  } finally {
+    await departedContext?.close();
+    await Promise.allSettled(contexts.map((context) => context.close()));
+  }
+});


### PR DESCRIPTION
## Summary
- keep a present assigned reader exclusive, then grant deterministic fallback to a fresh host or lowest-seat fresh human
- make retries idempotent and forbid reveal before the game is complete
- explain fallback agency in both reveal surfaces and preserve content across live query updates
- add policy, Convex integration, component, and three-player 390x844 browser coverage

## Verification
- pnpm ci:prepush (136 files; 1485 passed, 1 skipped)
- guarded shared-dev Convex sync plus fresh function-spec
- production-mode Next build check
- reveal-reader-leaver Playwright: 3 real mobile contexts, 9 rounds, real 45s presence timeout, session complete (1.2m)
- independent Solomon review; high-severity pre-completion authorization finding fixed and regression-tested

Powder: linejam-964

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added fallback reveal support when an assigned reader is unavailable.
  - The host or another eligible participant can step in to reveal the poem.
  - Reveal prompts now identify the absent reader and display “Step In & Read” or “Step in on stage.”
  - Fallback selection considers participant presence and chooses an eligible available participant.

- **Bug Fixes**
  - Improved reveal permissions and handling for already-revealed poems.
  - Returning participants can regain reveal access after reconnecting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->