### PR TITLE
fix(infra): reconcile Convex environment drift

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,9 @@ NEXT_PUBLIC_CONVEX_URL=
 
 # Convex Deploy Key (optional mirror for hosted CI - never commit real values)
 CONVEX_DEPLOY_KEY=
-# Set to production on the DigitalOcean web component so a missing or
-# mismatched deploy key fails closed before the frontend build.
-LINEJAM_DEPLOY_ENVIRONMENT=
+# Local/shared development must declare development. Set to production on the
+# DigitalOcean web component so a missing or mismatched marker fails closed.
+LINEJAM_DEPLOY_ENVIRONMENT=development
 
 # Clerk Authentication
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Compact router for repository agents. Read only the depth your lane needs.
 | Tests and QA                    | `docs/testing.md`, `vitest.config.ts`, Playwright configs    |
 | CI and live-operation authority | `docs/ops/observability-ci.md`, `scripts/ci/dagger-call.sh`  |
 | Production operations           | `docs/deployment.md`                                         |
+| Convex environment contract     | `config/convex-env-manifest.json`                            |
 | Agent CLI/MCP                   | `.agents/skills/linejam-cli/SKILL.md`, `docs/agent-faces.md` |
 
 The live stack is declared in `package.json`; do not copy dependency versions
@@ -45,7 +46,9 @@ or test counts into agent prose.
   and provider mutations require explicit live authority for that operation.
   Keep production guards enabled; a flag is a safety condition, not authority.
 - Never print, paste, commit, or persist credentials. Avoid value-bearing env
-  listings; prefer metadata and names-only probes.
+  listings. Use `pnpm convex:env:reconcile` for development or
+  `node scripts/ci/reconcile-convex-env.mjs --target production` for a bounded,
+  values-free production readback.
 
 ## Engineering invariants
 

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,6 +1,7 @@
 import { ConvexHttpClient } from 'convex/browser';
 import { api } from '@/convex/_generated/api';
 import type { ConvexEnvHealthReport } from '@/convex/lib/env';
