### PR TITLE
feat(ops): declare DigitalOcean topology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Compact router for repository agents. Read only the depth your lane needs.
 | CI and live-operation authority | `docs/ops/observability-ci.md`, `scripts/ci/dagger-call.sh`  |
 | Production operations           | `docs/deployment.md`                                         |
 | Convex environment contract     | `config/convex-env-manifest.json`                            |
+| DigitalOcean topology contract  | `config/digitalocean-apps.json`, `pnpm ops:do-drift`         |
 | Agent CLI/MCP                   | `.agents/skills/linejam-cli/SKILL.md`, `docs/agent-faces.md` |
 
 The live stack is declared in `package.json`; do not copy dependency versions

--- a/config/digitalocean-apps.json
+++ b/config/digitalocean-apps.json
@@ -1,0 +1,247 @@
+{
+  "schemaVersion": 1,
+  "deploymentAuthority": {
+    "source": {
+      "repository": "misty-step/linejam",
+      "branch": "master"
+    },
+    "frontendProductionOwner": {
+      "app": "linejam",
+      "component": "web"
+    },
+    "convexProductionOwner": {
+      "app": "linejam",
+      "component": "web",
+      "buildCommand": "pnpm install --frozen-lockfile && pnpm build"
+    }
+  },
+  "apps": [
+    {
+      "id": "53289d4b-0e9e-4e96-816c-f91348f2473f",
+      "name": "linejam",
+      "region": "nyc",
+      "features": ["buildpack-stack=ubuntu-22"],
+      "domains": [
+        {
+          "domain": "linejam.app",
+          "type": "PRIMARY",
+          "zone": "linejam.app"
+        },
+        {
+          "domain": "www.linejam.app",
+          "type": "ALIAS",
+          "zone": "linejam.app"
+        }
+      ],
+      "ingress": [{ "pathPrefix": "/", "component": "web" }],
+      "services": [
+        {
+          "name": "web",
+          "source": {
+            "repository": "misty-step/linejam",
+            "branch": "master",
+            "deployOnPush": true
+          },
+          "buildCommand": "pnpm install --frozen-lockfile && pnpm build",
+          "runCommand": "pnpm run start:next",
+          "httpPort": 3000,
+          "instanceCount": 1,
+          "instanceSize": "apps-s-1vcpu-1gb",
+          "healthCheckPath": "/api/health",
+          "environment": [
+            {
+              "name": "CANARY_API_KEY",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "CANARY_ENDPOINT",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "CLERK_JWT_ISSUER_DOMAIN",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "CLERK_SECRET_KEY",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "CONVEX_DEPLOYMENT",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "CONVEX_DEPLOYMENT_URL",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "CONVEX_DEPLOY_KEY",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "GUEST_TOKEN_SECRET",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "LINEJAM_DEPLOY_ENVIRONMENT",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "NEXT_PUBLIC_CANARY_API_KEY",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "NEXT_PUBLIC_CANARY_ENDPOINT",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "NEXT_PUBLIC_CONVEX_URL",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "NEXT_PUBLIC_SENTRY_DSN",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "PLAYWRIGHT_CLERK_TEST_EMAIL",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "SENTRY_AUTH_TOKEN",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "SENTRY_ORG",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "SENTRY_PROJECT",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ba0f56a7-f866-4238-af72-57bb64528f78",
+      "name": "linejam-canary-responder",
+      "region": "nyc",
+      "features": ["buildpack-stack=ubuntu-22"],
+      "domains": [],
+      "ingress": [{ "pathPrefix": "/", "component": "responder" }],
+      "services": [
+        {
+          "name": "responder",
+          "source": {
+            "repository": "misty-step/linejam",
+            "branch": "master",
+            "deployOnPush": true
+          },
+          "dockerfilePath": "Dockerfile.responder",
+          "httpPort": 8787,
+          "instanceCount": 1,
+          "instanceSize": "apps-s-1vcpu-2gb",
+          "healthCheckPath": "/healthz",
+          "environment": [
+            {
+              "name": "CANARY_API_KEY",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "CANARY_ENDPOINT",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "CLERK_SECRET_KEY",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "LINEJAM_ALLOWED_SMOKE_ORIGINS",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "LINEJAM_CANARY_RESPONDER_PORT",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "LINEJAM_CANARY_SERVICE",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "LINEJAM_CANARY_STORE_DIR",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "LINEJAM_CANARY_WEBHOOK_PATH",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "LINEJAM_CANARY_WEBHOOK_SECRET",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "LINEJAM_ENFORCE_SMOKE_URL_ALLOWLIST",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "LINEJAM_SMOKE_RUNNER",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "PLAYWRIGHT_BASE_URL",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
+              "name": "PLAYWRIGHT_CLERK_TEST_EMAIL",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "PLAYWRIGHT_REQUIRE_AUTH_SMOKE",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -99,6 +99,7 @@ must receive the identical value. A mismatch breaks guest-token verification.
 | `GUEST_TOKEN_SECRET`                | signs web guest tokens; must match Convex          |
 | `NEXT_PUBLIC_CONVEX_URL`            | production Convex URL                              |
 | `CONVEX_DEPLOYMENT`                 | production Convex deployment selector              |
+| `CONVEX_DEPLOYMENT_URL`             | production Convex deployment URL                   |
 | `CONVEX_DEPLOY_KEY`                 | production deploy key used during the hosted build |
 | `LINEJAM_DEPLOY_ENVIRONMENT`        | `production`; fail-closed hosted deploy guard      |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | browser Clerk key                                  |
@@ -108,7 +109,11 @@ must receive the identical value. A mismatch breaks guest-token verification.
 | `CANARY_API_KEY`                    | server-side Canary credential                      |
 | `NEXT_PUBLIC_CANARY_ENDPOINT`       | `https://canary.mistystep.io`                      |
 | `NEXT_PUBLIC_CANARY_API_KEY`        | browser write-only Canary credential               |
+| `NEXT_PUBLIC_SENTRY_DSN`            | browser Sentry destination                         |
 | `PLAYWRIGHT_CLERK_TEST_EMAIL`       | pre-created production smoke user                  |
+| `SENTRY_AUTH_TOKEN`                 | source-map upload credential                       |
+| `SENTRY_ORG`                        | Sentry organization slug                           |
+| `SENTRY_PROJECT`                    | Sentry project slug                                |
 
 ### Canary responder
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -16,6 +16,12 @@ Both apps deploy automatically from `master`. The public application is
 `https://linejam.app`; the responder is currently reachable at
 `https://linejam-canary-responder-fdflj.ondigitalocean.app`.
 
+[`config/digitalocean-apps.json`](../config/digitalocean-apps.json) is the
+canonical, values-free topology contract. It pins components, routes, domains,
+health checks, source, build/run commands, environment variable names, and the
+single frontend and Convex production deploy owner. The live provider spec must
+reconcile with it before a release is accepted.
+
 The stable Canary API origin is `https://canary.mistystep.io`. Use that custom
 hostname in application defaults and provider configuration rather than a
 provider-generated hostname.
@@ -29,9 +35,10 @@ provider-generated hostname.
   the approved credential plane
 - GitHub Actions access for the hosted quality and smoke gates
 
-Never commit an exported App Platform spec or print secret values. Exported
-specs can contain encrypted provider values and belong in a mode-`0600`
-temporary file only.
+Never commit a raw exported App Platform spec or print secret values. Raw
+exports can contain encrypted provider values and belong in a mode-`0600`
+temporary file only. The committed topology contract is separately constructed
+and validated to reject every environment `value` field.
 
 ## Discover the live apps
 
@@ -62,6 +69,23 @@ doctl apps get "$LINEJAM_RESPONDER_APP_ID" -o json |
 ```
 
 Both active deployments must report `ACTIVE` before a release is accepted.
+
+Reconcile every meaningful, non-value provider field against the committed
+contract with:
+
+```bash
+pnpm ops:do-drift
+```
+
+The command performs bounded, read-only `doctl apps get` calls. It discards
+provider-generated deployment fields and all environment values before the
+comparison. A bounded account inventory also rejects undeclared App Platform
+apps sourced from `misty-step/linejam@master`. Workers, jobs, functions, static
+sites, databases, and app-level environment blocks fail closed until the
+canonical model explicitly supports them. Failures report only sanitized field
+paths; provider stdout and stderr are never replayed. A component, build
+command, route, source, health check, environment name/type/scope, domain, or
+sizing change is meaningful drift.
 
 ## Environment contract
 
@@ -325,6 +349,7 @@ pnpm exec convex import --replace-all ./convex-backup.zip --prod
 ## Release checklist
 
 - [ ] `pnpm ci:prepush` passes
+- [ ] `pnpm ops:do-drift` reports both production apps clean
 - [ ] `pnpm ci:dagger:all` passes or its environment limitation is recorded
 - [ ] hosted merge and smoke gates pass
 - [ ] web and responder active deployments match the intended source SHA

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:convex": "convex dev",
     "convex:sync:shared-dev": "./scripts/ci/dagger-call.sh sync-shared-dev",
     "convex:env:reconcile": "node ./scripts/ci/reconcile-convex-env.mjs --target development",
+    "ops:do-drift": "node ./scripts/ops/check-digitalocean-app-drift.mjs",
     "build": "node ./scripts/ci/bootstrap-convex-env.mjs --deploy",
     "build:check": "next build",
     "start:next": "next start",

--- a/scripts/ops/check-digitalocean-app-drift.mjs
+++ b/scripts/ops/check-digitalocean-app-drift.mjs
@@ -1,0 +1,675 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const DOCTL_READ_TIMEOUT_MS = 30_000;
+const DOCTL_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+const ENV_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+const COMPONENT_COLLECTIONS = [
+  'services',
+  'workers',
+  'jobs',
+  'functions',
+  'static_sites',
+];
+const UNMODELED_LIVE_FIELDS = [
+  'workers',
+  'jobs',
+  'functions',
+  'static_sites',
+  'databases',
+  'envs',
+];
+const MODELED_APP_SPEC_FIELDS = [
+  'name',
+  'region',
+  'features',
+  'domains',
+  'ingress',
+  'services',
+];
+const MODELED_SERVICE_FIELDS = [
+  'name',
+  'github',
+  'dockerfile_path',
+  'build_command',
+  'run_command',
+  'http_port',
+  'instance_count',
+  'instance_size_slug',
+  'health_check',
+  'envs',
+];
+const DEFAULT_MANIFEST_URL = new URL(
+  '../../config/digitalocean-apps.json',
+  import.meta.url
+);
+
+/** @typedef {(command: string, args: string[], options: import('node:child_process').SpawnSyncOptionsWithStringEncoding) => { status: number | null, stdout?: string, stderr?: string, error?: NodeJS.ErrnoException }} Runner */
+
+function assertObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+}
+
+function assertExactKeys(value, allowed, label) {
+  assertObject(value, label);
+  const unsupported = Object.keys(value).filter(
+    (key) => !allowed.includes(key)
+  );
+  if (unsupported.length > 0) {
+    throw new Error(
+      `${label} has unsupported fields: ${unsupported.join(',')}.`
+    );
+  }
+}
+
+function assertString(value, label) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+}
+
+function assertValuesFree(value, path = 'manifest') {
+  if (!value || typeof value !== 'object') return;
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) =>
+      assertValuesFree(entry, `${path}[${index}]`)
+    );
+    return;
+  }
+
+  if (Object.hasOwn(value, 'value')) {
+    throw new Error(`${path} must remain values-free.`);
+  }
+  for (const [key, entry] of Object.entries(value)) {
+    assertValuesFree(entry, `${path}.${key}`);
+  }
+}
+
+function assertUnique(values, label) {
+  const duplicates = values.filter(
+    (value, index) => values.indexOf(value) !== index
+  );
+  if (duplicates.length > 0) {
+    throw new Error(
+      `${label} contains duplicates: ${[...new Set(duplicates)].join(',')}.`
+    );
+  }
+}
+
+function validateSource(source, label) {
+  assertExactKeys(source, ['repository', 'branch', 'deployOnPush'], label);
+  assertString(source.repository, `${label}.repository`);
+  assertString(source.branch, `${label}.branch`);
+  if (
+    source.deployOnPush !== undefined &&
+    typeof source.deployOnPush !== 'boolean'
+  ) {
+    throw new Error(`${label}.deployOnPush must be boolean.`);
+  }
+}
+
+function validateOwner(owner, label, withBuildCommand = false) {
+  const keys = withBuildCommand
+    ? ['app', 'component', 'buildCommand']
+    : ['app', 'component'];
+  assertExactKeys(owner, keys, label);
+  assertString(owner.app, `${label}.app`);
+  assertString(owner.component, `${label}.component`);
+  if (withBuildCommand)
+    assertString(owner.buildCommand, `${label}.buildCommand`);
+}
+
+function validateService(service, label) {
+  assertExactKeys(
+    service,
+    [
+      'name',
+      'source',
+      'dockerfilePath',
+      'buildCommand',
+      'runCommand',
+      'httpPort',
+      'instanceCount',
+      'instanceSize',
+      'healthCheckPath',
+      'environment',
+    ],
+    label
+  );
+  assertString(service.name, `${label}.name`);
+  validateSource(service.source, `${label}.source`);
+  for (const field of ['dockerfilePath', 'buildCommand', 'runCommand']) {
+    if (service[field] !== undefined)
+      assertString(service[field], `${label}.${field}`);
+  }
+  if (!Number.isInteger(service.httpPort) || service.httpPort < 1) {
+    throw new Error(`${label}.httpPort must be a positive integer.`);
+  }
+  if (!Number.isInteger(service.instanceCount) || service.instanceCount < 1) {
+    throw new Error(`${label}.instanceCount must be a positive integer.`);
+  }
+  assertString(service.instanceSize, `${label}.instanceSize`);
+  assertString(service.healthCheckPath, `${label}.healthCheckPath`);
+  if (!Array.isArray(service.environment)) {
+    throw new Error(`${label}.environment must be an array.`);
+  }
+  assertUnique(
+    service.environment.map((entry) => entry.name),
+    `${label}.environment`
+  );
+  service.environment.forEach((entry, index) => {
+    const envLabel = `${label}.environment[${index}]`;
+    assertExactKeys(entry, ['name', 'scope', 'secret'], envLabel);
+    if (!ENV_NAME_PATTERN.test(entry.name)) {
+      throw new Error(`${envLabel}.name must be an environment variable name.`);
+    }
+    assertString(entry.scope, `${envLabel}.scope`);
+    if (typeof entry.secret !== 'boolean') {
+      throw new Error(`${envLabel}.secret must be boolean.`);
+    }
+  });
+}
+
+/**
+ * Validate the deliberately sanitized provider contract. It is not a provider
+ * export: value fields are forbidden at every depth.
+ */
+export function validateDigitalOceanAppManifest(candidate) {
+  assertValuesFree(candidate);
+  assertExactKeys(
+    candidate,
+    ['schemaVersion', 'deploymentAuthority', 'apps'],
+    'manifest'
+  );
+  if (candidate.schemaVersion !== 1) {
+    throw new Error('manifest.schemaVersion must be 1.');
+  }
+  assertExactKeys(
+    candidate.deploymentAuthority,
+    ['source', 'frontendProductionOwner', 'convexProductionOwner'],
+    'manifest.deploymentAuthority'
+  );
+  validateSource(
+    candidate.deploymentAuthority.source,
+    'manifest.deploymentAuthority.source'
+  );
+  validateOwner(
+    candidate.deploymentAuthority.frontendProductionOwner,
+    'manifest.deploymentAuthority.frontendProductionOwner'
+  );
+  validateOwner(
+    candidate.deploymentAuthority.convexProductionOwner,
+    'manifest.deploymentAuthority.convexProductionOwner',
+    true
+  );
+  if (!Array.isArray(candidate.apps) || candidate.apps.length === 0) {
+    throw new Error('manifest.apps must be a non-empty array.');
+  }
+  assertUnique(
+    candidate.apps.map((app) => app.id),
+    'manifest.apps ids'
+  );
+  assertUnique(
+    candidate.apps.map((app) => app.name),
+    'manifest.apps names'
+  );
+
+  candidate.apps.forEach((app, appIndex) => {
+    const label = `manifest.apps[${appIndex}]`;
+    assertExactKeys(
+      app,
+      ['id', 'name', 'region', 'features', 'domains', 'ingress', 'services'],
+      label
+    );
+    assertString(app.id, `${label}.id`);
+    assertString(app.name, `${label}.name`);
+    assertString(app.region, `${label}.region`);
+    if (!Array.isArray(app.features) || !Array.isArray(app.domains)) {
+      throw new Error(`${label}.features and domains must be arrays.`);
+    }
+    app.features.forEach((feature, index) =>
+      assertString(feature, `${label}.features[${index}]`)
+    );
+    app.domains.forEach((domain, index) => {
+      const domainLabel = `${label}.domains[${index}]`;
+      assertExactKeys(domain, ['domain', 'type', 'zone'], domainLabel);
+      assertString(domain.domain, `${domainLabel}.domain`);
+      assertString(domain.type, `${domainLabel}.type`);
+      assertString(domain.zone, `${domainLabel}.zone`);
+    });
+    assertUnique(
+      app.domains.map((domain) => domain.domain),
+      `${label}.domains`
+    );
+    if (!Array.isArray(app.ingress) || !Array.isArray(app.services)) {
+      throw new Error(`${label}.ingress and services must be arrays.`);
+    }
+    app.ingress.forEach((rule, index) => {
+      const ruleLabel = `${label}.ingress[${index}]`;
+      assertExactKeys(rule, ['pathPrefix', 'component'], ruleLabel);
+      assertString(rule.pathPrefix, `${ruleLabel}.pathPrefix`);
+      assertString(rule.component, `${ruleLabel}.component`);
+    });
+    assertUnique(
+      app.ingress.map((rule) => `${rule.pathPrefix}->${rule.component}`),
+      `${label}.ingress`
+    );
+    assertUnique(
+      app.services.map((service) => service.name),
+      `${label}.services`
+    );
+    app.services.forEach((service, index) =>
+      validateService(service, `${label}.services[${index}]`)
+    );
+  });
+
+  const findOwnerService = (owner, label) => {
+    const app = candidate.apps.find((entry) => entry.name === owner.app);
+    const service = app?.services.find(
+      (entry) => entry.name === owner.component
+    );
+    if (!service)
+      throw new Error(`${label} does not resolve to a declared service.`);
+    return service;
+  };
+  const frontendOwner = candidate.deploymentAuthority.frontendProductionOwner;
+  findOwnerService(frontendOwner, 'frontend production owner');
+  const domainApps = candidate.apps.filter((app) => app.domains.length > 0);
+  if (domainApps.length !== 1 || domainApps[0].name !== frontendOwner.app) {
+    throw new Error(
+      'Exactly the frontend production owner app must declare domains.'
+    );
+  }
+  if (
+    !domainApps[0].ingress.some(
+      (rule) => rule.component === frontendOwner.component
+    )
+  ) {
+    throw new Error(
+      'Frontend production owner must own a declared ingress route.'
+    );
+  }
+  const convexService = findOwnerService(
+    candidate.deploymentAuthority.convexProductionOwner,
+    'Convex production owner'
+  );
+  if (
+    convexService.buildCommand !==
+    candidate.deploymentAuthority.convexProductionOwner.buildCommand
+  ) {
+    throw new Error(
+      'Convex production owner build command must match its service.'
+    );
+  }
+
+  const authoritySource = candidate.deploymentAuthority.source;
+  const allServices = candidate.apps.flatMap((app) =>
+    app.services.map((service) => ({ app: app.name, service }))
+  );
+  for (const { app, service } of allServices) {
+    if (
+      service.source.repository !== authoritySource.repository ||
+      service.source.branch !== authoritySource.branch ||
+      service.source.deployOnPush !== true
+    ) {
+      throw new Error(
+        `manifest service ${app}/${service.name} must use the declared source with deployOnPush enabled.`
+      );
+    }
+  }
+  const convexCommandOwners = allServices.filter(
+    ({ service }) =>
+      service.buildCommand ===
+      candidate.deploymentAuthority.convexProductionOwner.buildCommand
+  );
+  if (
+    convexCommandOwners.length !== 1 ||
+    convexCommandOwners[0].app !==
+      candidate.deploymentAuthority.convexProductionOwner.app ||
+    convexCommandOwners[0].service.name !==
+      candidate.deploymentAuthority.convexProductionOwner.component
+  ) {
+    throw new Error(
+      'Exactly one declared service must own the Convex production build command.'
+    );
+  }
+
+  return candidate;
+}
+
+export function loadDigitalOceanAppManifest(path = DEFAULT_MANIFEST_URL) {
+  return validateDigitalOceanAppManifest(
+    JSON.parse(readFileSync(path, 'utf8'))
+  );
+}
+
+function optional(target, key, value) {
+  if (typeof value === 'string' && value.trim() !== '') target[key] = value;
+}
+
+/** Strip provider-generated fields and every environment value. */
+export function normalizeDigitalOceanApp(readback) {
+  assertObject(readback, 'DigitalOcean app readback');
+  assertObject(readback.spec, 'DigitalOcean app spec');
+  const spec = readback.spec;
+  assertExactKeys(
+    spec,
+    [...MODELED_APP_SPEC_FIELDS, ...UNMODELED_LIVE_FIELDS],
+    `DigitalOcean app ${spec.name || 'unknown'} spec`
+  );
+  for (const field of UNMODELED_LIVE_FIELDS) {
+    const value = spec[field];
+    const populated = Array.isArray(value)
+      ? value.length > 0
+      : value !== undefined && value !== null;
+    if (populated) {
+      throw new Error(
+        `DigitalOcean app ${spec.name || 'unknown'} has unsupported live field spec.${field}.`
+      );
+    }
+  }
+  assertUnique(
+    (spec.services ?? []).map((service) => service.name),
+    `DigitalOcean app ${spec.name || 'unknown'} services`
+  );
+  const services = (spec.services ?? []).map((service) => {
+    assertExactKeys(
+      service,
+      MODELED_SERVICE_FIELDS,
+      `DigitalOcean app ${spec.name || 'unknown'} service ${service.name || 'unknown'}`
+    );
+    assertUnique(
+      (service.envs ?? []).map((entry) => entry.key),
+      `DigitalOcean app ${spec.name || 'unknown'} service ${service.name || 'unknown'} environment`
+    );
+    const normalized = {
+      name: service.name,
+      source: {
+        repository: service.github?.repo,
+        branch: service.github?.branch,
+        deployOnPush: service.github?.deploy_on_push,
+      },
+      httpPort: service.http_port,
+      instanceCount: service.instance_count,
+      instanceSize: service.instance_size_slug,
+      healthCheckPath: service.health_check?.http_path,
+      environment: (service.envs ?? [])
+        .map((entry) => ({
+          name: entry.key,
+          scope: entry.scope,
+          secret: entry.type === 'SECRET',
+        }))
+        .sort((left, right) => left.name.localeCompare(right.name)),
+    };
+    optional(normalized, 'dockerfilePath', service.dockerfile_path);
+    optional(normalized, 'buildCommand', service.build_command);
+    optional(normalized, 'runCommand', service.run_command);
+    return normalized;
+  });
+
+  assertUnique(
+    (spec.domains ?? []).map((domain) => domain.domain),
+    `DigitalOcean app ${spec.name || 'unknown'} domains`
+  );
+  assertUnique(
+    (spec.ingress?.rules ?? []).map(
+      (rule) =>
+        `${rule.match?.path?.prefix || 'unknown'}->${rule.component?.name || 'unknown'}`
+    ),
+    `DigitalOcean app ${spec.name || 'unknown'} ingress`
+  );
+
+  return {
+    id: readback.id,
+    name: spec.name,
+    region: spec.region,
+    features: [...(spec.features ?? [])].sort(),
+    domains: (spec.domains ?? [])
+      .map(({ domain, type, zone }) => ({ domain, type, zone }))
+      .sort((left, right) => left.domain.localeCompare(right.domain)),
+    ingress: (spec.ingress?.rules ?? [])
+      .map((rule) => ({
+        pathPrefix: rule.match?.path?.prefix,
+        component: rule.component?.name,
+      }))
+      .sort((left, right) =>
+        `${left.pathPrefix}:${left.component}`.localeCompare(
+          `${right.pathPrefix}:${right.component}`
+        )
+      ),
+    services: services.sort((left, right) =>
+      left.name.localeCompare(right.name)
+    ),
+  };
+}
+
+function comparisonTree(app) {
+  return {
+    id: app.id,
+    name: app.name,
+    region: app.region,
+    features: app.features,
+    domains: Object.fromEntries(
+      app.domains.map(({ domain, ...details }) => [domain, details])
+    ),
+    ingress: Object.fromEntries(
+      app.ingress.map((rule) => [`${rule.pathPrefix}->${rule.component}`, true])
+    ),
+    services: Object.fromEntries(
+      app.services.map(({ name, environment, ...service }) => [
+        name,
+        {
+          ...service,
+          environment: Object.fromEntries(
+            environment.map(({ name: envName, ...entry }) => [envName, entry])
+          ),
+        },
+      ])
+    ),
+  };
+}
+
+function collectDrift(expected, actual, path, output) {
+  if (Object.is(expected, actual)) return;
+  if (Array.isArray(expected) || Array.isArray(actual)) {
+    if (JSON.stringify(expected) !== JSON.stringify(actual)) {
+      output.push({ path, expected, actual });
+    }
+    return;
+  }
+  if (
+    expected &&
+    actual &&
+    typeof expected === 'object' &&
+    typeof actual === 'object'
+  ) {
+    const keys = [
+      ...new Set([...Object.keys(expected), ...Object.keys(actual)]),
+    ].sort();
+    for (const key of keys) {
+      collectDrift(
+        expected[key],
+        actual[key],
+        path ? `${path}.${key}` : key,
+        output
+      );
+    }
+    return;
+  }
+  output.push({ path, expected, actual });
+}
+
+export function diffDigitalOceanApp(expected, actual) {
+  const drift = [];
+  collectDrift(comparisonTree(expected), comparisonTree(actual), '', drift);
+  return drift;
+}
+
+function parseReadback(stdout) {
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new Error('DigitalOcean provider read returned invalid JSON.');
+  }
+  if (!Array.isArray(parsed) || parsed.length !== 1) {
+    throw new Error(
+      'DigitalOcean provider read returned an unexpected app shape.'
+    );
+  }
+  return parsed[0];
+}
+
+function parseAppInventory(stdout) {
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new Error('DigitalOcean app inventory returned invalid JSON.');
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error('DigitalOcean app inventory returned an unexpected shape.');
+  }
+  return parsed;
+}
+
+function sourceApps(inventory, source) {
+  return inventory
+    .filter((app) =>
+      COMPONENT_COLLECTIONS.some((collection) =>
+        (app.spec?.[collection] ?? []).some(
+          (component) =>
+            component.github?.repo === source.repository &&
+            component.github?.branch === source.branch
+        )
+      )
+    )
+    .map((app) => ({ id: app.id, name: app.spec?.name || 'unknown' }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function runProviderRead(runner, label, args) {
+  const result = runner('doctl', args, {
+    encoding: 'utf8',
+    timeout: DOCTL_READ_TIMEOUT_MS,
+    maxBuffer: DOCTL_MAX_BUFFER_BYTES,
+  });
+  if (result.error) {
+    throw new Error(
+      result.error.code === 'ETIMEDOUT'
+        ? `DigitalOcean ${label} provider read timed out.`
+        : `DigitalOcean ${label} provider read failed to start.`
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `DigitalOcean ${label} provider read failed with status ${result.status ?? 'unknown'}.`
+    );
+  }
+  return result.stdout ?? '';
+}
+
+/**
+ * @param {{ manifest?: any, runner?: Runner, logger?: { log: (message: string) => void } }} [options]
+ */
+export function runDigitalOceanDriftCheck({
+  manifest = loadDigitalOceanAppManifest(),
+  runner = spawnSync,
+  logger = console,
+} = {}) {
+  const validated = validateDigitalOceanAppManifest(manifest);
+  const drift = [];
+  const checkedApps = [];
+
+  const inventory = parseAppInventory(
+    runProviderRead(runner, 'app inventory', [
+      'apps',
+      'list',
+      '--output',
+      'json',
+    ])
+  );
+  const liveSourceApps = sourceApps(
+    inventory,
+    validated.deploymentAuthority.source
+  );
+  const expectedIds = validated.apps.map((app) => app.id).sort();
+  const liveIds = liveSourceApps.map((app) => app.id);
+  const missingIds = expectedIds.filter((id) => !liveIds.includes(id));
+  const unexpectedApps = liveSourceApps.filter(
+    (app) => !expectedIds.includes(app.id)
+  );
+  if (missingIds.length > 0 || unexpectedApps.length > 0) {
+    const missingNames = validated.apps
+      .filter((app) => missingIds.includes(app.id))
+      .map((app) => app.name)
+      .sort();
+    const unexpectedNames = unexpectedApps.map((app) => app.name).sort();
+    throw new Error(
+      `DigitalOcean source-app drift: missing=${missingNames.join(',') || 'none'}; unexpected=${unexpectedNames.join(',') || 'none'}.`
+    );
+  }
+
+  for (const app of validated.apps) {
+    const actual = normalizeDigitalOceanApp(
+      parseReadback(
+        runProviderRead(runner, app.name, [
+          'apps',
+          'get',
+          app.id,
+          '--output',
+          'json',
+        ])
+      )
+    );
+    drift.push(
+      ...diffDigitalOceanApp(app, actual).map((entry) => ({
+        ...entry,
+        path: `apps.${app.name}.${entry.path}`,
+      }))
+    );
+    checkedApps.push(app.name);
+  }
+
+  if (drift.length > 0) {
+    throw new Error(
+      `DigitalOcean app drift: ${drift.map((entry) => entry.path).join(',')}`
+    );
+  }
+
+  logger.log(
+    `READY: DigitalOcean app drift clean for ${checkedApps.join(',')}`
+  );
+  return { checkedApps, drift };
+}
+
+function manifestArgument(argv) {
+  const index = argv.indexOf('--manifest');
+  if (index === -1) return undefined;
+  const value = argv[index + 1];
+  if (!value) throw new Error('--manifest requires a path.');
+  return value;
+}
+
+function main() {
+  const manifestPath = manifestArgument(process.argv.slice(2));
+  runDigitalOceanDriftCheck({
+    manifest: manifestPath
+      ? loadDigitalOceanAppManifest(manifestPath)
+      : loadDigitalOceanAppManifest(),
+  });
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error?.message || error);
+    process.exit(1);
+  }
+}

--- a/scripts/ops/check-digitalocean-app-drift.mjs
+++ b/scripts/ops/check-digitalocean-app-drift.mjs
@@ -42,6 +42,7 @@ const MODELED_SERVICE_FIELDS = [
   'health_check',
   'envs',
 ];
+const MODELED_ENVIRONMENT_FIELDS = ['key', 'scope', 'type', 'value'];
 const DEFAULT_MANIFEST_URL = new URL(
   '../../config/digitalocean-apps.json',
   import.meta.url
@@ -387,6 +388,13 @@ export function normalizeDigitalOceanApp(readback) {
       (service.envs ?? []).map((entry) => entry.key),
       `DigitalOcean app ${spec.name || 'unknown'} service ${service.name || 'unknown'} environment`
     );
+    (service.envs ?? []).forEach((entry) =>
+      assertExactKeys(
+        entry,
+        MODELED_ENVIRONMENT_FIELDS,
+        `DigitalOcean app ${spec.name || 'unknown'} service ${service.name || 'unknown'} environment entry`
+      )
+    );
     const normalized = {
       name: service.name,
       source: {
@@ -453,7 +461,7 @@ function comparisonTree(app) {
     id: app.id,
     name: app.name,
     region: app.region,
-    features: app.features,
+    features: [...app.features].sort(),
     domains: Object.fromEntries(
       app.domains.map(({ domain, ...details }) => [domain, details])
     ),

--- a/tests/scripts/canary-responder-http.test.ts
+++ b/tests/scripts/canary-responder-http.test.ts
@@ -398,6 +398,10 @@ describe('canary responder http server', () => {
       await waitForMockCalls(mocks.runSmoke, 2);
       expect(mocks.runSmoke).toHaveBeenCalledTimes(2);
       await waitForStoredFiles(dir, 'smoke', 2);
+      // A smoke artifact is written before the delivery update and summary.
+      // Wait for all three request summaries plus both terminal smoke summaries
+      // so teardown cannot race the background follow-up's remaining writes.
+      await waitForStoredFiles(dir, 'summaries', 5);
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }

--- a/tests/scripts/digitalocean-app-drift.test.ts
+++ b/tests/scripts/digitalocean-app-drift.test.ts
@@ -1,0 +1,375 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  diffDigitalOceanApp,
+  loadDigitalOceanAppManifest,
+  normalizeDigitalOceanApp,
+  runDigitalOceanDriftCheck,
+  validateDigitalOceanAppManifest,
+} from '@/scripts/ops/check-digitalocean-app-drift.mjs';
+
+const manifest = {
+  schemaVersion: 1 as const,
+  deploymentAuthority: {
+    source: { repository: 'misty-step/linejam', branch: 'master' },
+    frontendProductionOwner: { app: 'linejam', component: 'web' },
+    convexProductionOwner: {
+      app: 'linejam',
+      component: 'web',
+      buildCommand: 'pnpm install --frozen-lockfile && pnpm build',
+    },
+  },
+  apps: [
+    {
+      id: 'app-web',
+      name: 'linejam',
+      region: 'nyc',
+      features: ['buildpack-stack=ubuntu-22'],
+      domains: [
+        { domain: 'linejam.app', type: 'PRIMARY', zone: 'linejam.app' },
+      ],
+      ingress: [{ pathPrefix: '/', component: 'web' }],
+      services: [
+        {
+          name: 'web',
+          source: {
+            repository: 'misty-step/linejam',
+            branch: 'master',
+            deployOnPush: true,
+          },
+          buildCommand: 'pnpm install --frozen-lockfile && pnpm build',
+          runCommand: 'pnpm run start:next',
+          httpPort: 3000,
+          instanceCount: 1,
+          instanceSize: 'apps-s-1vcpu-1gb',
+          healthCheckPath: '/api/health',
+          environment: [
+            {
+              name: 'GUEST_TOKEN_SECRET',
+              scope: 'RUN_AND_BUILD_TIME',
+              secret: true,
+            },
+            {
+              name: 'LINEJAM_DEPLOY_ENVIRONMENT',
+              scope: 'RUN_AND_BUILD_TIME',
+              secret: false,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function liveApp() {
+  return {
+    id: 'app-web',
+    active_deployment: { id: 'generated-deployment', phase: 'ACTIVE' },
+    spec: {
+      name: 'linejam',
+      region: 'nyc',
+      features: ['buildpack-stack=ubuntu-22'],
+      domains: [
+        { domain: 'linejam.app', type: 'PRIMARY', zone: 'linejam.app' },
+      ],
+      ingress: {
+        rules: [
+          {
+            match: { path: { prefix: '/' } },
+            component: { name: 'web' },
+          },
+        ],
+      },
+      services: [
+        {
+          name: 'web',
+          github: {
+            repo: 'misty-step/linejam',
+            branch: 'master',
+            deploy_on_push: true,
+          },
+          build_command: 'pnpm install --frozen-lockfile && pnpm build',
+          run_command: 'pnpm run start:next',
+          http_port: 3000,
+          instance_count: 1,
+          instance_size_slug: 'apps-s-1vcpu-1gb',
+          health_check: { http_path: '/api/health' },
+          envs: [
+            {
+              key: 'LINEJAM_DEPLOY_ENVIRONMENT',
+              scope: 'RUN_AND_BUILD_TIME',
+              value: 'production',
+            },
+            {
+              key: 'GUEST_TOKEN_SECRET',
+              scope: 'RUN_AND_BUILD_TIME',
+              type: 'SECRET',
+              value: 'EV[1:provider-ciphertext]',
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+describe('DigitalOcean app drift', () => {
+  it('loads the committed values-free production contract', () => {
+    const committed = loadDigitalOceanAppManifest();
+
+    expect(committed.apps.map((app: { name: string }) => app.name)).toEqual([
+      'linejam',
+      'linejam-canary-responder',
+    ]);
+    expect(JSON.stringify(committed)).not.toContain('value');
+    expect(committed.deploymentAuthority).toMatchObject({
+      frontendProductionOwner: { app: 'linejam', component: 'web' },
+      convexProductionOwner: { app: 'linejam', component: 'web' },
+    });
+  });
+
+  it('validates a values-free manifest with one frontend and Convex owner', () => {
+    expect(validateDigitalOceanAppManifest(manifest)).toEqual(manifest);
+    expect(() =>
+      validateDigitalOceanAppManifest({
+        ...manifest,
+        apps: [
+          {
+            ...manifest.apps[0],
+            services: [
+              {
+                ...manifest.apps[0].services[0],
+                environment: [
+                  {
+                    name: 'GUEST_TOKEN_SECRET',
+                    scope: 'RUN_AND_BUILD_TIME',
+                    secret: true,
+                    value: 'must-not-be-committed',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    ).toThrow('values-free');
+  });
+
+  it('rejects services that diverge from the declared source authority', () => {
+    expect(() =>
+      validateDigitalOceanAppManifest({
+        ...manifest,
+        apps: [
+          {
+            ...manifest.apps[0],
+            services: [
+              {
+                ...manifest.apps[0].services[0],
+                source: {
+                  ...manifest.apps[0].services[0].source,
+                  branch: 'feature/drift',
+                },
+              },
+            ],
+          },
+        ],
+      })
+    ).toThrow('must use the declared source');
+  });
+
+  it('normalizes meaningful fields and discards provider fields and values', () => {
+    const normalized = normalizeDigitalOceanApp(liveApp());
+
+    expect(normalized).toEqual(manifest.apps[0]);
+    expect(JSON.stringify(normalized)).not.toContain('provider-ciphertext');
+    expect(JSON.stringify(normalized)).not.toContain('generated-deployment');
+  });
+
+  it('reports no drift for equivalent normalized state', () => {
+    expect(
+      diffDigitalOceanApp(manifest.apps[0], normalizeDigitalOceanApp(liveApp()))
+    ).toEqual([]);
+  });
+
+  it('reports meaningful drift without replaying environment values', () => {
+    const live = liveApp();
+    live.spec.services[0].build_command = 'pnpm exec next build';
+    live.spec.services[0].envs[1].value = 'must-never-appear';
+
+    const drift = diffDigitalOceanApp(
+      manifest.apps[0],
+      normalizeDigitalOceanApp(live)
+    );
+
+    expect(drift).toContainEqual(
+      expect.objectContaining({ path: 'services.web.buildCommand' })
+    );
+    expect(JSON.stringify(drift)).not.toContain('must-never-appear');
+  });
+
+  it('detects added environment names while discarding their values', () => {
+    const live = liveApp();
+    live.spec.services[0].envs.push({
+      key: 'UNDECLARED_NAME',
+      scope: 'RUN_AND_BUILD_TIME',
+      value: 'must-never-appear',
+    });
+
+    const drift = diffDigitalOceanApp(
+      manifest.apps[0],
+      normalizeDigitalOceanApp(live)
+    );
+
+    expect(drift).toContainEqual(
+      expect.objectContaining({
+        path: 'services.web.environment.UNDECLARED_NAME',
+      })
+    );
+    expect(JSON.stringify(drift)).not.toContain('must-never-appear');
+  });
+
+  it('fails closed on live components outside the declared service model', () => {
+    const live = liveApp();
+    Object.assign(live.spec, {
+      workers: [
+        {
+          name: 'shadow-deployer',
+          github: { repo: 'misty-step/linejam', branch: 'master' },
+        },
+      ],
+    });
+
+    expect(() => normalizeDigitalOceanApp(live)).toThrow(
+      'unsupported live field spec.workers'
+    );
+  });
+
+  it('fails closed on unknown live service fields', () => {
+    const live = liveApp();
+    Object.assign(live.spec.services[0], {
+      autoscaling: { min_instance_count: 1, max_instance_count: 3 },
+    });
+
+    expect(() => normalizeDigitalOceanApp(live)).toThrow(
+      'service web has unsupported fields: autoscaling'
+    );
+  });
+
+  it('rejects duplicate live environment names before comparison', () => {
+    const live = liveApp();
+    live.spec.services[0].envs.push({
+      ...live.spec.services[0].envs[0],
+      value: 'another-value',
+    });
+
+    expect(() => normalizeDigitalOceanApp(live)).toThrow(
+      'environment contains duplicates'
+    );
+  });
+
+  it('bounds provider reads and emits only a values-free receipt', () => {
+    const runner = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify([liveApp()]),
+      stderr: 'provider warning GUEST_TOKEN_SECRET=must-not-replay',
+    });
+    const logger = { log: vi.fn() };
+
+    expect(
+      runDigitalOceanDriftCheck({ manifest, runner, logger })
+    ).toMatchObject({ checkedApps: ['linejam'], drift: [] });
+    expect(runner).toHaveBeenCalledWith(
+      'doctl',
+      ['apps', 'get', 'app-web', '--output', 'json'],
+      expect.objectContaining({
+        encoding: 'utf8',
+        timeout: 30_000,
+        maxBuffer: 10 * 1024 * 1024,
+      })
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      'READY: DigitalOcean app drift clean for linejam'
+    );
+    expect(JSON.stringify(logger.log.mock.calls)).not.toContain(
+      'must-not-replay'
+    );
+  });
+
+  it('fails when another live app deploys the declared source branch', () => {
+    const duplicate = liveApp();
+    duplicate.id = 'app-shadow';
+    duplicate.spec.name = 'linejam-shadow';
+    const runner = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify([liveApp(), duplicate]),
+      stderr: '',
+    });
+
+    expect(() =>
+      runDigitalOceanDriftCheck({
+        manifest,
+        runner,
+        logger: { log: vi.fn() },
+      })
+    ).toThrow(
+      'DigitalOcean source-app drift: missing=none; unexpected=linejam-shadow'
+    );
+  });
+
+  it('fails closed without replaying provider output', () => {
+    const providerOutput = 'GUEST_TOKEN_SECRET=must-not-replay';
+    let error: unknown;
+    try {
+      runDigitalOceanDriftCheck({
+        manifest,
+        runner: vi.fn().mockReturnValue({
+          status: 1,
+          stdout: providerOutput,
+          stderr: providerOutput,
+        }),
+        logger: { log: vi.fn() },
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(String(error)).toContain('provider read failed with status 1');
+    expect(String(error)).not.toContain('must-not-replay');
+  });
+
+  it('fails closed when the provider read times out', () => {
+    const timeout = Object.assign(new Error('must-not-replay'), {
+      code: 'ETIMEDOUT',
+    });
+
+    expect(() =>
+      runDigitalOceanDriftCheck({
+        manifest,
+        runner: vi.fn().mockReturnValue({ status: null, error: timeout }),
+        logger: { log: vi.fn() },
+      })
+    ).toThrow('DigitalOcean app inventory provider read timed out');
+  });
+
+  it('rejects invalid provider JSON without replaying it', () => {
+    const providerOutput = '{GUEST_TOKEN_SECRET=must-not-replay';
+    let error: unknown;
+    try {
+      runDigitalOceanDriftCheck({
+        manifest,
+        runner: vi.fn().mockReturnValue({
+          status: 0,
+          stdout: providerOutput,
+          stderr: providerOutput,
+        }),
+        logger: { log: vi.fn() },
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(String(error)).toContain('inventory returned invalid JSON');
+    expect(String(error)).not.toContain('must-not-replay');
+  });
+});

--- a/tests/scripts/digitalocean-app-drift.test.ts
+++ b/tests/scripts/digitalocean-app-drift.test.ts
@@ -62,6 +62,31 @@ const manifest = {
   ],
 };
 
+type ExpectedApp = {
+  id: string;
+  name: string;
+  region: string;
+  features: string[];
+  domains: Array<{ domain: string; type: string; zone: string }>;
+  ingress: Array<{ pathPrefix: string; component: string }>;
+  services: Array<{
+    name: string;
+    source: {
+      repository: string;
+      branch: string;
+      deployOnPush: boolean;
+    };
+    dockerfilePath?: string;
+    buildCommand?: string;
+    runCommand?: string;
+    httpPort: number;
+    instanceCount: number;
+    instanceSize: string;
+    healthCheckPath: string;
+    environment: Array<{ name: string; scope: string; secret: boolean }>;
+  }>;
+};
+
 function manifestCopy(): typeof manifest {
   return structuredClone(manifest);
 }
@@ -114,6 +139,49 @@ function liveApp() {
           ],
         },
       ],
+    },
+  };
+}
+
+function liveAppFromExpected(expected: ExpectedApp) {
+  return {
+    id: expected.id,
+    spec: {
+      name: expected.name,
+      region: expected.region,
+      features: expected.features,
+      domains: expected.domains,
+      ingress: {
+        rules: expected.ingress.map((rule) => ({
+          match: { path: { prefix: rule.pathPrefix } },
+          component: { name: rule.component },
+        })),
+      },
+      services: expected.services.map((service) => ({
+        name: service.name,
+        github: {
+          repo: service.source.repository,
+          branch: service.source.branch,
+          deploy_on_push: service.source.deployOnPush,
+        },
+        ...(service.dockerfilePath
+          ? { dockerfile_path: service.dockerfilePath }
+          : {}),
+        ...(service.buildCommand
+          ? { build_command: service.buildCommand }
+          : {}),
+        ...(service.runCommand ? { run_command: service.runCommand } : {}),
+        http_port: service.httpPort,
+        instance_count: service.instanceCount,
+        instance_size_slug: service.instanceSize,
+        health_check: { http_path: service.healthCheckPath },
+        envs: service.environment.map((entry) => ({
+          key: entry.name,
+          scope: entry.scope,
+          ...(entry.secret ? { type: 'SECRET' } : {}),
+          value: entry.secret ? 'EV[1:redacted]' : 'redacted',
+        })),
+      })),
     },
   };
 }
@@ -552,6 +620,43 @@ describe('DigitalOcean app drift', () => {
     );
     expect(JSON.stringify(logger.log.mock.calls)).not.toContain(
       'must-not-replay'
+    );
+  });
+
+  it('checks both production apps, including the Canary responder', () => {
+    const production = loadDigitalOceanAppManifest() as {
+      apps: ExpectedApp[];
+    };
+    const liveApps = production.apps.map(liveAppFromExpected);
+    const runner = vi.fn((_command: string, args: string[]) => {
+      if (args[1] === 'list') {
+        return { status: 0, stdout: JSON.stringify(liveApps) };
+      }
+      const requested = liveApps.find((app) => app.id === args[2]);
+      return { status: 0, stdout: JSON.stringify([requested]) };
+    });
+
+    expect(
+      runDigitalOceanDriftCheck({
+        manifest: loadDigitalOceanAppManifest(),
+        runner,
+        logger: { log: vi.fn() },
+      })
+    ).toEqual({
+      checkedApps: ['linejam', 'linejam-canary-responder'],
+      drift: [],
+    });
+    expect(runner).toHaveBeenCalledWith(
+      'doctl',
+      [
+        'apps',
+        'get',
+        production.apps.find((app) => app.name === 'linejam-canary-responder')
+          ?.id,
+        '--output',
+        'json',
+      ],
+      expect.any(Object)
     );
   });
 

--- a/tests/scripts/digitalocean-app-drift.test.ts
+++ b/tests/scripts/digitalocean-app-drift.test.ts
@@ -396,6 +396,15 @@ describe('DigitalOcean app drift', () => {
     ).toEqual([]);
   });
 
+  it('compares features without treating ordering as drift', () => {
+    const expected = structuredClone(manifest.apps[0]);
+    const actual = structuredClone(manifest.apps[0]);
+    expected.features = ['z-feature', 'a-feature'];
+    actual.features = ['a-feature', 'z-feature'];
+
+    expect(diffDigitalOceanApp(expected, actual)).toEqual([]);
+  });
+
   it('reports meaningful drift without replaying environment values', () => {
     const live = liveApp();
     live.spec.services[0].build_command = 'pnpm exec next build';
@@ -504,6 +513,17 @@ describe('DigitalOcean app drift', () => {
 
     expect(() => normalizeDigitalOceanApp(live)).toThrow(
       'environment contains duplicates'
+    );
+  });
+
+  it('fails closed on unknown live environment fields', () => {
+    const live = liveApp();
+    Object.assign(live.spec.services[0].envs[0], {
+      generated_metadata: 'must-not-replay',
+    });
+
+    expect(() => normalizeDigitalOceanApp(live)).toThrow(
+      'environment entry has unsupported fields: generated_metadata'
     );
   });
 

--- a/tests/scripts/digitalocean-app-drift.test.ts
+++ b/tests/scripts/digitalocean-app-drift.test.ts
@@ -62,6 +62,10 @@ const manifest = {
   ],
 };
 
+function manifestCopy(): typeof manifest {
+  return structuredClone(manifest);
+}
+
 function liveApp() {
   return {
     id: 'app-web',
@@ -156,6 +160,206 @@ describe('DigitalOcean app drift', () => {
     ).toThrow('values-free');
   });
 
+  it.each([
+    {
+      name: 'a non-object root',
+      mutate: () => null,
+      message: 'manifest must be an object',
+    },
+    {
+      name: 'an unsupported root field',
+      mutate: (copy: typeof manifest) => ({ ...copy, providerExport: true }),
+      message: 'manifest has unsupported fields: providerExport',
+    },
+    {
+      name: 'an unsupported schema version',
+      mutate: (copy: typeof manifest) => ({ ...copy, schemaVersion: 2 }),
+      message: 'manifest.schemaVersion must be 1',
+    },
+    {
+      name: 'a non-boolean deploy-on-push flag',
+      mutate: (copy: typeof manifest) => {
+        Reflect.set(copy.deploymentAuthority.source, 'deployOnPush', 'yes');
+        return copy;
+      },
+      message: 'deployOnPush must be boolean',
+    },
+    {
+      name: 'no apps',
+      mutate: (copy: typeof manifest) => ({ ...copy, apps: [] }),
+      message: 'manifest.apps must be a non-empty array',
+    },
+    {
+      name: 'duplicate app ids',
+      mutate: (copy: typeof manifest) => {
+        copy.apps.push({ ...structuredClone(copy.apps[0]), name: 'other' });
+        return copy;
+      },
+      message: 'manifest.apps ids contains duplicates',
+    },
+    {
+      name: 'duplicate app names',
+      mutate: (copy: typeof manifest) => {
+        copy.apps.push({ ...structuredClone(copy.apps[0]), id: 'other' });
+        return copy;
+      },
+      message: 'manifest.apps names contains duplicates',
+    },
+    {
+      name: 'non-array features',
+      mutate: (copy: typeof manifest) => {
+        Reflect.set(copy.apps[0], 'features', 'feature');
+        return copy;
+      },
+      message: 'features and domains must be arrays',
+    },
+    {
+      name: 'a blank domain',
+      mutate: (copy: typeof manifest) => {
+        copy.apps[0].domains[0].domain = '';
+        return copy;
+      },
+      message: 'domain must be a non-empty string',
+    },
+    {
+      name: 'duplicate domains',
+      mutate: (copy: typeof manifest) => {
+        copy.apps[0].domains.push(structuredClone(copy.apps[0].domains[0]));
+        return copy;
+      },
+      message: 'domains contains duplicates',
+    },
+    {
+      name: 'non-array ingress',
+      mutate: (copy: typeof manifest) => {
+        Reflect.set(copy.apps[0], 'ingress', null);
+        return copy;
+      },
+      message: 'ingress and services must be arrays',
+    },
+    {
+      name: 'duplicate ingress rules',
+      mutate: (copy: typeof manifest) => {
+        copy.apps[0].ingress.push(structuredClone(copy.apps[0].ingress[0]));
+        return copy;
+      },
+      message: 'ingress contains duplicates',
+    },
+    {
+      name: 'duplicate service names',
+      mutate: (copy: typeof manifest) => {
+        copy.apps[0].services.push(structuredClone(copy.apps[0].services[0]));
+        return copy;
+      },
+      message: 'services contains duplicates',
+    },
+    {
+      name: 'an invalid HTTP port',
+      mutate: (copy: typeof manifest) => {
+        copy.apps[0].services[0].httpPort = 0;
+        return copy;
+      },
+      message: 'httpPort must be a positive integer',
+    },
+    {
+      name: 'an invalid instance count',
+      mutate: (copy: typeof manifest) => {
+        copy.apps[0].services[0].instanceCount = 0;
+        return copy;
+      },
+      message: 'instanceCount must be a positive integer',
+    },
+    {
+      name: 'a non-array environment',
+      mutate: (copy: typeof manifest) => {
+        Reflect.set(copy.apps[0].services[0], 'environment', null);
+        return copy;
+      },
+      message: 'environment must be an array',
+    },
+    {
+      name: 'duplicate environment names',
+      mutate: (copy: typeof manifest) => {
+        copy.apps[0].services[0].environment.push(
+          structuredClone(copy.apps[0].services[0].environment[0])
+        );
+        return copy;
+      },
+      message: 'environment contains duplicates',
+    },
+    {
+      name: 'an invalid environment name',
+      mutate: (copy: typeof manifest) => {
+        copy.apps[0].services[0].environment[0].name = 'lowercase';
+        return copy;
+      },
+      message: 'must be an environment variable name',
+    },
+    {
+      name: 'a non-boolean secret flag',
+      mutate: (copy: typeof manifest) => {
+        Reflect.set(copy.apps[0].services[0].environment[0], 'secret', 'yes');
+        return copy;
+      },
+      message: 'secret must be boolean',
+    },
+    {
+      name: 'an unresolved frontend owner',
+      mutate: (copy: typeof manifest) => {
+        copy.deploymentAuthority.frontendProductionOwner.component = 'missing';
+        return copy;
+      },
+      message: 'frontend production owner does not resolve',
+    },
+    {
+      name: 'domains on a non-frontend app',
+      mutate: (copy: typeof manifest) => {
+        const frontend = structuredClone(copy.apps[0]);
+        frontend.id = 'other';
+        frontend.name = 'other';
+        frontend.domains = [];
+        copy.apps.push(frontend);
+        copy.deploymentAuthority.frontendProductionOwner.app = 'other';
+        return copy;
+      },
+      message: 'Exactly the frontend production owner app must declare domains',
+    },
+    {
+      name: 'no frontend ingress',
+      mutate: (copy: typeof manifest) => {
+        copy.apps[0].ingress = [];
+        return copy;
+      },
+      message: 'must own a declared ingress route',
+    },
+    {
+      name: 'a mismatched Convex build command',
+      mutate: (copy: typeof manifest) => {
+        copy.deploymentAuthority.convexProductionOwner.buildCommand =
+          'pnpm convex deploy';
+        return copy;
+      },
+      message: 'build command must match its service',
+    },
+    {
+      name: 'multiple Convex build-command owners',
+      mutate: (copy: typeof manifest) => {
+        const duplicateOwner = structuredClone(copy.apps[0]);
+        duplicateOwner.id = 'other';
+        duplicateOwner.name = 'other';
+        duplicateOwner.domains = [];
+        duplicateOwner.ingress = [];
+        copy.apps.push(duplicateOwner);
+        return copy;
+      },
+      message: 'Exactly one declared service must own the Convex production',
+    },
+  ])('rejects $name', ({ mutate, message }) => {
+    expect(() =>
+      validateDigitalOceanAppManifest(mutate(manifestCopy()))
+    ).toThrow(message);
+  });
+
   it('rejects services that diverge from the declared source authority', () => {
     expect(() =>
       validateDigitalOceanAppManifest({
@@ -245,6 +449,41 @@ describe('DigitalOcean app drift', () => {
     );
   });
 
+  it('fails closed on a populated non-array live surface', () => {
+    const live = liveApp();
+    Object.assign(live.spec, { databases: { name: 'unexpected' } });
+
+    expect(() => normalizeDigitalOceanApp(live)).toThrow(
+      'unsupported live field spec.databases'
+    );
+  });
+
+  it.each([
+    [null, 'DigitalOcean app readback must be an object'],
+    [{}, 'DigitalOcean app spec must be an object'],
+  ])('rejects malformed live app readback %#', (readback, message) => {
+    expect(() => normalizeDigitalOceanApp(readback)).toThrow(message);
+  });
+
+  it('normalizes omitted optional provider collections and commands', () => {
+    const live = liveApp();
+    Reflect.deleteProperty(live.spec, 'features');
+    Reflect.deleteProperty(live.spec, 'domains');
+    Reflect.deleteProperty(live.spec, 'ingress');
+    Reflect.deleteProperty(live.spec.services[0], 'build_command');
+    Reflect.deleteProperty(live.spec.services[0], 'run_command');
+    Reflect.deleteProperty(live.spec.services[0], 'envs');
+
+    const normalized = normalizeDigitalOceanApp(live);
+
+    expect(normalized.features).toEqual([]);
+    expect(normalized.domains).toEqual([]);
+    expect(normalized.ingress).toEqual([]);
+    expect(normalized.services[0]).not.toHaveProperty('buildCommand');
+    expect(normalized.services[0]).not.toHaveProperty('runCommand');
+    expect(normalized.services[0].environment).toEqual([]);
+  });
+
   it('fails closed on unknown live service fields', () => {
     const live = liveApp();
     Object.assign(live.spec.services[0], {
@@ -317,6 +556,43 @@ describe('DigitalOcean app drift', () => {
     );
   });
 
+  it('fails when a declared source app is missing from inventory', () => {
+    const runner = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: '[]',
+      stderr: '',
+    });
+
+    expect(() =>
+      runDigitalOceanDriftCheck({
+        manifest,
+        runner,
+        logger: { log: vi.fn() },
+      })
+    ).toThrow(
+      'DigitalOcean source-app drift: missing=linejam; unexpected=none'
+    );
+  });
+
+  it('reports normalized live drift by app path', () => {
+    const drifted = liveApp();
+    drifted.spec.services[0].instance_count = 2;
+    const runner = vi
+      .fn()
+      .mockReturnValueOnce({ status: 0, stdout: JSON.stringify([liveApp()]) })
+      .mockReturnValueOnce({ status: 0, stdout: JSON.stringify([drifted]) });
+
+    expect(() =>
+      runDigitalOceanDriftCheck({
+        manifest,
+        runner,
+        logger: { log: vi.fn() },
+      })
+    ).toThrow(
+      'DigitalOcean app drift: apps.linejam.services.web.instanceCount'
+    );
+  });
+
   it('fails closed without replaying provider output', () => {
     const providerOutput = 'GUEST_TOKEN_SECRET=must-not-replay';
     let error: unknown;
@@ -352,6 +628,31 @@ describe('DigitalOcean app drift', () => {
     ).toThrow('DigitalOcean app inventory provider read timed out');
   });
 
+  it('fails closed when the provider process cannot start', () => {
+    expect(() =>
+      runDigitalOceanDriftCheck({
+        manifest,
+        runner: vi.fn().mockReturnValue({
+          status: null,
+          error: Object.assign(new Error('must-not-replay'), {
+            code: 'ENOENT',
+          }),
+        }),
+        logger: { log: vi.fn() },
+      })
+    ).toThrow('DigitalOcean app inventory provider read failed to start');
+  });
+
+  it('reports an unknown provider status without replaying output', () => {
+    expect(() =>
+      runDigitalOceanDriftCheck({
+        manifest,
+        runner: vi.fn().mockReturnValue({ status: null }),
+        logger: { log: vi.fn() },
+      })
+    ).toThrow('provider read failed with status unknown');
+  });
+
   it('rejects invalid provider JSON without replaying it', () => {
     const providerOutput = '{GUEST_TOKEN_SECRET=must-not-replay';
     let error: unknown;
@@ -371,5 +672,33 @@ describe('DigitalOcean app drift', () => {
 
     expect(String(error)).toContain('inventory returned invalid JSON');
     expect(String(error)).not.toContain('must-not-replay');
+  });
+
+  it('rejects non-array inventory JSON', () => {
+    expect(() =>
+      runDigitalOceanDriftCheck({
+        manifest,
+        runner: vi.fn().mockReturnValue({ status: 0, stdout: '{}' }),
+        logger: { log: vi.fn() },
+      })
+    ).toThrow('app inventory returned an unexpected shape');
+  });
+
+  it.each([
+    ['{', 'provider read returned invalid JSON'],
+    ['[]', 'provider read returned an unexpected app shape'],
+  ])('rejects malformed exact app readback %#', (stdout, message) => {
+    const runner = vi
+      .fn()
+      .mockReturnValueOnce({ status: 0, stdout: JSON.stringify([liveApp()]) })
+      .mockReturnValueOnce({ status: 0, stdout });
+
+    expect(() =>
+      runDigitalOceanDriftCheck({
+        manifest,
+        runner,
+        logger: { log: vi.fn() },
+      })
+    ).toThrow(message);
   });
 });


### PR DESCRIPTION
## Summary
- add a secret-free canonical topology for both Linejam DigitalOcean apps
- add a bounded, values-free live drift oracle with source-app inventory
- fail closed on undeclared components, duplicate deploy owners, source drift, and unknown service fields

## Evidence
- `pnpm vitest run tests/scripts/digitalocean-app-drift.test.ts` — 15 passed
- `pnpm typecheck` — passed
- `pnpm ci:prepush` — 138 files, 1520 passed, 1 skipped
- staged `gitleaks protect --redact` — no leaks
- live `pnpm ops:do-drift` — clean for `linejam,linejam-canary-responder`
- independent Solomon review findings addressed

## Powder
- linejam-969

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DigitalOcean Apps production + canary deployment configuration.
  * Introduced a `ops:do-drift` command to reconcile the declared topology contract with live DigitalOcean state.
* **Documentation**
  * Updated deployment guidance with the values-free topology contract, required drift reconciliation, and expanded release checklist requirements.
  * Added “Sources of truth” documentation for the DigitalOcean topology contract.
* **Tests**
  * Added end-to-end drift-check test coverage (manifest validation, normalization, diffing, and fail-closed safety).
  * Improved canary responder smoke-queue teardown timing to prevent race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->