+import { signGuestSessionThrottleProof } from '@/lib/guestSessionThrottleProof';
 import {
   captureCanaryException,
   isCanaryEnabled,
@@ -8,17 +9,25 @@ import {
 } from '@/lib/canaryServer';
 import { log, logError, logRequest } from '@/lib/logger';
 
-const CONVEX_HEALTH_TIMEOUT_MS = 1_500;
+const CONVEX_HEALTH_TIMEOUT_MS = 3_000;
 const ROUTE = '/api/health';
+const GUEST_PARITY_KEY = 'guestSession:deployment-readiness';
 
 export async function GET() {
   const startedAt = Date.now();
 
   try {
-    const { status: convexStatus, report: convexEnv } = await checkConvex();
-    const envChecks = checkEnvVars();
+    const {
+      status: convexStatus,
+      report: convexEnv,
+      guestTokenParity,
+      deploymentMatch,
+    } = await checkConvex();
+    const envChecks = checkEnvVars(guestTokenParity, deploymentMatch);
     const serviceHealthy =
       envChecks.guestTokenSecret &&
+      envChecks.guestTokenParity &&
+      envChecks.convexDeploymentMatch &&
       envChecks.convexUrl &&
       convexStatus === 'connected' &&
       convexEnv?.ok === true;
@@ -74,9 +83,14 @@ export async function GET() {
  * Check presence of critical environment variables.
  * Does not expose actual values, only boolean presence.
  */
-function checkEnvVars() {
+function checkEnvVars(
+  guestTokenParity: boolean,
+  convexDeploymentMatch: boolean
+) {
   return {
     guestTokenSecret: !!process.env.GUEST_TOKEN_SECRET,
+    guestTokenParity,
+    convexDeploymentMatch,
     convexUrl: !!process.env.NEXT_PUBLIC_CONVEX_URL,
     clerkPublishableKey: !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
     canaryIngestKey: isCanaryEnabled(),
@@ -86,6 +100,8 @@ function checkEnvVars() {
 type ConvexHealth = {
   status: 'connected' | 'unreachable' | 'skipped';
   report: ConvexEnvHealthReport | null;
+  guestTokenParity: boolean;
+  deploymentMatch: boolean;
 };
 
 /**
@@ -97,14 +113,24 @@ type ConvexHealth = {
  */
 async function checkConvex(): Promise<ConvexHealth> {
   const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
-  if (!convexUrl) return { status: 'skipped', report: null };
+  if (!convexUrl) {
+    return {
+      status: 'skipped',
+      report: null,
+      guestTokenParity: false,
+      deploymentMatch: false,
+    };
+  }
 
   const startedAt = Date.now();
 
   try {
     const client = new ConvexHttpClient(convexUrl);
-    const report = (await Promise.race([
-      client.query(api.health.capabilities),
+    const [report, guestTokenParity] = (await Promise.race([
+      Promise.all([
+        client.query(api.health.capabilities),
+        checkGuestTokenParity(client),
+      ]),
       new Promise<never>((_, reject) => {
         setTimeout(() => {
           reject(
@@ -114,8 +140,13 @@ async function checkConvex(): Promise<ConvexHealth> {
           );
         }, CONVEX_HEALTH_TIMEOUT_MS);
       }),
-    ])) as ConvexEnvHealthReport;
-    return { status: 'connected', report };
+    ])) as [ConvexEnvHealthReport, boolean];
+    return {
+      status: 'connected',
+      report,
+      guestTokenParity,
+      deploymentMatch: deploymentMatchesWebTarget(convexUrl, report),
+    };
   } catch (error) {
     log.warn('Convex health ping failed; marking unreachable', {
       method: 'GET',
@@ -125,7 +156,57 @@ async function checkConvex(): Promise<ConvexHealth> {
       errorName: error instanceof Error ? error.name : 'UnknownError',
       errorMessage: error instanceof Error ? error.message : String(error),
     });
-    return { status: 'unreachable', report: null };
+    return {
+      status: 'unreachable',
+      report: null,
+      guestTokenParity: false,
+      deploymentMatch: false,
+    };
+  }
+}
+
+function deploymentMatchesWebTarget(
+  convexUrl: string,
+  report: ConvexEnvHealthReport
+) {
+  const declared = process.env.LINEJAM_DEPLOY_ENVIRONMENT?.trim();
+  const expectedEnvironment =
+    declared === 'production' || declared === 'preview'
+      ? declared
+      : 'development';
+
+  try {
+    return (
+      report.deployment.markerValid &&
+      report.environment === expectedEnvironment &&
+      report.deployment.url !== null &&
+      new URL(report.deployment.url).origin === new URL(convexUrl).origin
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function checkGuestTokenParity(client: ConvexHttpClient) {
+  const secret = process.env.GUEST_TOKEN_SECRET?.trim();
+  if (!secret) return false;
+
+  try {
+    const proof = await signGuestSessionThrottleProof(GUEST_PARITY_KEY, secret);
+    await client.mutation(api.guestSessions.checkSignedGuestSessionThrottle, {
+      key: GUEST_PARITY_KEY,
+      proof,
+      dryRun: true,
+    });
+    return true;
+  } catch (error) {
+    log.warn('Guest token parity probe failed; marking unhealthy', {
+      method: 'GET',
+      route: ROUTE,
+      operation: 'guestTokenParity',
+      errorName: error instanceof Error ? error.name : 'UnknownError',
+    });
+    return false;
   }
 }
 

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -170,10 +170,14 @@ function deploymentMatchesWebTarget(
   report: ConvexEnvHealthReport
 ) {
   const declared = process.env.LINEJAM_DEPLOY_ENVIRONMENT?.trim();
-  const expectedEnvironment =
-    declared === 'production' || declared === 'preview'
-      ? declared
-      : 'development';
+  if (
+    declared !== 'production' &&
+    declared !== 'preview' &&
+    declared !== 'development'
+  ) {
+    return false;
+  }
+  const expectedEnvironment = declared;
 
   try {
     return (

--- a/config/convex-env-manifest.json
+++ b/config/convex-env-manifest.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": 1,
+  "environments": {
+    "development": {
+      "required": [],
+      "optional": [
+        "AI_DAILY_CALL_ALERT_THRESHOLD",
+        "AI_DAILY_CALL_BUDGET",
+        "AI_DAILY_COST_BUDGET_USD",
+        "AI_ESTIMATED_COST_PER_GENERATION_USD",
+        "AI_MODEL",
+        "CANARY_API_KEY",
+        "CANARY_ENDPOINT",
+        "CLERK_JWT_ISSUER_DOMAIN",
+        "GUEST_TOKEN_SECRET",
+        "LINEJAM_DEPLOY_ENVIRONMENT",
+        "MAX_AI_PLAYERS",
+        "OPENROUTER_API_KEY"
+      ]
+    },
+    "preview": {
+      "required": [
+        "CANARY_API_KEY",
+        "CANARY_ENDPOINT",
+        "CLERK_JWT_ISSUER_DOMAIN",
+        "GUEST_TOKEN_SECRET",
+        "LINEJAM_DEPLOY_ENVIRONMENT",
+        "OPENROUTER_API_KEY"
+      ],
+      "optional": [
+        "AI_DAILY_CALL_ALERT_THRESHOLD",
+        "AI_DAILY_CALL_BUDGET",
+        "AI_DAILY_COST_BUDGET_USD",
+        "AI_ESTIMATED_COST_PER_GENERATION_USD",
+        "AI_MODEL",
+        "MAX_AI_PLAYERS"
+      ]
+    },
+    "production": {
+      "required": [
+        "CANARY_API_KEY",
+        "CANARY_ENDPOINT",
+        "CLERK_JWT_ISSUER_DOMAIN",
+        "GUEST_TOKEN_SECRET",
+        "LINEJAM_DEPLOY_ENVIRONMENT",
+        "OPENROUTER_API_KEY"
+      ],
+      "optional": [
+        "AI_DAILY_CALL_ALERT_THRESHOLD",
+        "AI_DAILY_CALL_BUDGET",
+        "AI_DAILY_COST_BUDGET_USD",
+        "AI_ESTIMATED_COST_PER_GENERATION_USD",
+        "AI_MODEL",
+        "MAX_AI_PLAYERS"
+      ]
+    }
+  }
+}

--- a/convex/lib/env.ts
+++ b/convex/lib/env.ts
@@ -1,6 +1,7 @@
 import { log } from './errors';
+import convexEnvManifest from '../../config/convex-env-manifest.json';
 
-type ConvexEnvironment = 'production' | 'development';
+type ConvexEnvironment = 'production' | 'preview' | 'development';
 type CapabilityStatus = 'ready' | 'disabled' | 'missing_required';
 
 type ConvexCapabilityHealth = {
@@ -11,21 +12,30 @@ type ConvexCapabilityHealth = {
 
 export type ConvexRuntimeConfig = {
   environment: ConvexEnvironment;
+  deploymentMarkerValid: boolean;
+  deploymentUrl?: string;
   guestTokenSecret?: string;
   openRouterApiKey?: string;
+  requiredEnvironmentVariables: Readonly<Record<string, boolean>>;
 };
 
 export type ConvexEnvHealthReport = {
   ok: boolean;
   status: 200 | 500;
   environment: ConvexEnvironment;
+  deployment: {
+    markerValid: boolean;
+    url: string | null;
+  };
   capabilities: {
     guestTokenVerification: ConvexCapabilityHealth;
     aiLineGeneration: ConvexCapabilityHealth;
   };
+  configuration: {
+    missingRequired: string[];
+  };
 };
 
-const CONVEX_PRODUCTION_HOST = 'convex.cloud';
 const DEV_GUEST_TOKEN_SECRET = 'dev-only-insecure-secret-change-in-production';
 
 function readEnv(name: string): string | undefined {
@@ -33,17 +43,44 @@ function readEnv(name: string): string | undefined {
   return value ? value : undefined;
 }
 
-function readEnvironment(): ConvexEnvironment {
-  return readEnv('CONVEX_CLOUD_URL')?.includes(CONVEX_PRODUCTION_HOST)
-    ? 'production'
-    : 'development';
+function readEnvironment(): {
+  environment: ConvexEnvironment;
+  markerValid: boolean;
+} {
+  const declared = readEnv('LINEJAM_DEPLOY_ENVIRONMENT');
+  if (!declared) {
+    return {
+      environment: 'development',
+      markerValid: !readEnv('CONVEX_CLOUD_URL'),
+    };
+  }
+  if (
+    declared === 'production' ||
+    declared === 'preview' ||
+    declared === 'development'
+  ) {
+    return { environment: declared, markerValid: true };
+  }
+  return { environment: 'development', markerValid: false };
 }
 
 function loadConvexRuntimeConfig(): ConvexRuntimeConfig {
+  const { environment, markerValid: deploymentMarkerValid } = readEnvironment();
+  const manifestEnvironment = environment;
+  const requiredEnvironmentVariables = Object.fromEntries(
+    convexEnvManifest.environments[manifestEnvironment].required.map((name) => [
+      name,
+      Boolean(readEnv(name)),
+    ])
+  );
+
   return {
-    environment: readEnvironment(),
+    environment,
+    deploymentMarkerValid,
+    deploymentUrl: readEnv('CONVEX_CLOUD_URL'),
     guestTokenSecret: readEnv('GUEST_TOKEN_SECRET'),
     openRouterApiKey: readEnv('OPENROUTER_API_KEY'),
+    requiredEnvironmentVariables: Object.freeze(requiredEnvironmentVariables),
   };
 }
 
@@ -65,7 +102,7 @@ function evaluateCapability(
 const convexRuntimeConfig = Object.freeze(loadConvexRuntimeConfig());
 
 if (
-  convexRuntimeConfig.environment === 'production' &&
+  convexRuntimeConfig.environment !== 'development' &&
   !convexRuntimeConfig.openRouterApiKey
 ) {
   log.error('OPENROUTER_API_KEY not configured at module load', {
@@ -82,7 +119,10 @@ export function getConvexGuestTokenSecret(): string {
     return convexRuntimeConfig.guestTokenSecret;
   }
 
-  if (convexRuntimeConfig.environment === 'production') {
+  if (
+    convexRuntimeConfig.environment !== 'development' ||
+    convexRuntimeConfig.deploymentUrl
+  ) {
     throw new Error(
       'GUEST_TOKEN_SECRET must be set in Convex environment. ' +
         'Run: npx convex env set GUEST_TOKEN_SECRET "your-secret" production'
@@ -93,7 +133,7 @@ export function getConvexGuestTokenSecret(): string {
 }
 
 export function getConvexEnvHealthReport(): ConvexEnvHealthReport {
-  const required = convexRuntimeConfig.environment === 'production';
+  const required = convexRuntimeConfig.environment !== 'development';
   const guestTokenVerification = evaluateCapability(
     Boolean(convexRuntimeConfig.guestTokenSecret),
     required
@@ -102,7 +142,15 @@ export function getConvexEnvHealthReport(): ConvexEnvHealthReport {
     Boolean(convexRuntimeConfig.openRouterApiKey),
     required
   );
+  const missingRequired = Object.entries(
+    convexRuntimeConfig.requiredEnvironmentVariables
+  )
+    .filter(([, available]) => !available)
+    .map(([name]) => name)
+    .sort();
   const ok =
+    convexRuntimeConfig.deploymentMarkerValid &&
+    missingRequired.length === 0 &&
     guestTokenVerification.status !== 'missing_required' &&
     aiLineGeneration.status !== 'missing_required';
 
@@ -110,9 +158,16 @@ export function getConvexEnvHealthReport(): ConvexEnvHealthReport {
     ok,
     status: ok ? 200 : 500,
     environment: convexRuntimeConfig.environment,
+    deployment: {
+      markerValid: convexRuntimeConfig.deploymentMarkerValid,
+      url: convexRuntimeConfig.deploymentUrl ?? null,
+    },
     capabilities: {
       guestTokenVerification,
       aiLineGeneration,
+    },
+    configuration: {
+      missingRequired,
     },
   };
 }

--- a/convex/lib/env.ts
+++ b/convex/lib/env.ts
@@ -125,7 +125,7 @@ export function getConvexGuestTokenSecret(): string {
   ) {
     throw new Error(
       'GUEST_TOKEN_SECRET must be set in Convex environment. ' +
-        'Run: npx convex env set GUEST_TOKEN_SECRET "your-secret" production'
+        'Set it on the current Convex deployment before retrying.'
     );
   }
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -132,6 +132,41 @@ pnpm exec convex env set --prod OPENROUTER_API_KEY
 pnpm exec convex env list --prod --names-only
 ```
 
+[`config/convex-env-manifest.json`](../config/convex-env-manifest.json) is the
+repo-owned declaration of required and optional Convex environment variable
+names for development, preview, and production. It never stores values. Run a
+bounded, values-free readback with:
+
+```bash
+node scripts/ci/reconcile-convex-env.mjs --target production
+```
+
+The reconciler invokes only `convex env ... list --names-only`, rejects any
+non-name output without echoing it, and fails on either a missing required name
+or an undeclared live name. The hosted production build runs this reconciliation
+after `convex deploy` and then runs the signed guest-token parity dry run before
+App Platform can activate the web build. A present-but-different
+`GUEST_TOKEN_SECRET` therefore fails deployment even though both providers have
+a variable with the right name.
+
+Run the production reconciliation before merging any manifest change. Strict
+unexpected-name detection intentionally makes undeclared operational variables
+a deployment blocker, so add a new name to the manifest before setting it live.
+The post-deploy parity probe also reads the selected production function spec's
+public deployment URL and refuses a `NEXT_PUBLIC_CONVEX_URL` that points at a
+sibling deployment.
+
+The same manifest also drives Convex runtime health. The five-minute Production
+Health Monitor reaches the exact web/Convex pair through `/api/health`, which
+checks required-name presence and repeats the zero-write signed parity probe.
+That catches drift introduced after a successful deployment without giving the
+scheduled workflow a production control-plane credential.
+
+`LINEJAM_DEPLOY_ENVIRONMENT` is a non-secret deployment-type marker maintained
+by the hosted bootstrap in the target Convex environment. Runtime health uses
+it instead of guessing from the `convex.cloud` hostname, which is shared by dev,
+preview, and production deployments.
+
 The production App Platform build executes the Convex deploy before the Next.js
 build. Local agents must not push production Convex code unless
 `LINEJAM_ALLOW_PROD_CONVEX_SYNC=1` was set deliberately for that operation.
@@ -162,6 +197,8 @@ doctl apps logs "$LINEJAM_APP_ID" web --type run --tail 200
 
 All three routes must return HTTP 200. `/api/health` must report the core app,
 Convex, guest-token, Clerk, AI, and Canary readiness expected for production.
+Its `guestTokenParity` boolean is a proof result only; neither secret nor a
+fingerprint is returned.
 
 ## Deploy the Canary responder
 
@@ -291,6 +328,7 @@ pnpm exec convex import --replace-all ./convex-backup.zip --prod
 - [ ] `pnpm ci:dagger:all` passes or its environment limitation is recorded
 - [ ] hosted merge and smoke gates pass
 - [ ] web and responder active deployments match the intended source SHA
+- [ ] production Convex env reconciliation names every required manifest entry
 - [ ] `linejam.app` health, host, and join routes return 200
 - [ ] responder liveness and readiness return 200
 - [ ] Canary uses `https://canary.mistystep.io`

--- a/docs/ops/observability-ci.md
+++ b/docs/ops/observability-ci.md
@@ -48,7 +48,9 @@ that token.
 - To assert one function landed, run
   `node scripts/convex/probe-function-exists.mjs <module.js:functionName>`.
 - Avoid `convex env list`: it can reveal values. If names are essential, use
-  `--names-only` where the command supports it and still redact the receipt.
+  the repo-owned
+  `node scripts/ci/reconcile-convex-env.mjs --target <environment>` command. It
+  pins `--names-only`, validates the output shape, and emits names only.
 - A dev migration requires explicit authority naming the function, arguments,
   target deployment, expected affected rows/state, and rollback or recovery.
   Confirm the target as above, run the bounded `pnpm exec convex run ...`
@@ -69,6 +71,16 @@ replace operator authority. See `docs/deployment.md`.
    selector smoke, E2E, and QA evidence jobs as configured there.
 5. After an authorized merge/deploy, confirm source SHA, provider deployment
    health, production smoke, public route postconditions, and relevant logs.
+
+The production hosted build adds two postconditions before activation:
+
+1. `config/convex-env-manifest.json` must match the exact target deployment's
+   names-only inventory.
+2. The web `GUEST_TOKEN_SECRET` must sign a zero-write proof accepted by that
+   deployment's guest-session throttle.
+
+`/api/health` repeats the second postcondition and uses the same manifest for
+runtime required-name health, so the scheduled monitor catches later drift.
 
 `pnpm ci:dagger:all` is the local full-contract mirror when Docker and required
 Clerk, Convex, guest-token, and Canary inputs are available. Dagger may prepare

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:next": "next dev --turbopack",
     "dev:convex": "convex dev",
     "convex:sync:shared-dev": "./scripts/ci/dagger-call.sh sync-shared-dev",
+    "convex:env:reconcile": "node ./scripts/ci/reconcile-convex-env.mjs --target development",
     "build": "node ./scripts/ci/bootstrap-convex-env.mjs --deploy",
     "build:check": "next build",
     "start:next": "next start",

--- a/scripts/ci/bootstrap-convex-env.mjs
+++ b/scripts/ci/bootstrap-convex-env.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
  */
 
 const CONVEX_EXECUTABLE = ['pnpm', ['exec', 'convex']];
+const POST_DEPLOY_VERIFY_TIMEOUT_MS = 60_000;
 
 /**
  * @param {EnvShape} [env]
@@ -366,6 +367,7 @@ function runPostDeployVerification({ env, target, runner }) {
   const reconcile = runner('node', ['scripts/ci/reconcile-convex-env.mjs'], {
     stdio: 'inherit',
     env,
+    timeout: POST_DEPLOY_VERIFY_TIMEOUT_MS,
   });
   if (reconcile.status !== 0) {
     throw new Error('Hosted Convex environment reconciliation failed.');
@@ -376,7 +378,7 @@ function runPostDeployVerification({ env, target, runner }) {
   const parity = runner(
     'node',
     ['scripts/convex/probe-signed-throttle-ready.mjs', '--assert-prod-target'],
-    { stdio: 'inherit', env }
+    { stdio: 'inherit', env, timeout: POST_DEPLOY_VERIFY_TIMEOUT_MS }
   );
   if (parity.status !== 0) {
     throw new Error('Hosted guest-token secret parity verification failed.');

--- a/scripts/ci/bootstrap-convex-env.mjs
+++ b/scripts/ci/bootstrap-convex-env.mjs
@@ -375,7 +375,7 @@ function runPostDeployVerification({ env, target, runner }) {
 
   const parity = runner(
     'node',
-    ['scripts/convex/probe-signed-throttle-ready.mjs'],
+    ['scripts/convex/probe-signed-throttle-ready.mjs', '--assert-prod-target'],
     { stdio: 'inherit', env }
   );
   if (parity.status !== 0) {

--- a/scripts/ci/bootstrap-convex-env.mjs
+++ b/scripts/ci/bootstrap-convex-env.mjs
@@ -208,11 +208,19 @@ export function buildConvexEnvBootstrapPlan(env = process.env) {
     );
   }
 
+  const deploymentEnvironment =
+    target.status === 'prod'
+      ? 'production'
+      : target.status === 'preview'
+        ? 'preview'
+        : 'development';
+
   return {
     target,
     entries: [
       ['GUEST_TOKEN_SECRET', guestTokenSecret],
       ['CLERK_JWT_ISSUER_DOMAIN', clerkIssuerDomain],
+      ['LINEJAM_DEPLOY_ENVIRONMENT', deploymentEnvironment],
     ],
   };
 }
@@ -337,7 +345,42 @@ export function deployHostedConvex({
     throw new Error('Hosted Convex deploy failed.');
   }
 
+  runPostDeployVerification({
+    env,
+    target: resolveConvexEnvTarget(env),
+    runner,
+  });
+
   return args;
+}
+
+/**
+ * App Platform does not activate the build until this process exits. Keep the
+ * values-free name reconciliation and zero-write guest-secret parity probe in
+ * this unskippable post-deploy path so frontend traffic cannot race stale or
+ * mismatched Convex configuration.
+ *
+ * @param {{ env: EnvShape; target: ReturnType<typeof resolveConvexEnvTarget>; runner: Runner }} options
+ */
+function runPostDeployVerification({ env, target, runner }) {
+  const reconcile = runner('node', ['scripts/ci/reconcile-convex-env.mjs'], {
+    stdio: 'inherit',
+    env,
+  });
+  if (reconcile.status !== 0) {
+    throw new Error('Hosted Convex environment reconciliation failed.');
+  }
+
+  if (target.status !== 'prod') return;
+
+  const parity = runner(
+    'node',
+    ['scripts/convex/probe-signed-throttle-ready.mjs'],
+    { stdio: 'inherit', env }
+  );
+  if (parity.status !== 0) {
+    throw new Error('Hosted guest-token secret parity verification failed.');
+  }
 }
 
 async function main() {

--- a/scripts/ci/reconcile-convex-env.mjs
+++ b/scripts/ci/reconcile-convex-env.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { resolveConvexEnvTarget } from './bootstrap-convex-env.mjs';
+
+const ENV_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+const ENVIRONMENTS = ['development', 'preview', 'production'];
+const DEFAULT_MANIFEST_URL = new URL(
+  '../../config/convex-env-manifest.json',
+  import.meta.url
+);
+
+/** @typedef {'development' | 'preview' | 'production'} ManifestEnvironment */
+/** @typedef {{ required: string[], optional: string[] }} ManifestEntry */
+/** @typedef {{ schemaVersion: 1, environments: Record<ManifestEnvironment, ManifestEntry> }} ConvexEnvManifest */
+/** @typedef {{ status: 'skipped' | 'default' | 'preview' | 'prod', reason?: string, args: string[], explicit?: boolean }} ConvexEnvTarget */
+/** @typedef {(command: string, args: string[], options: import('node:child_process').SpawnSyncOptionsWithStringEncoding) => { status: number | null, stdout?: string, stderr?: string }} Runner */
+
+/**
+ * The manifest contains names only. Rejecting every other shape prevents this
+ * reconciliation surface from becoming a place where secret values can land.
+ *
+ * @param {unknown} candidate
+ * @returns {ConvexEnvManifest}
+ */
+export function validateConvexEnvManifest(candidate) {
+  if (!candidate || typeof candidate !== 'object') {
+    throw new Error('Convex env manifest must be an object.');
+  }
+
+  const manifest = /** @type {Record<string, unknown>} */ (candidate);
+  assertExactKeys('Convex env manifest', manifest, [
+    'schemaVersion',
+    'environments',
+  ]);
+  if (manifest.schemaVersion !== 1) {
+    throw new Error('Convex env manifest schemaVersion must be 1.');
+  }
+
+  if (!manifest.environments || typeof manifest.environments !== 'object') {
+    throw new Error('Convex env manifest must declare environments.');
+  }
+
+  const environments = /** @type {Record<string, unknown>} */ (
+    manifest.environments
+  );
+  assertExactKeys(
+    'Convex env manifest environments',
+    environments,
+    ENVIRONMENTS
+  );
+  for (const environment of ENVIRONMENTS) {
+    validateManifestEntry(environment, environments[environment]);
+  }
+
+  return /** @type {ConvexEnvManifest} */ (candidate);
+}
+
+/**
+ * @param {string} environment
+ * @param {unknown} candidate
+ */
+function validateManifestEntry(environment, candidate) {
+  if (!candidate || typeof candidate !== 'object') {
+    throw new Error(`Convex env manifest must declare ${environment}.`);
+  }
+
+  const entry = /** @type {Record<string, unknown>} */ (candidate);
+  assertExactKeys(`Convex env manifest ${environment}`, entry, [
+    'required',
+    'optional',
+  ]);
+  for (const field of ['required', 'optional']) {
+    const names = entry[field];
+    if (!Array.isArray(names)) {
+      throw new Error(
+        `Convex env manifest ${environment}.${field} must be an array.`
+      );
+    }
+    if (
+      !names.every(
+        (name) => typeof name === 'string' && ENV_NAME_PATTERN.test(name)
+      )
+    ) {
+      throw new Error(
+        `Convex env manifest ${environment}.${field} must contain environment variable names only.`
+      );
+    }
+    if (new Set(names).size !== names.length) {
+      throw new Error(
+        `Convex env manifest ${environment}.${field} contains duplicate names.`
+      );
+    }
+  }
+
+  const required = /** @type {string[]} */ (entry.required);
+  const optional = new Set(/** @type {string[]} */ (entry.optional));
+  if (required.some((name) => optional.has(name))) {
+    throw new Error(
+      `Convex env manifest ${environment} cannot list a name as both required and optional.`
+    );
+  }
+}
+
+/**
+ * @param {string} label
+ * @param {Record<string, unknown>} candidate
+ * @param {string[]} expected
+ */
+function assertExactKeys(label, candidate, expected) {
+  const actual = Object.keys(candidate).sort();
+  const allowed = [...expected].sort();
+  if (
+    actual.length !== allowed.length ||
+    actual.some((key, index) => key !== allowed[index])
+  ) {
+    throw new Error(`${label} contains unsupported fields.`);
+  }
+}
+
+/**
+ * @param {string | URL} [path]
+ * @returns {ConvexEnvManifest}
+ */
+export function loadConvexEnvManifest(path = DEFAULT_MANIFEST_URL) {
+  return validateConvexEnvManifest(JSON.parse(readFileSync(path, 'utf8')));
+}
+
+/**
+ * Parse only the stdout of `convex env ... list --names-only`. Never include
+ * rejected output in an exception: a provider regression must not echo values.
+ *
+ * @param {string} output
+ * @returns {string[]}
+ */
+export function parseConvexEnvNames(output) {
+  const names = output
+    .split(/\r?\n/u)
+    .map((name) => name.trim())
+    .filter(Boolean);
+
+  if (!names.every((name) => ENV_NAME_PATTERN.test(name))) {
+    throw new Error('Convex env names-only output contained a non-name entry.');
+  }
+
+  return [...new Set(names)].sort();
+}
+
+/**
+ * @param {ManifestEntry} entry
+ * @param {string[]} liveNames
+ */
+export function diffConvexEnvNames(entry, liveNames) {
+  const live = new Set(liveNames);
+  const allowed = new Set([...entry.required, ...entry.optional]);
+
+  return {
+    missing: entry.required.filter((name) => !live.has(name)).sort(),
+    unexpected: liveNames.filter((name) => !allowed.has(name)).sort(),
+  };
+}
+
+/**
+ * @param {ConvexEnvTarget['status']} status
+ * @returns {ManifestEnvironment}
+ */
+function manifestEnvironmentForTarget(status) {
+  if (status === 'prod') return 'production';
+  if (status === 'preview') return 'preview';
+  if (status === 'default') return 'development';
+  throw new Error('Cannot reconcile a skipped Convex environment target.');
+}
+
+/**
+ * @param {{
+ *   target: ConvexEnvTarget;
+ *   manifest?: ConvexEnvManifest;
+ *   runner?: Runner;
+ *   logger?: { log: (message: string) => void };
+ *   env?: NodeJS.ProcessEnv;
+ * }} options
+ */
+export function runConvexEnvReconciliation({
+  target,
+  manifest = loadConvexEnvManifest(),
+  runner = spawnSync,
+  logger = console,
+  env = process.env,
+}) {
+  const environment = manifestEnvironmentForTarget(target.status);
+  const validatedManifest = validateConvexEnvManifest(manifest);
+  const childEnv = { ...env };
+  if (target.explicit) delete childEnv.CONVEX_DEPLOY_KEY;
+  const result = runner(
+    'pnpm',
+    ['exec', 'convex', 'env', ...target.args, 'list', '--names-only'],
+    { encoding: 'utf8', env: childEnv }
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Convex ${environment} names-only read failed with status ${result.status ?? 'unknown'}.`
+    );
+  }
+
+  const liveNames = parseConvexEnvNames(result.stdout ?? '');
+  const entry = validatedManifest.environments[environment];
+  const diff = diffConvexEnvNames(entry, liveNames);
+  if (diff.missing.length > 0 || diff.unexpected.length > 0) {
+    throw new Error(
+      `Convex ${environment} environment drift: missing=${formatNames(diff.missing)}; unexpected=${formatNames(diff.unexpected)}`
+    );
+  }
+
+  logger.log(
+    `READY: Convex ${environment} env manifest required=${entry.required.join(',') || 'none'}; optional_present=${liveNames.filter((name) => entry.optional.includes(name)).join(',') || 'none'}`
+  );
+
+  return { environment, liveNames, ...diff };
+}
+
+/** @param {string[]} names */
+function formatNames(names) {
+  return names.length > 0 ? names.join(',') : 'none';
+}
+
+function manifestArgument(argv) {
+  const index = argv.indexOf('--manifest');
+  if (index === -1) return undefined;
+  const value = argv[index + 1];
+  if (!value) throw new Error('--manifest requires a path.');
+  return value;
+}
+
+/**
+ * Explicit targets are for bounded operator/readback commands. Hosted deploys
+ * omit the flag and remain pinned to the deploy-key target resolved by the
+ * production build policy.
+ *
+ * @param {string[]} argv
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {ConvexEnvTarget}
+ */
+export function resolveReconciliationTarget(argv, env = process.env) {
+  const index = argv.indexOf('--target');
+  if (index === -1) return resolveConvexEnvTarget(env);
+
+  const target = argv[index + 1];
+  if (target === 'development') {
+    return { status: 'default', args: [], explicit: true };
+  }
+  if (target === 'production') {
+    return { status: 'prod', args: ['--prod'], explicit: true };
+  }
+  if (target === 'preview') {
+    const previewIndex = argv.indexOf('--preview-name');
+    if (previewIndex === -1 || !argv[previewIndex + 1]) {
+      throw new Error('--target preview requires --preview-name.');
+    }
+    const previewName = argv[previewIndex + 1];
+    return {
+      status: 'preview',
+      args: ['--preview-name', previewName],
+      explicit: true,
+    };
+  }
+
+  throw new Error('--target must be development, preview, or production.');
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const target = resolveReconciliationTarget(argv);
+  runConvexEnvReconciliation({
+    target,
+    manifest: loadConvexEnvManifest(manifestArgument(argv)),
+  });
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    main();
+  } catch (error) {
+    console.error(
+      error instanceof Error
+        ? error.message
+        : 'Convex env reconciliation failed.'
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/reconcile-convex-env.mjs
+++ b/scripts/ci/reconcile-convex-env.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { resolveConvexEnvTarget } from './bootstrap-convex-env.mjs';
 
 const ENV_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+const CONVEX_ENV_LIST_TIMEOUT_MS = 30_000;
 const ENVIRONMENTS = ['development', 'preview', 'production'];
 const DEFAULT_MANIFEST_URL = new URL(
   '../../config/convex-env-manifest.json',
@@ -17,7 +18,7 @@ const DEFAULT_MANIFEST_URL = new URL(
 /** @typedef {{ required: string[], optional: string[] }} ManifestEntry */
 /** @typedef {{ schemaVersion: 1, environments: Record<ManifestEnvironment, ManifestEntry> }} ConvexEnvManifest */
 /** @typedef {{ status: 'skipped' | 'default' | 'preview' | 'prod', reason?: string, args: string[], explicit?: boolean }} ConvexEnvTarget */
-/** @typedef {(command: string, args: string[], options: import('node:child_process').SpawnSyncOptionsWithStringEncoding) => { status: number | null, stdout?: string, stderr?: string }} Runner */
+/** @typedef {(command: string, args: string[], options: import('node:child_process').SpawnSyncOptionsWithStringEncoding) => { status: number | null, stdout?: string, stderr?: string, error?: NodeJS.ErrnoException }} Runner */
 
 /**
  * The manifest contains names only. Rejecting every other shape prevents this
@@ -197,8 +198,20 @@ export function runConvexEnvReconciliation({
   const result = runner(
     'pnpm',
     ['exec', 'convex', 'env', ...target.args, 'list', '--names-only'],
-    { encoding: 'utf8', env: childEnv }
+    {
+      encoding: 'utf8',
+      env: childEnv,
+      timeout: CONVEX_ENV_LIST_TIMEOUT_MS,
+    }
   );
+
+  if (result.error) {
+    throw new Error(
+      result.error.code === 'ETIMEDOUT'
+        ? `Convex ${environment} names-only read timed out.`
+        : `Convex ${environment} names-only read failed to start.`
+    );
+  }
 
   if (result.status !== 0) {
     throw new Error(

--- a/scripts/convex/probe-signed-throttle-ready.mjs
+++ b/scripts/convex/probe-signed-throttle-ready.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { spawnSync } from 'node:child_process';
 import { createHmac } from 'node:crypto';
 import { ConvexHttpClient } from 'convex/browser';
 import { makeFunctionReference } from 'convex/server';
@@ -36,6 +37,39 @@ export async function probeSignedThrottleReady(convexUrl, secret, mutate) {
   }
 }
 
+export function parseFunctionSpecDeploymentUrl(functionSpecJson) {
+  const parsed = JSON.parse(functionSpecJson);
+  if (!parsed || typeof parsed.url !== 'string') {
+    throw new Error('Convex function-spec omitted its deployment URL.');
+  }
+  return new URL(parsed.url).origin;
+}
+
+export function assertSelectedDeploymentMatches(
+  convexUrl,
+  env = process.env,
+  runner = spawnSync
+) {
+  if (!convexUrl) throw new Error('NEXT_PUBLIC_CONVEX_URL is required');
+  const result = runner('pnpm', ['exec', 'convex', 'function-spec', '--prod'], {
+    env,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `Convex production deployment identity read failed with status ${result.status ?? 'unknown'}.`
+    );
+  }
+
+  const selectedUrl = parseFunctionSpecDeploymentUrl(result.stdout ?? '');
+  if (selectedUrl !== new URL(convexUrl).origin) {
+    throw new Error(
+      'NEXT_PUBLIC_CONVEX_URL does not match the production deployment selected by CONVEX_DEPLOY_KEY.'
+    );
+  }
+  return selectedUrl;
+}
+
 function extractErrorMessage(error) {
   if (error && typeof error === 'object' && typeof error.data === 'string') {
     return error.data;
@@ -47,6 +81,7 @@ function extractErrorMessage(error) {
 async function main() {
   const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL?.trim();
   const secret = process.env.GUEST_TOKEN_SECRET?.trim();
+  assertSelectedDeploymentMatches(convexUrl, process.env);
   const client = convexUrl ? new ConvexHttpClient(convexUrl) : null;
   const ready = await probeSignedThrottleReady(
     convexUrl,

--- a/scripts/convex/probe-signed-throttle-ready.mjs
+++ b/scripts/convex/probe-signed-throttle-ready.mjs
@@ -8,6 +8,7 @@ import { makeFunctionReference } from 'convex/server';
 const FUNCTION_NAME = 'guestSessions:checkSignedGuestSessionThrottle';
 const READINESS_KEY = 'guestSession:deployment-readiness';
 const THROTTLE_PROOF_CONTEXT = 'linejam:guest-session-throttle:v1:';
+const FUNCTION_SPEC_TIMEOUT_MS = 30_000;
 const signedThrottle = makeFunctionReference(FUNCTION_NAME);
 
 /**
@@ -54,7 +55,15 @@ export function assertSelectedDeploymentMatches(
   const result = runner('pnpm', ['exec', 'convex', 'function-spec', '--prod'], {
     env,
     encoding: 'utf8',
+    timeout: FUNCTION_SPEC_TIMEOUT_MS,
   });
+  if (result.error) {
+    throw new Error(
+      result.error.code === 'ETIMEDOUT'
+        ? 'Convex production deployment identity read timed out.'
+        : 'Convex production deployment identity read failed to start.'
+    );
+  }
   if (result.status !== 0) {
     throw new Error(
       `Convex production deployment identity read failed with status ${result.status ?? 'unknown'}.`

--- a/scripts/convex/probe-signed-throttle-ready.mjs
+++ b/scripts/convex/probe-signed-throttle-ready.mjs
@@ -81,7 +81,9 @@ function extractErrorMessage(error) {
 async function main() {
   const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL?.trim();
   const secret = process.env.GUEST_TOKEN_SECRET?.trim();
-  assertSelectedDeploymentMatches(convexUrl, process.env);
+  if (process.argv.includes('--assert-prod-target')) {
+    assertSelectedDeploymentMatches(convexUrl, process.env);
+  }
   const client = convexUrl ? new ConvexHttpClient(convexUrl) : null;
   const ready = await probeSignedThrottleReady(
     convexUrl,

--- a/tests/app/api/health.test.ts
+++ b/tests/app/api/health.test.ts
@@ -19,7 +19,31 @@ const HEALTHY_ENV = {
   NEXT_PUBLIC_CANARY_API_KEY: 'sk_test_canary',
 };
 
+const HEALTHY_REPORT = {
+  ok: true,
+  status: 200,
+  environment: 'development',
+  deployment: {
+    markerValid: true,
+    url: HEALTHY_ENV.NEXT_PUBLIC_CONVEX_URL,
+  },
+  capabilities: {
+    guestTokenVerification: {
+      status: 'ready',
+      available: true,
+      required: false,
+    },
+    aiLineGeneration: {
+      status: 'ready',
+      available: true,
+      required: false,
+    },
+  },
+  configuration: { missingRequired: [] },
+};
+
 const mockQuery = vi.fn();
+const mockMutation = vi.fn();
 const fetchMock = vi.fn();
 
 function parseJsonLogCalls(spy: ReturnType<typeof vi.spyOn>) {
@@ -31,6 +55,7 @@ function parseJsonLogCalls(spy: ReturnType<typeof vi.spyOn>) {
 
 class MockConvexHttpClient {
   query = mockQuery;
+  mutation = mockMutation;
 }
 
 describe('/api/health', () => {
@@ -54,7 +79,8 @@ describe('/api/health', () => {
       vi.doMock('convex/browser', () => ({
         ConvexHttpClient: MockConvexHttpClient,
       }));
-      mockQuery.mockResolvedValue({ ok: true });
+      mockQuery.mockResolvedValue(HEALTHY_REPORT);
+      mockMutation.mockResolvedValue({ ok: true });
       vi.stubGlobal('fetch', fetchMock);
       fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
 
@@ -64,7 +90,9 @@ describe('/api/health', () => {
 
     afterEach(() => {
       mockQuery.mockReset();
-      mockQuery.mockResolvedValue({ ok: true });
+      mockQuery.mockResolvedValue(HEALTHY_REPORT);
+      mockMutation.mockReset();
+      mockMutation.mockResolvedValue({ ok: true });
       fetchMock.mockClear();
       fetchMock.mockResolvedValue(new Response(null, { status: 202 }));
       vi.useRealTimers();
@@ -84,6 +112,8 @@ describe('/api/health', () => {
         env: {
           nodeEnv: expect.stringMatching(/^(development|test|production)$/),
           guestTokenSecret: true,
+          guestTokenParity: true,
+          convexDeploymentMatch: true,
           convexUrl: true,
           canaryIngestKey: true,
         },
@@ -125,7 +155,7 @@ describe('/api/health', () => {
     });
 
     it('returns connected when Convex ping succeeds', async () => {
-      mockQuery.mockResolvedValue({ ok: true });
+      mockQuery.mockResolvedValue(HEALTHY_REPORT);
 
       const response = await GET();
       const data = await response.json();
@@ -133,6 +163,29 @@ describe('/api/health', () => {
       expect(response.status).toBe(200);
       expect(data.convex).toBe('connected');
       expect(mockQuery).toHaveBeenCalled();
+      expect(mockMutation).toHaveBeenCalledWith(expect.anything(), {
+        key: 'guestSession:deployment-readiness',
+        proof: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
+        dryRun: true,
+      });
+    });
+
+    it('returns 503 without exposing values when web and Convex guest secrets differ', async () => {
+      mockMutation.mockRejectedValue(
+        new Error('Invalid guest session throttle proof')
+      );
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(data).toMatchObject({
+        status: 'unhealthy',
+        env: { guestTokenSecret: true, guestTokenParity: false },
+      });
+      expect(JSON.stringify(data)).not.toContain(
+        HEALTHY_ENV.GUEST_TOKEN_SECRET
+      );
     });
 
     it('returns 503 when Convex is reachable but a required capability is unconfigured', async () => {
@@ -143,6 +196,10 @@ describe('/api/health', () => {
         ok: false,
         status: 500,
         environment: 'production',
+        deployment: {
+          markerValid: true,
+          url: HEALTHY_ENV.NEXT_PUBLIC_CONVEX_URL,
+        },
         capabilities: {
           guestTokenVerification: {
             status: 'ready',
@@ -235,7 +292,7 @@ describe('/api/health', () => {
       vi.useFakeTimers();
 
       const responsePromise = GET();
-      await vi.advanceTimersByTimeAsync(1_500);
+      await vi.advanceTimersByTimeAsync(3_000);
 
       const response = await responsePromise;
       const data = await response.json();
@@ -263,6 +320,30 @@ describe('/api/health', () => {
           canaryIngestKey: false,
         },
       });
+    });
+
+    it('fails health when a remote deployment loses its environment marker', async () => {
+      const previous = process.env.LINEJAM_DEPLOY_ENVIRONMENT;
+      process.env.LINEJAM_DEPLOY_ENVIRONMENT = 'production';
+      mockQuery.mockResolvedValue({
+        ...HEALTHY_REPORT,
+        environment: 'development',
+        deployment: {
+          markerValid: false,
+          url: HEALTHY_ENV.NEXT_PUBLIC_CONVEX_URL,
+        },
+      });
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(data.env.convexDeploymentMatch).toBe(false);
+      if (previous === undefined) {
+        delete process.env.LINEJAM_DEPLOY_ENVIRONMENT;
+      } else {
+        process.env.LINEJAM_DEPLOY_ENVIRONMENT = previous;
+      }
     });
 
     it('falls back to development when NODE_ENV is unset', async () => {
@@ -304,6 +385,7 @@ describe('/api/health', () => {
         status: 'unhealthy',
         env: {
           guestTokenSecret: false,
+          guestTokenParity: false,
           convexUrl: false,
           canaryIngestKey: false,
         },

--- a/tests/app/api/health.test.ts
+++ b/tests/app/api/health.test.ts
@@ -15,6 +15,7 @@ const originalEnv = { ...process.env };
 
 const HEALTHY_ENV = {
   GUEST_TOKEN_SECRET: 'test-secret-for-health-checks',
+  LINEJAM_DEPLOY_ENVIRONMENT: 'development',
   NEXT_PUBLIC_CONVEX_URL: 'https://test.convex.cloud',
   NEXT_PUBLIC_CANARY_API_KEY: 'sk_test_canary',
 };
@@ -72,6 +73,8 @@ describe('/api/health', () => {
       delete process.env.CANARY_API_KEY;
       delete process.env.CANARY_ENDPOINT;
       process.env.GUEST_TOKEN_SECRET = HEALTHY_ENV.GUEST_TOKEN_SECRET;
+      process.env.LINEJAM_DEPLOY_ENVIRONMENT =
+        HEALTHY_ENV.LINEJAM_DEPLOY_ENVIRONMENT;
       process.env.NEXT_PUBLIC_CONVEX_URL = HEALTHY_ENV.NEXT_PUBLIC_CONVEX_URL;
       process.env.NEXT_PUBLIC_CANARY_API_KEY =
         HEALTHY_ENV.NEXT_PUBLIC_CANARY_API_KEY;
@@ -324,25 +327,44 @@ describe('/api/health', () => {
 
     it('fails health when a remote deployment loses its environment marker', async () => {
       const previous = process.env.LINEJAM_DEPLOY_ENVIRONMENT;
-      process.env.LINEJAM_DEPLOY_ENVIRONMENT = 'production';
-      mockQuery.mockResolvedValue({
-        ...HEALTHY_REPORT,
-        environment: 'development',
-        deployment: {
-          markerValid: false,
-          url: HEALTHY_ENV.NEXT_PUBLIC_CONVEX_URL,
-        },
-      });
+      try {
+        process.env.LINEJAM_DEPLOY_ENVIRONMENT = 'production';
+        mockQuery.mockResolvedValue({
+          ...HEALTHY_REPORT,
+          environment: 'development',
+          deployment: {
+            markerValid: false,
+            url: HEALTHY_ENV.NEXT_PUBLIC_CONVEX_URL,
+          },
+        });
 
-      const response = await GET();
-      const data = await response.json();
+        const response = await GET();
+        const data = await response.json();
 
-      expect(response.status).toBe(503);
-      expect(data.env.convexDeploymentMatch).toBe(false);
-      if (previous === undefined) {
+        expect(response.status).toBe(503);
+        expect(data.env.convexDeploymentMatch).toBe(false);
+      } finally {
+        if (previous === undefined) {
+          delete process.env.LINEJAM_DEPLOY_ENVIRONMENT;
+        } else {
+          process.env.LINEJAM_DEPLOY_ENVIRONMENT = previous;
+        }
+      }
+    });
+
+    it('fails health when the web deployment marker is missing', async () => {
+      const previous = process.env.LINEJAM_DEPLOY_ENVIRONMENT;
+      try {
         delete process.env.LINEJAM_DEPLOY_ENVIRONMENT;
-      } else {
-        process.env.LINEJAM_DEPLOY_ENVIRONMENT = previous;
+        const response = await GET();
+        const data = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(data.env.convexDeploymentMatch).toBe(false);
+      } finally {
+        if (previous !== undefined) {
+          process.env.LINEJAM_DEPLOY_ENVIRONMENT = previous;
+        }
       }
     });
 

--- a/tests/convex/envValidation.test.ts
+++ b/tests/convex/envValidation.test.ts
@@ -19,6 +19,10 @@ describe('Convex env validation', () => {
     await withEnv(
       {
         CONVEX_CLOUD_URL: 'https://linejam.convex.cloud',
+        LINEJAM_DEPLOY_ENVIRONMENT: 'production',
+        CANARY_API_KEY: undefined,
+        CANARY_ENDPOINT: undefined,
+        CLERK_JWT_ISSUER_DOMAIN: undefined,
         GUEST_TOKEN_SECRET: undefined,
       },
       async () => {
@@ -33,6 +37,7 @@ describe('Convex env validation', () => {
     await withEnv(
       {
         CONVEX_CLOUD_URL: 'https://linejam.convex.cloud',
+        LINEJAM_DEPLOY_ENVIRONMENT: 'production',
         GUEST_TOKEN_SECRET: undefined,
       },
       async () => {
@@ -59,6 +64,21 @@ describe('Convex env validation', () => {
     );
   });
 
+  it('never enables the development fallback secret on an unmarked remote deployment', async () => {
+    await withEnv(
+      {
+        CONVEX_CLOUD_URL: 'https://linejam.convex.cloud',
+        LINEJAM_DEPLOY_ENVIRONMENT: undefined,
+        GUEST_TOKEN_SECRET: undefined,
+      },
+      async () => {
+        await expect(import('../../convex/lib/guestToken')).rejects.toThrow(
+          'GUEST_TOKEN_SECRET must be set in Convex environment'
+        );
+      }
+    );
+  });
+
   it('logs a structured error at module load when OPENROUTER_API_KEY is missing in production-like Convex env', async () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
@@ -67,6 +87,7 @@ describe('Convex env validation', () => {
     await withEnv(
       {
         CONVEX_CLOUD_URL: 'https://linejam.convex.cloud',
+        LINEJAM_DEPLOY_ENVIRONMENT: 'production',
         GUEST_TOKEN_SECRET: 'test-secret',
         OPENROUTER_API_KEY: undefined,
       },
@@ -96,6 +117,7 @@ describe('Convex env validation', () => {
     await withEnv(
       {
         CONVEX_CLOUD_URL: 'https://linejam.convex.cloud',
+        LINEJAM_DEPLOY_ENVIRONMENT: 'production',
         GUEST_TOKEN_SECRET: 'test-secret',
         OPENROUTER_API_KEY: 'test-openrouter-key',
       },
@@ -117,6 +139,10 @@ describe('Convex env validation', () => {
     await withEnv(
       {
         CONVEX_CLOUD_URL: 'https://linejam.convex.cloud',
+        LINEJAM_DEPLOY_ENVIRONMENT: 'production',
+        CANARY_API_KEY: undefined,
+        CANARY_ENDPOINT: undefined,
+        CLERK_JWT_ISSUER_DOMAIN: undefined,
         GUEST_TOKEN_SECRET: undefined,
         OPENROUTER_API_KEY: undefined,
       },
@@ -140,6 +166,15 @@ describe('Convex env validation', () => {
               required: true,
             },
           },
+          configuration: {
+            missingRequired: expect.arrayContaining([
+              'CANARY_API_KEY',
+              'CANARY_ENDPOINT',
+              'CLERK_JWT_ISSUER_DOMAIN',
+              'GUEST_TOKEN_SECRET',
+              'OPENROUTER_API_KEY',
+            ]),
+          },
         });
       }
     );
@@ -149,6 +184,7 @@ describe('Convex env validation', () => {
     await withEnv(
       {
         CONVEX_CLOUD_URL: 'https://linejam.convex.cloud',
+        LINEJAM_DEPLOY_ENVIRONMENT: 'production',
         GUEST_TOKEN_SECRET: undefined,
         OPENROUTER_API_KEY: 'test-openrouter-key',
       },
@@ -171,6 +207,36 @@ describe('Convex env validation', () => {
               available: true,
               required: true,
             },
+          },
+        });
+      }
+    );
+  });
+
+  it('uses the manifest to fail health when a non-capability production name is missing', async () => {
+    await withEnv(
+      {
+        CONVEX_CLOUD_URL: 'https://linejam.convex.cloud',
+        LINEJAM_DEPLOY_ENVIRONMENT: 'production',
+        CANARY_API_KEY: 'test-canary-key',
+        CANARY_ENDPOINT: 'https://canary.test',
+        CLERK_JWT_ISSUER_DOMAIN: undefined,
+        GUEST_TOKEN_SECRET: 'test-secret',
+        OPENROUTER_API_KEY: 'test-openrouter-key',
+      },
+      async () => {
+        const { getConvexEnvHealthReport } =
+          await import('../../convex/lib/env');
+
+        expect(getConvexEnvHealthReport()).toMatchObject({
+          ok: false,
+          status: 500,
+          capabilities: {
+            guestTokenVerification: { status: 'ready' },
+            aiLineGeneration: { status: 'ready' },
+          },
+          configuration: {
+            missingRequired: ['CLERK_JWT_ISSUER_DOMAIN'],
           },
         });
       }
@@ -209,10 +275,39 @@ describe('Convex env validation', () => {
     );
   });
 
+  it('fails health for a missing or invalid deployment marker on a remote deployment', async () => {
+    for (const marker of [undefined, 'prod']) {
+      vi.resetModules();
+      await withEnv(
+        {
+          CONVEX_CLOUD_URL: 'https://linejam.convex.cloud',
+          LINEJAM_DEPLOY_ENVIRONMENT: marker,
+          GUEST_TOKEN_SECRET: 'test-secret',
+          OPENROUTER_API_KEY: 'test-openrouter-key',
+        },
+        async () => {
+          const { getConvexEnvHealthReport } =
+            await import('../../convex/lib/env');
+
+          expect(getConvexEnvHealthReport()).toMatchObject({
+            ok: false,
+            status: 500,
+            environment: 'development',
+            deployment: {
+              markerValid: false,
+              url: 'https://linejam.convex.cloud',
+            },
+          });
+        }
+      );
+    }
+  });
+
   it('keeps runtime config and health report stable after module load', async () => {
     await withEnv(
       {
         CONVEX_CLOUD_URL: 'https://linejam.convex.cloud',
+        LINEJAM_DEPLOY_ENVIRONMENT: 'production',
         GUEST_TOKEN_SECRET: 'first-secret',
         OPENROUTER_API_KEY: undefined,
       },

--- a/tests/convex/http.test.ts
+++ b/tests/convex/http.test.ts
@@ -36,6 +36,7 @@ describe('convex/http health route', () => {
     await withEnv(
       {
         CONVEX_CLOUD_URL: 'https://linejam.convex.cloud',
+        LINEJAM_DEPLOY_ENVIRONMENT: 'production',
         GUEST_TOKEN_SECRET: undefined,
         OPENROUTER_API_KEY: undefined,
       },
@@ -70,6 +71,10 @@ describe('convex/http health route', () => {
     await withEnv(
       {
         CONVEX_CLOUD_URL: 'https://linejam.convex.cloud',
+        LINEJAM_DEPLOY_ENVIRONMENT: 'production',
+        CANARY_API_KEY: 'test-canary-key',
+        CANARY_ENDPOINT: 'https://canary.test',
+        CLERK_JWT_ISSUER_DOMAIN: 'https://clerk.test',
         GUEST_TOKEN_SECRET: 'test-secret',
         OPENROUTER_API_KEY: 'test-openrouter-key',
       },
@@ -104,6 +109,7 @@ describe('convex/http health route', () => {
     await withEnv(
       {
         CONVEX_CLOUD_URL: 'https://linejam.convex.cloud',
+        LINEJAM_DEPLOY_ENVIRONMENT: 'production',
         GUEST_TOKEN_SECRET: 'test-secret',
         OPENROUTER_API_KEY: undefined,
       },

--- a/tests/scripts/bootstrap-convex-env.test.ts
+++ b/tests/scripts/bootstrap-convex-env.test.ts
@@ -278,12 +278,18 @@ describe('bootstrap-convex-env', () => {
       },
       {
         bin: 'node',
-        args: ['scripts/convex/probe-signed-throttle-ready.mjs'],
+        args: [
+          'scripts/convex/probe-signed-throttle-ready.mjs',
+          '--assert-prod-target',
+        ],
       },
     ]);
     expect(calls.at(-1)).toEqual({
       bin: 'node',
-      args: ['scripts/convex/probe-signed-throttle-ready.mjs'],
+      args: [
+        'scripts/convex/probe-signed-throttle-ready.mjs',
+        '--assert-prod-target',
+      ],
     });
   });
 
@@ -313,7 +319,10 @@ describe('bootstrap-convex-env', () => {
 
     expect(runner).not.toHaveBeenCalledWith(
       'node',
-      ['scripts/convex/probe-signed-throttle-ready.mjs'],
+      [
+        'scripts/convex/probe-signed-throttle-ready.mjs',
+        '--assert-prod-target',
+      ],
       expect.anything()
     );
   });
@@ -555,7 +564,7 @@ exit 0
         'exec convex env --prod set LINEJAM_DEPLOY_ENVIRONMENT production',
         'exec convex deploy --cmd pnpm run build:check',
         'node scripts/ci/reconcile-convex-env.mjs',
-        'node scripts/convex/probe-signed-throttle-ready.mjs',
+        'node scripts/convex/probe-signed-throttle-ready.mjs --assert-prod-target',
       ]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/tests/scripts/bootstrap-convex-env.test.ts
+++ b/tests/scripts/bootstrap-convex-env.test.ts
@@ -325,6 +325,11 @@ describe('bootstrap-convex-env', () => {
       ],
       expect.anything()
     );
+    expect(runner).toHaveBeenCalledWith(
+      'node',
+      ['scripts/ci/reconcile-convex-env.mjs'],
+      expect.objectContaining({ timeout: 60_000 })
+    );
   });
 
   it('can force hosted preview builds to deploy Convex explicitly', () => {

--- a/tests/scripts/bootstrap-convex-env.test.ts
+++ b/tests/scripts/bootstrap-convex-env.test.ts
@@ -80,11 +80,12 @@ describe('bootstrap-convex-env', () => {
           'CLERK_JWT_ISSUER_DOMAIN',
           'https://solid-beetle-24.clerk.accounts.dev',
         ],
+        ['LINEJAM_DEPLOY_ENVIRONMENT', 'preview'],
       ],
     });
   });
 
-  it('seeds both required env vars into the hosted Convex target', () => {
+  it('seeds every bootstrap env var into the hosted Convex target', () => {
     const calls: Array<{ bin: string; args: string[] }> = [];
     const runner = (bin: string, args: string[]) => {
       calls.push({ bin, args });
@@ -131,6 +132,19 @@ describe('bootstrap-convex-env', () => {
           'set',
           'CLERK_JWT_ISSUER_DOMAIN',
           'https://solid-beetle-24.clerk.accounts.dev',
+        ],
+      },
+      {
+        bin: 'pnpm',
+        args: [
+          'exec',
+          'convex',
+          'env',
+          '--preview-name',
+          'codex/canary-local-ci-agentic-qa',
+          'set',
+          'LINEJAM_DEPLOY_ENVIRONMENT',
+          'preview',
         ],
       },
     ]);
@@ -244,13 +258,64 @@ describe('bootstrap-convex-env', () => {
       },
       {
         bin: 'pnpm',
+        args: [
+          'exec',
+          'convex',
+          'env',
+          '--prod',
+          'set',
+          'LINEJAM_DEPLOY_ENVIRONMENT',
+          'production',
+        ],
+      },
+      {
+        bin: 'pnpm',
         args: ['exec', 'convex', 'deploy', '--cmd', 'pnpm run build:check'],
+      },
+      {
+        bin: 'node',
+        args: ['scripts/ci/reconcile-convex-env.mjs'],
+      },
+      {
+        bin: 'node',
+        args: ['scripts/convex/probe-signed-throttle-ready.mjs'],
       },
     ]);
     expect(calls.at(-1)).toEqual({
-      bin: 'pnpm',
-      args: ['exec', 'convex', 'deploy', '--cmd', 'pnpm run build:check'],
+      bin: 'node',
+      args: ['scripts/convex/probe-signed-throttle-ready.mjs'],
     });
+  });
+
+  it('fails the hosted production build when post-deploy verification fails', () => {
+    const runner = vi.fn((bin: string, args: string[]) => ({
+      status:
+        bin === 'node' && args[0] === 'scripts/ci/reconcile-convex-env.mjs'
+          ? 1
+          : 0,
+    }));
+
+    expect(() =>
+      deployHostedConvex({
+        env: env({
+          CONVEX_DEPLOY_KEY: 'prod:team:project|secret',
+          GUEST_TOKEN_SECRET: 'guest-secret',
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: clerkPublishableKey(
+            'live',
+            'clerk.linejam.app'
+          ),
+          CLERK_JWT_ISSUER_DOMAIN: 'https://clerk.linejam.app',
+        }),
+        runner,
+        logger: { log: vi.fn() },
+      })
+    ).toThrow('Hosted Convex environment reconciliation failed');
+
+    expect(runner).not.toHaveBeenCalledWith(
+      'node',
+      ['scripts/convex/probe-signed-throttle-ready.mjs'],
+      expect.anything()
+    );
   });
 
   it('can force hosted preview builds to deploy Convex explicitly', () => {
@@ -284,7 +349,7 @@ describe('bootstrap-convex-env', () => {
       '--preview-create',
       'codex/canary-local-ci-agentic-qa',
     ]);
-    expect(calls.at(-1)).toEqual({
+    expect(calls).toContainEqual({
       bin: 'pnpm',
       args: [
         'exec',
@@ -295,6 +360,10 @@ describe('bootstrap-convex-env', () => {
         '--preview-create',
         'codex/canary-local-ci-agentic-qa',
       ],
+    });
+    expect(calls.at(-1)).toEqual({
+      bin: 'node',
+      args: ['scripts/ci/reconcile-convex-env.mjs'],
     });
   });
 
@@ -423,6 +492,7 @@ exit 0
       expect(readFileSync(logPath, 'utf8').trim().split('\n')).toEqual([
         'exec convex env --preview-name codex/canary-local-ci-agentic-qa set GUEST_TOKEN_SECRET guest-secret',
         'exec convex env --preview-name codex/canary-local-ci-agentic-qa set CLERK_JWT_ISSUER_DOMAIN https://solid-beetle-24.clerk.accounts.dev',
+        'exec convex env --preview-name codex/canary-local-ci-agentic-qa set LINEJAM_DEPLOY_ENVIRONMENT preview',
       ]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
@@ -434,6 +504,7 @@ exit 0
       join(tmpdir(), 'linejam-bootstrap-convex-deploy-')
     );
     const fakePnpm = join(tempDir, 'pnpm');
+    const fakeNode = join(tempDir, 'node');
     const logPath = join(tempDir, 'pnpm.log');
 
     try {
@@ -445,6 +516,14 @@ exit 0
 `
       );
       chmodSync(fakePnpm, 0o755);
+      writeFileSync(
+        fakeNode,
+        `#!/bin/sh
+printf 'node %s\n' "$*" >> "${logPath}"
+exit 0
+`
+      );
+      chmodSync(fakeNode, 0o755);
 
       const result = spawnSync(
         process.execPath,
@@ -473,7 +552,10 @@ exit 0
       expect(readFileSync(logPath, 'utf8').trim().split('\n')).toEqual([
         'exec convex env --prod set GUEST_TOKEN_SECRET guest-secret',
         'exec convex env --prod set CLERK_JWT_ISSUER_DOMAIN https://clerk.linejam.app',
+        'exec convex env --prod set LINEJAM_DEPLOY_ENVIRONMENT production',
         'exec convex deploy --cmd pnpm run build:check',
+        'node scripts/ci/reconcile-convex-env.mjs',
+        'node scripts/convex/probe-signed-throttle-ready.mjs',
       ]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/tests/scripts/convex-probe-signed-throttle-ready.test.ts
+++ b/tests/scripts/convex-probe-signed-throttle-ready.test.ts
@@ -1,7 +1,11 @@
 /** @vitest-environment node */
 import { describe, expect, it, vi } from 'vitest';
 import { ConvexError } from 'convex/values';
-import { probeSignedThrottleReady } from '@/scripts/convex/probe-signed-throttle-ready.mjs';
+import {
+  assertSelectedDeploymentMatches,
+  parseFunctionSpecDeploymentUrl,
+  probeSignedThrottleReady,
+} from '@/scripts/convex/probe-signed-throttle-ready.mjs';
 import { signGuestSessionThrottleProof } from '@/lib/guestSessionThrottleProof';
 
 const TEST_SECRET = 'test-guest-token-secret-with-enough-entropy';
@@ -73,5 +77,58 @@ describe('probeSignedThrottleReady', () => {
     await expect(
       probeSignedThrottleReady('https://test.convex.cloud', '', vi.fn())
     ).rejects.toThrow('GUEST_TOKEN_SECRET is required');
+  });
+});
+
+describe('deployment identity verification', () => {
+  it('accepts the production selector only when its public URL matches the web target', () => {
+    const runner = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({
+        url: 'https://test.convex.cloud/',
+        functions: [],
+      }),
+      stderr: '',
+    });
+
+    expect(
+      assertSelectedDeploymentMatches(
+        'https://test.convex.cloud',
+        { ...process.env, CONVEX_DEPLOY_KEY: 'prod:test' },
+        runner
+      )
+    ).toBe('https://test.convex.cloud');
+    expect(runner).toHaveBeenCalledWith(
+      'pnpm',
+      ['exec', 'convex', 'function-spec', '--prod'],
+      expect.objectContaining({ encoding: 'utf8' })
+    );
+  });
+
+  it('fails closed when the selected production deployment is a sibling', () => {
+    const runner = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({
+        url: 'https://sibling.convex.cloud',
+        functions: [],
+      }),
+      stderr: 'must not be replayed',
+    });
+
+    expect(() =>
+      assertSelectedDeploymentMatches(
+        'https://test.convex.cloud',
+        { ...process.env },
+        runner
+      )
+    ).toThrow('does not match the production deployment');
+  });
+
+  it('parses only the public deployment URL from function-spec', () => {
+    expect(
+      parseFunctionSpecDeploymentUrl(
+        JSON.stringify({ url: 'https://test.convex.cloud', functions: [] })
+      )
+    ).toBe('https://test.convex.cloud');
   });
 });

--- a/tests/scripts/convex-probe-signed-throttle-ready.test.ts
+++ b/tests/scripts/convex-probe-signed-throttle-ready.test.ts
@@ -101,7 +101,7 @@ describe('deployment identity verification', () => {
     expect(runner).toHaveBeenCalledWith(
       'pnpm',
       ['exec', 'convex', 'function-spec', '--prod'],
-      expect.objectContaining({ encoding: 'utf8' })
+      expect.objectContaining({ encoding: 'utf8', timeout: 30_000 })
     );
   });
 
@@ -130,5 +130,19 @@ describe('deployment identity verification', () => {
         JSON.stringify({ url: 'https://test.convex.cloud', functions: [] })
       )
     ).toBe('https://test.convex.cloud');
+  });
+
+  it('fails closed when the deployment identity read times out', () => {
+    const timeout = Object.assign(new Error('do-not-replay'), {
+      code: 'ETIMEDOUT',
+    });
+
+    expect(() =>
+      assertSelectedDeploymentMatches(
+        'https://test.convex.cloud',
+        { ...process.env },
+        vi.fn().mockReturnValue({ status: null, error: timeout })
+      )
+    ).toThrow('deployment identity read timed out');
   });
 });

--- a/tests/scripts/reconcile-convex-env.test.ts
+++ b/tests/scripts/reconcile-convex-env.test.ts
@@ -1,0 +1,209 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  diffConvexEnvNames,
+  parseConvexEnvNames,
+  resolveReconciliationTarget,
+  runConvexEnvReconciliation,
+  validateConvexEnvManifest,
+} from '@/scripts/ci/reconcile-convex-env.mjs';
+
+const manifest = {
+  schemaVersion: 1 as const,
+  environments: {
+    development: {
+      required: ['CLERK_JWT_ISSUER_DOMAIN', 'GUEST_TOKEN_SECRET'],
+      optional: ['OPENROUTER_API_KEY'],
+    },
+    preview: {
+      required: ['GUEST_TOKEN_SECRET', 'OPENROUTER_API_KEY'],
+      optional: [],
+    },
+    production: {
+      required: [
+        'CANARY_API_KEY',
+        'CANARY_ENDPOINT',
+        'CLERK_JWT_ISSUER_DOMAIN',
+        'GUEST_TOKEN_SECRET',
+        'OPENROUTER_API_KEY',
+      ],
+      optional: ['AI_MODEL'],
+    },
+  },
+};
+
+describe('Convex environment reconciliation', () => {
+  it('supports explicit values-free operator targets without a deploy key', () => {
+    const emptyEnv = {} as NodeJS.ProcessEnv;
+    expect(
+      resolveReconciliationTarget(['--target', 'development'], emptyEnv)
+    ).toEqual({ status: 'default', args: [], explicit: true });
+    expect(
+      resolveReconciliationTarget(['--target', 'production'], emptyEnv)
+    ).toEqual({ status: 'prod', args: ['--prod'], explicit: true });
+  });
+
+  it('removes an ambient deploy key from explicit operator targets', () => {
+    const runner = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: 'CLERK_JWT_ISSUER_DOMAIN\nGUEST_TOKEN_SECRET\n',
+      stderr: '',
+    });
+
+    runConvexEnvReconciliation({
+      target: { status: 'default', args: [], explicit: true },
+      manifest,
+      runner,
+      logger: { log: vi.fn() },
+      env: { ...process.env, CONVEX_DEPLOY_KEY: 'prod:must-not-leak' },
+    });
+
+    expect(runner).toHaveBeenCalledWith(
+      'pnpm',
+      ['exec', 'convex', 'env', 'list', '--names-only'],
+      expect.objectContaining({
+        env: expect.not.objectContaining({
+          CONVEX_DEPLOY_KEY: expect.anything(),
+        }),
+      })
+    );
+  });
+
+  it('validates a values-free, environment-specific manifest', () => {
+    expect(validateConvexEnvManifest(manifest)).toEqual(manifest);
+    expect(() =>
+      validateConvexEnvManifest({
+        ...manifest,
+        environments: {
+          ...manifest.environments,
+          production: {
+            required: ['GUEST_TOKEN_SECRET=secret-value'],
+            optional: [],
+          },
+        },
+      })
+    ).toThrow('environment variable names');
+    expect(() =>
+      validateConvexEnvManifest({
+        ...manifest,
+        secretValues: { GUEST_TOKEN_SECRET: 'do-not-store-this' },
+      })
+    ).toThrow('unsupported fields');
+  });
+
+  it('parses only names and refuses value-bearing CLI output without echoing it', () => {
+    expect(
+      parseConvexEnvNames('GUEST_TOKEN_SECRET\nOPENROUTER_API_KEY\n')
+    ).toEqual(['GUEST_TOKEN_SECRET', 'OPENROUTER_API_KEY']);
+
+    const secretOutput = 'GUEST_TOKEN_SECRET=do-not-disclose';
+    let error: unknown;
+    try {
+      parseConvexEnvNames(secretOutput);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).toContain('names-only');
+    expect(String(error)).not.toContain('do-not-disclose');
+  });
+
+  it('reports missing and unexpected names deterministically', () => {
+    expect(
+      diffConvexEnvNames(manifest.environments.production, [
+        'OPENROUTER_API_KEY',
+        'GUEST_TOKEN_SECRET',
+        'UNDECLARED_KEY',
+        'CANARY_ENDPOINT',
+        'CANARY_API_KEY',
+      ])
+    ).toEqual({
+      missing: ['CLERK_JWT_ISSUER_DOMAIN'],
+      unexpected: ['UNDECLARED_KEY'],
+    });
+  });
+
+  it('targets production with names-only output and emits a names-only receipt', () => {
+    const runner = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: [
+        'CANARY_API_KEY',
+        'CANARY_ENDPOINT',
+        'CLERK_JWT_ISSUER_DOMAIN',
+        'GUEST_TOKEN_SECRET',
+        'OPENROUTER_API_KEY',
+      ].join('\n'),
+      stderr: 'provider warning that must not be echoed',
+    });
+    const logger = { log: vi.fn() };
+
+    expect(
+      runConvexEnvReconciliation({
+        target: { status: 'prod', args: ['--prod'] },
+        manifest,
+        runner,
+        logger,
+      })
+    ).toMatchObject({
+      environment: 'production',
+      missing: [],
+      unexpected: [],
+    });
+    expect(runner).toHaveBeenCalledWith(
+      'pnpm',
+      ['exec', 'convex', 'env', '--prod', 'list', '--names-only'],
+      expect.objectContaining({ encoding: 'utf8' })
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'CANARY_API_KEY,CANARY_ENDPOINT,CLERK_JWT_ISSUER_DOMAIN,GUEST_TOKEN_SECRET,OPENROUTER_API_KEY'
+      )
+    );
+    expect(logger.log).not.toHaveBeenCalledWith(
+      expect.stringContaining('provider warning')
+    );
+  });
+
+  it('fails closed naming only the missing variable', () => {
+    const runner = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: [
+        'CANARY_API_KEY',
+        'CANARY_ENDPOINT',
+        'CLERK_JWT_ISSUER_DOMAIN',
+        'GUEST_TOKEN_SECRET',
+      ].join('\n'),
+      stderr: 'do-not-disclose-provider-output',
+    });
+
+    expect(() =>
+      runConvexEnvReconciliation({
+        target: { status: 'prod', args: ['--prod'] },
+        manifest,
+        runner,
+        logger: { log: vi.fn() },
+      })
+    ).toThrow(
+      'Convex production environment drift: missing=OPENROUTER_API_KEY; unexpected=none'
+    );
+  });
+
+  it('fails without replaying CLI output when the names-only command fails', () => {
+    const runner = vi.fn().mockReturnValue({
+      status: 1,
+      stdout: 'GUEST_TOKEN_SECRET=do-not-disclose',
+      stderr: 'CONVEX_DEPLOY_KEY=do-not-disclose',
+    });
+
+    expect(() =>
+      runConvexEnvReconciliation({
+        target: { status: 'prod', args: ['--prod'] },
+        manifest,
+        runner,
+        logger: { log: vi.fn() },
+      })
+    ).toThrow('Convex production names-only read failed with status 1');
+  });
+});

--- a/tests/scripts/reconcile-convex-env.test.ts
+++ b/tests/scripts/reconcile-convex-env.test.ts
@@ -154,7 +154,7 @@ describe('Convex environment reconciliation', () => {
     expect(runner).toHaveBeenCalledWith(
       'pnpm',
       ['exec', 'convex', 'env', '--prod', 'list', '--names-only'],
-      expect.objectContaining({ encoding: 'utf8' })
+      expect.objectContaining({ encoding: 'utf8', timeout: 30_000 })
     );
     expect(logger.log).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -205,5 +205,20 @@ describe('Convex environment reconciliation', () => {
         logger: { log: vi.fn() },
       })
     ).toThrow('Convex production names-only read failed with status 1');
+  });
+
+  it('fails closed when the names-only CLI times out', () => {
+    const timeout = Object.assign(new Error('do-not-replay'), {
+      code: 'ETIMEDOUT',
+    });
+
+    expect(() =>
+      runConvexEnvReconciliation({
+        target: { status: 'prod', args: ['--prod'] },
+        manifest,
+        runner: vi.fn().mockReturnValue({ status: null, error: timeout }),
+        logger: { log: vi.fn() },
+      })
+    ).toThrow('Convex production names-only read timed out');
   });
 });


### PR DESCRIPTION
## Summary
- declare required/optional Convex env names per development, preview, and production without storing values
- block hosted activation on exact-target names-only reconciliation, deployment identity, and zero-write guest-secret parity
- make runtime health fail closed on missing/invalid deployment markers, backend URL mismatch, missing manifest names, or secret mismatch

## Review
Fresh Solomon reliability/security review found and drove fixes for fail-open marker loss, split-target verification, ambient deploy-key contamination, timeout noise, and an orphaned live fixture.

## Verification
- focused: 89 passed, 1 live-only skip
- `pnpm typecheck`: green
- production-configured `pnpm build:check`: green
- `pnpm ci:prepush`: 137 files; 1,502 passed, 1 skipped
- commit hooks: gitleaks, formatting, lint, commitlint green
- shared dev: marker absent => HTTP 500; marker restored => HTTP 200
- shared-dev and production names-only reconciliation: green
- production function-spec identity + signed zero-write parity: green

Powder: linejam-961

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment reconciliation for development, preview, and production deployments.
  * Health checks now verify required configuration, deployment identity, and guest-session readiness.
  * Hosted deployments now perform post-deployment configuration and production readiness checks.
  * Added a command for reconciling development environment configuration.

* **Bug Fixes**
  * Health checks now fail safely when deployments are mismatched, improperly configured, or guest credentials differ.

* **Documentation**
  * Updated deployment and observability guidance for environment reconciliation and readiness verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->