### PR TITLE
fix: recover stale clients across production deploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,13 @@ CONVEX_DEPLOY_KEY=
 # DigitalOcean web component so a missing or mismatched marker fails closed.
 LINEJAM_DEPLOY_ENVIRONMENT=development
 
+# Rolling-deploy skew protection. App Platform production binds
+# NEXT_DEPLOYMENT_ID to ${_self.COMMIT_HASH}; local builds may leave it blank.
+# Keep the 32-byte base64 Server Action key stable across production builds.
+# Generate once with: openssl rand -base64 32
+NEXT_DEPLOYMENT_ID=
+NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=
+
 # Clerk Authentication
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 CLERK_SECRET_KEY=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,9 @@ or test counts into agent prose.
   N+1 queries. Every `while` loop needs an explicit bound.
 - `GUEST_TOKEN_SECRET` must match the web and target Convex deployment. Treat
   guest tokens as credentials.
+- Production rolling deploys require `NEXT_DEPLOYMENT_ID` bound to the source
+  commit and one stable 32-byte base64 `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY`.
+  Never rotate that key as part of a normal release.
 - Never bypass hooks with `--no-verify`. Never push when `pnpm ci:prepush` is
   red. Never claim validation without the exact command and exercised surface.
 

--- a/app/api/deployment/route.ts
+++ b/app/api/deployment/route.ts
@@ -1,0 +1,12 @@
+import { resolveDeploymentId } from '@/lib/deploymentId';
+
+export async function GET() {
+  return Response.json(
+    {
+      deployment: {
+        id: resolveDeploymentId(process.env.NEXT_DEPLOYMENT_ID) ?? null,
+      },
+    },
+    { headers: { 'Cache-Control': 'no-store' } }
+  );
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,7 +1,9 @@
 import { ConvexHttpClient } from 'convex/browser';
 import { api } from '@/convex/_generated/api';
 import type { ConvexEnvHealthReport } from '@/convex/lib/env';
+import { resolveDeploymentId } from '@/lib/deploymentId';
 import { signGuestSessionThrottleProof } from '@/lib/guestSessionThrottleProof';
+import { isValidServerActionEncryptionKey } from '@/lib/serverActionEncryptionKey';
 import {
   captureCanaryException,
   isCanaryEnabled,
@@ -87,10 +89,10 @@ export async function GET() {
 }
 
 function deploymentReadiness() {
-  const id = process.env.NEXT_DEPLOYMENT_ID?.trim() || null;
+  const id = resolveDeploymentId(process.env.NEXT_DEPLOYMENT_ID) ?? null;
   const skewProtection = id !== null;
-  const stableServerActions = Boolean(
-    process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY?.trim()
+  const stableServerActions = isValidServerActionEncryptionKey(
+    process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY
   );
   const required = process.env.LINEJAM_DEPLOY_ENVIRONMENT === 'production';
 

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -32,9 +32,15 @@ export async function GET() {
       convexStatus === 'connected' &&
       convexEnv?.ok === true;
     const canaryReady = envChecks.canaryIngestKey;
-    const status = serviceHealthy ? 200 : 503;
+    const deployment = deploymentReadiness();
+    const status = serviceHealthy && deployment.ready ? 200 : 503;
     const body = {
-      status: serviceHealthy ? 'ok' : 'unhealthy',
+      status: status === 200 ? 'ok' : 'unhealthy',
+      deployment: {
+        id: deployment.id,
+        skewProtection: deployment.skewProtection,
+        stableServerActions: deployment.stableServerActions,
+      },
       convex: convexStatus,
       convexEnv: convexEnv?.capabilities ?? null,
       env: {
@@ -58,10 +64,11 @@ export async function GET() {
     });
 
     await reportHealthCheckIn({
-      status: serviceHealthy ? 'alive' : 'error',
-      summary: serviceHealthy
-        ? 'linejam health route ok'
-        : 'linejam health route degraded',
+      status: status === 200 ? 'alive' : 'error',
+      summary:
+        status === 200
+          ? 'linejam health route ok'
+          : 'linejam health route degraded',
       routeStatus: status,
       startedAt,
     });
@@ -77,6 +84,22 @@ export async function GET() {
       { status: 500, headers: { 'Cache-Control': 'no-store' } }
     );
   }
+}
+
+function deploymentReadiness() {
+  const id = process.env.NEXT_DEPLOYMENT_ID?.trim() || null;
+  const skewProtection = id !== null;
+  const stableServerActions = Boolean(
+    process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY?.trim()
+  );
+  const required = process.env.LINEJAM_DEPLOY_ENVIRONMENT === 'production';
+
+  return {
+    id,
+    skewProtection,
+    stableServerActions,
+    ready: !required || (skewProtection && stableServerActions),
+  };
 }
 
 /**

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -204,7 +204,7 @@ export default function RootLayout({
     >
       <body className="antialiased">
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
-        <Providers>
+        <Providers deploymentId={process.env.NEXT_DEPLOYMENT_ID?.trim()}>
           <div className="min-h-screen flex flex-col bg-[var(--color-background)]">
             <Header />
             <main className="flex-1 flex flex-col">{children}</main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from 'next';
+import { resolveDeploymentId } from '@/lib/deploymentId';
 import {
   Libre_Baskerville,
   IBM_Plex_Sans,
@@ -204,7 +205,9 @@ export default function RootLayout({
     >
       <body className="antialiased">
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
-        <Providers deploymentId={process.env.NEXT_DEPLOYMENT_ID?.trim()}>
+        <Providers
+          deploymentId={resolveDeploymentId(process.env.NEXT_DEPLOYMENT_ID)}
+        >
           <div className="min-h-screen flex flex-col bg-[var(--color-background)]">
             <Header />
             <main className="flex-1 flex flex-col">{children}</main>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -7,13 +7,20 @@ import { ThemeProvider } from '@/lib/themes';
 import { PostHogProvider } from '@/lib/posthog/PostHogProvider';
 import { PostHogPageview } from '@/lib/posthog/PostHogPageview';
 import { CanaryClientObserver } from '@/components/CanaryClientObserver';
+import { DeploymentSkewObserver } from '@/components/DeploymentSkewObserver';
 import {
   linejamClerkAppearance,
   useClerkThemeVariables,
 } from '@/lib/clerk/appearance';
 import { ReactNode } from 'react';
 
-export function Providers({ children }: { children: ReactNode }) {
+export function Providers({
+  children,
+  deploymentId,
+}: {
+  children: ReactNode;
+  deploymentId?: string;
+}) {
   const variables = useClerkThemeVariables();
 
   return (
@@ -25,6 +32,7 @@ export function Providers({ children }: { children: ReactNode }) {
       <PostHogProvider>
         <PostHogPageview />
         <CanaryClientObserver />
+        <DeploymentSkewObserver deploymentId={deploymentId} />
         <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
           <ThemeProvider>{children}</ThemeProvider>
         </ConvexProviderWithClerk>

--- a/components/CanaryClientObserver.tsx
+++ b/components/CanaryClientObserver.tsx
@@ -2,6 +2,10 @@
 
 import { useEffect } from 'react';
 import { captureCanaryException } from '@/lib/canary';
+import {
+  isUnrecognizedServerActionError,
+  notifyDeploymentStale,
+} from '@/lib/deploymentSkew';
 
 function captureBrowserFailure(error: unknown, source: string) {
   void captureCanaryException(error, {
@@ -20,6 +24,12 @@ export function CanaryClientObserver() {
     };
 
     const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      if (isUnrecognizedServerActionError(event.reason)) {
+        event.preventDefault();
+        notifyDeploymentStale();
+        return;
+      }
+
       captureBrowserFailure(
         event.reason ?? new Error('Unhandled promise rejection'),
         'window.unhandledrejection'

--- a/components/DeploymentSkewObserver.tsx
+++ b/components/DeploymentSkewObserver.tsx
@@ -29,7 +29,7 @@ export function DeploymentSkewObserver({
       if (!deploymentId || disposed) return;
 
       try {
-        const response = await fetch('/api/health', {
+        const response = await fetch('/api/deployment', {
           cache: 'no-store',
           headers: { Accept: 'application/json' },
         });

--- a/components/DeploymentSkewObserver.tsx
+++ b/components/DeploymentSkewObserver.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { DEPLOYMENT_STALE_EVENT } from '@/lib/deploymentSkew';
+
+const DEPLOYMENT_CHECK_INTERVAL_MS = 60_000;
+
+type DeploymentSkewObserverProps = {
+  deploymentId?: string;
+  reload?: () => void;
+};
+
+type HealthPayload = {
+  deployment?: { id?: unknown };
+};
+
+export function DeploymentSkewObserver({
+  deploymentId,
+  reload = () => window.location.reload(),
+}: DeploymentSkewObserverProps) {
+  const [isStale, setIsStale] = useState(false);
+
+  useEffect(() => {
+    let disposed = false;
+
+    const markStale = () => setIsStale(true);
+    const checkDeployment = async () => {
+      if (!deploymentId || disposed) return;
+
+      try {
+        const response = await fetch('/api/health', {
+          cache: 'no-store',
+          headers: { Accept: 'application/json' },
+        });
+        if (!response.ok || disposed) return;
+
+        const payload = (await response.json()) as HealthPayload;
+        const serverDeploymentId = payload.deployment?.id;
+        if (
+          typeof serverDeploymentId === 'string' &&
+          serverDeploymentId !== deploymentId
+        ) {
+          markStale();
+        }
+      } catch {
+        // Connectivity failures have their own recovery surface. A failed
+        // version check is not proof that this client is stale.
+      }
+    };
+    const checkWhenVisible = () => {
+      if (document.visibilityState === 'visible') void checkDeployment();
+    };
+
+    window.addEventListener(DEPLOYMENT_STALE_EVENT, markStale);
+    window.addEventListener('focus', checkDeployment);
+    document.addEventListener('visibilitychange', checkWhenVisible);
+    const intervalId = window.setInterval(
+      checkDeployment,
+      DEPLOYMENT_CHECK_INTERVAL_MS
+    );
+    void checkDeployment();
+
+    return () => {
+      disposed = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener(DEPLOYMENT_STALE_EVENT, markStale);
+      window.removeEventListener('focus', checkDeployment);
+      document.removeEventListener('visibilitychange', checkWhenVisible);
+    };
+  }, [deploymentId]);
+
+  if (!isStale) return null;
+
+  return (
+    <div
+      aria-label="Linejam was updated"
+      className="fixed inset-x-3 top-3 z-[120] mx-auto flex max-w-xl items-center justify-between gap-4 rounded-md border border-primary/40 bg-background px-4 py-3 text-left shadow-lg"
+      role="status"
+    >
+      <p className="text-sm leading-snug text-text-primary">
+        Linejam was updated. Your draft is safe—reload to rejoin the latest
+        room.
+      </p>
+      <Button onClick={reload} size="sm" type="button">
+        Reload Linejam
+      </Button>
+    </div>
+  );
+}

--- a/components/DeploymentSkewObserver.tsx
+++ b/components/DeploymentSkewObserver.tsx
@@ -36,6 +36,8 @@ export function DeploymentSkewObserver({
         if (!response.ok || disposed) return;
 
         const payload = (await response.json()) as HealthPayload;
+        if (disposed) return;
+
         const serverDeploymentId = payload.deployment?.id;
         if (
           typeof serverDeploymentId === 'string' &&
@@ -53,20 +55,25 @@ export function DeploymentSkewObserver({
     };
 
     window.addEventListener(DEPLOYMENT_STALE_EVENT, markStale);
-    window.addEventListener('focus', checkDeployment);
-    document.addEventListener('visibilitychange', checkWhenVisible);
-    const intervalId = window.setInterval(
-      checkDeployment,
-      DEPLOYMENT_CHECK_INTERVAL_MS
-    );
-    void checkDeployment();
+    let intervalId: number | undefined;
+    if (deploymentId) {
+      window.addEventListener('focus', checkDeployment);
+      document.addEventListener('visibilitychange', checkWhenVisible);
+      intervalId = window.setInterval(
+        checkDeployment,
+        DEPLOYMENT_CHECK_INTERVAL_MS
+      );
+      void checkDeployment();
+    }
 
     return () => {
       disposed = true;
-      window.clearInterval(intervalId);
+      if (intervalId !== undefined) window.clearInterval(intervalId);
       window.removeEventListener(DEPLOYMENT_STALE_EVENT, markStale);
-      window.removeEventListener('focus', checkDeployment);
-      document.removeEventListener('visibilitychange', checkWhenVisible);
+      if (deploymentId) {
+        window.removeEventListener('focus', checkDeployment);
+        document.removeEventListener('visibilitychange', checkWhenVisible);
+      }
     };
   }, [deploymentId]);
 

--- a/components/WritingScreen.tsx
+++ b/components/WritingScreen.tsx
@@ -18,6 +18,12 @@ import { WordSlots } from '@/components/ui/WordSlots';
 import { RoundClock } from '@/components/ui/RoundClock';
 import { WaitingScreen } from '@/components/WaitingScreen';
 import { buildInProgressChromeCopy } from '@/lib/roomChromeCopy';
+import {
+  clearWritingDraft,
+  readWritingDraft,
+  saveWritingDraft,
+  writingDraftKey,
+} from '@/lib/writingDraft';
 
 interface WritingScreenProps {
   roomCode: string;
@@ -77,7 +83,13 @@ function WritingComposer({
   roomCode,
 }: WritingComposerProps) {
   const submitLine = useMutation(api.game.submitLine);
-  const [text, setText] = useState('');
+  const draftKey = writingDraftKey(
+    roomCode,
+    assignment.poemId,
+    assignment.lineIndex
+  );
+  const [text, setText] = useState(() => readWritingDraft(draftKey));
+  const [draftWasRestored] = useState(() => text.length > 0);
   const [submissionState, setSubmissionState] = useState<
     'idle' | 'submitting' | 'confirmed'
   >('idle');
@@ -120,6 +132,10 @@ function WritingComposer({
   const placeholderText = `write ${numberToWord(targetCount)} word${targetCount === 1 ? '' : 's'}…`;
 
   // Announce validation state changes to screen readers (debounced)
+  useEffect(() => {
+    saveWritingDraft(draftKey, text);
+  }, [draftKey, text]);
+
   useEffect(() => {
     const timeoutId = setTimeout(() => {
       if (isValid) {
@@ -171,6 +187,7 @@ function WritingComposer({
         text,
         guestToken: guestToken || undefined,
       });
+      clearWritingDraft(draftKey);
 
       // Show confirmation state briefly before transitioning to waiting
       setSubmissionState('confirmed');
@@ -252,6 +269,12 @@ function WritingComposer({
             </p>
             <p>Match the word slots, then pass it on.</p>
           </div>
+        )}
+
+        {draftWasRestored && (
+          <p aria-live="polite" className="text-sm text-text-secondary">
+            Draft restored
+          </p>
         )}
 
         {/* The Memory - No container */}

--- a/config/digitalocean-apps.json
+++ b/config/digitalocean-apps.json
@@ -95,6 +95,11 @@
               "secret": false
             },
             {
+              "name": "NEXT_DEPLOYMENT_ID",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": false
+            },
+            {
               "name": "NEXT_PUBLIC_CANARY_API_KEY",
               "scope": "RUN_AND_BUILD_TIME",
               "secret": true
@@ -116,6 +121,11 @@
             },
             {
               "name": "NEXT_PUBLIC_SENTRY_DSN",
+              "scope": "RUN_AND_BUILD_TIME",
+              "secret": true
+            },
+            {
+              "name": "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
               "scope": "RUN_AND_BUILD_TIME",
               "secret": true
             },

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -94,26 +94,28 @@ must receive the identical value. A mismatch breaks guest-token verification.
 
 ### Web application
 
-| Variable                            | Purpose                                            |
-| ----------------------------------- | -------------------------------------------------- |
-| `GUEST_TOKEN_SECRET`                | signs web guest tokens; must match Convex          |
-| `NEXT_PUBLIC_CONVEX_URL`            | production Convex URL                              |
-| `CONVEX_DEPLOYMENT`                 | production Convex deployment selector              |
-| `CONVEX_DEPLOYMENT_URL`             | production Convex deployment URL                   |
-| `CONVEX_DEPLOY_KEY`                 | production deploy key used during the hosted build |
-| `LINEJAM_DEPLOY_ENVIRONMENT`        | `production`; fail-closed hosted deploy guard      |
-| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | browser Clerk key                                  |
-| `CLERK_SECRET_KEY`                  | server Clerk key                                   |
-| `CLERK_JWT_ISSUER_DOMAIN`           | Clerk issuer used by Convex auth                   |
-| `CANARY_ENDPOINT`                   | `https://canary.mistystep.io`                      |
-| `CANARY_API_KEY`                    | server-side Canary credential                      |
-| `NEXT_PUBLIC_CANARY_ENDPOINT`       | `https://canary.mistystep.io`                      |
-| `NEXT_PUBLIC_CANARY_API_KEY`        | browser write-only Canary credential               |
-| `NEXT_PUBLIC_SENTRY_DSN`            | browser Sentry destination                         |
-| `PLAYWRIGHT_CLERK_TEST_EMAIL`       | pre-created production smoke user                  |
-| `SENTRY_AUTH_TOKEN`                 | source-map upload credential                       |
-| `SENTRY_ORG`                        | Sentry organization slug                           |
-| `SENTRY_PROJECT`                    | Sentry project slug                                |
+| Variable                             | Purpose                                            |
+| ------------------------------------ | -------------------------------------------------- |
+| `GUEST_TOKEN_SECRET`                 | signs web guest tokens; must match Convex          |
+| `NEXT_PUBLIC_CONVEX_URL`             | production Convex URL                              |
+| `CONVEX_DEPLOYMENT`                  | production Convex deployment selector              |
+| `CONVEX_DEPLOYMENT_URL`              | production Convex deployment URL                   |
+| `CONVEX_DEPLOY_KEY`                  | production deploy key used during the hosted build |
+| `LINEJAM_DEPLOY_ENVIRONMENT`         | `production`; fail-closed hosted deploy guard      |
+| `NEXT_DEPLOYMENT_ID`                 | `${_self.COMMIT_HASH}`; rolling-build identifier   |
+| `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` | stable 32-byte base64 Server Action key            |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`  | browser Clerk key                                  |
+| `CLERK_SECRET_KEY`                   | server Clerk key                                   |
+| `CLERK_JWT_ISSUER_DOMAIN`            | Clerk issuer used by Convex auth                   |
+| `CANARY_ENDPOINT`                    | `https://canary.mistystep.io`                      |
+| `CANARY_API_KEY`                     | server-side Canary credential                      |
+| `NEXT_PUBLIC_CANARY_ENDPOINT`        | `https://canary.mistystep.io`                      |
+| `NEXT_PUBLIC_CANARY_API_KEY`         | browser write-only Canary credential               |
+| `NEXT_PUBLIC_SENTRY_DSN`             | browser Sentry destination                         |
+| `PLAYWRIGHT_CLERK_TEST_EMAIL`        | pre-created production smoke user                  |
+| `SENTRY_AUTH_TOKEN`                  | source-map upload credential                       |
+| `SENTRY_ORG`                         | Sentry organization slug                           |
+| `SENTRY_PROJECT`                     | Sentry project slug                                |
 
 ### Canary responder
 
@@ -149,6 +151,32 @@ rm /tmp/linejam-app.yaml
 
 Repeat with `LINEJAM_RESPONDER_APP_ID` for responder-only configuration. Read
 the resulting deployment phase and health route before continuing.
+
+### Rolling-deploy skew protection
+
+App Platform can briefly serve a browser bundle from one release against a
+server from the next release. Two production-only variables make that handoff
+recoverable:
+
+- Set `NEXT_DEPLOYMENT_ID` to the App Platform bindable value
+  `${_self.COMMIT_HASH}`. Next.js includes it in framework requests and the
+  Linejam health receipt exposes the current identifier for a values-free
+  client/version comparison.
+- Generate `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` once with
+  `openssl rand -base64 32`, store it as an encrypted App Platform value, and
+  preserve it across releases. Rotating it invalidates outstanding Server
+  Action references, so rotate only as a controlled incident operation.
+
+Production builds fail closed when either variable is absent or when the
+Server Action key does not decode to exactly 32 bytes. `/api/health` reports
+only the deployment identifier and boolean readiness; it never returns the
+key or a fingerprint.
+
+During a rollout, keep one pre-deploy room tab open with an unsubmitted line.
+After the new deployment becomes `ACTIVE`, the tab must present the Linejam
+update banner, reload only on the player's action, and restore the draft. Then
+run two consecutive production smokes and inspect activation logs for any
+unclassified `Failed to find Server Action` burst.
 
 ## Convex configuration
 

--- a/lib/deploymentId.ts
+++ b/lib/deploymentId.ts
@@ -1,0 +1,5 @@
+export function resolveDeploymentId(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+
+  return value.trim() || undefined;
+}

--- a/lib/deploymentSkew.ts
+++ b/lib/deploymentSkew.ts
@@ -1,0 +1,18 @@
+export const DEPLOYMENT_STALE_EVENT = 'linejam:deployment-stale';
+
+export function isUnrecognizedServerActionError(error: unknown) {
+  if (!(error instanceof Error)) return false;
+
+  const nextErrorCode = (error as Error & { __NEXT_ERROR_CODE?: unknown })
+    .__NEXT_ERROR_CODE;
+  return (
+    nextErrorCode === 'E715' ||
+    error.name === 'UnrecognizedActionError' ||
+    (error.message.startsWith('Server Action "') &&
+      error.message.includes('was not found on the server.'))
+  );
+}
+
+export function notifyDeploymentStale() {
+  window.dispatchEvent(new Event(DEPLOYMENT_STALE_EVENT));
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -14,6 +14,10 @@ const REQUIRED_PUBLIC_ENV = [
   'NEXT_PUBLIC_CANARY_ENDPOINT',
   'NEXT_PUBLIC_CANARY_API_KEY',
 ] as const;
+const REQUIRED_PRODUCTION_SKEW_ENV = [
+  'NEXT_DEPLOYMENT_ID',
+  'NEXT_SERVER_ACTIONS_ENCRYPTION_KEY',
+] as const;
 const PLACEHOLDER_CANARY_KEYS = new Set([
   'example_canary_server_key',
   'example_canary_write_key',
@@ -37,6 +41,7 @@ export function getServerGuestTokenSecret(): string {
  */
 export function validateEnv(): void {
   const missing: string[] = [];
+  const invalidPlaceholders: string[] = [];
   const invalid: string[] = [];
   const isDependabot = process.env.GITHUB_ACTOR === 'dependabot[bot]';
 
@@ -52,12 +57,28 @@ export function validateEnv(): void {
     }
   }
 
-  const canaryApiKey = process.env.NEXT_PUBLIC_CANARY_API_KEY?.trim();
-  if (canaryApiKey && PLACEHOLDER_CANARY_KEYS.has(canaryApiKey)) {
-    invalid.push('NEXT_PUBLIC_CANARY_API_KEY');
+  if (process.env.LINEJAM_DEPLOY_ENVIRONMENT === 'production') {
+    for (const key of REQUIRED_PRODUCTION_SKEW_ENV) {
+      if (!process.env[key]?.trim()) missing.push(key);
+    }
+
+    const serverActionKey =
+      process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY?.trim();
+    if (serverActionKey && !isValidServerActionEncryptionKey(serverActionKey)) {
+      invalid.push('NEXT_SERVER_ACTIONS_ENCRYPTION_KEY');
+    }
   }
 
-  if (missing.length > 0 || invalid.length > 0) {
+  const canaryApiKey = process.env.NEXT_PUBLIC_CANARY_API_KEY?.trim();
+  if (canaryApiKey && PLACEHOLDER_CANARY_KEYS.has(canaryApiKey)) {
+    invalidPlaceholders.push('NEXT_PUBLIC_CANARY_API_KEY');
+  }
+
+  if (
+    missing.length > 0 ||
+    invalidPlaceholders.length > 0 ||
+    invalid.length > 0
+  ) {
     const sections: string[] = [];
 
     if (missing.length > 0) {
@@ -68,9 +89,17 @@ export function validateEnv(): void {
       );
     }
 
+    if (invalidPlaceholders.length > 0) {
+      sections.push(
+        `Invalid placeholder environment variables:\n${invalidPlaceholders
+          .map((k) => `  - ${k}`)
+          .join('\n')}`
+      );
+    }
+
     if (invalid.length > 0) {
       sections.push(
-        `Invalid placeholder environment variables:\n${invalid
+        `Invalid environment variables:\n${invalid
           .map((k) => `  - ${k}`)
           .join('\n')}`
       );
@@ -79,5 +108,15 @@ export function validateEnv(): void {
     throw new Error(
       `${sections.join('\n\n')}\n\nSee .env.example for documentation.`
     );
+  }
+}
+
+function isValidServerActionEncryptionKey(value: string) {
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) return false;
+
+  try {
+    return Buffer.from(value, 'base64').byteLength === 32;
+  } catch {
+    return false;
   }
 }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -5,6 +5,8 @@
  * Prevents deploying with missing configuration.
  */
 
+import { isValidServerActionEncryptionKey } from '@/lib/serverActionEncryptionKey';
+
 // Required for Next.js runtime (signing guest tokens)
 const REQUIRED_SERVER_ENV = ['GUEST_TOKEN_SECRET'] as const;
 
@@ -108,15 +110,5 @@ export function validateEnv(): void {
     throw new Error(
       `${sections.join('\n\n')}\n\nSee .env.example for documentation.`
     );
-  }
-}
-
-function isValidServerActionEncryptionKey(value: string) {
-  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) return false;
-
-  try {
-    return Buffer.from(value, 'base64').byteLength === 32;
-  } catch {
-    return false;
   }
 }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -5,7 +5,7 @@
  * Prevents deploying with missing configuration.
  */
 
-import { isValidServerActionEncryptionKey } from '@/lib/serverActionEncryptionKey';
+import { isValidServerActionEncryptionKey } from './serverActionEncryptionKey';
 
 // Required for Next.js runtime (signing guest tokens)
 const REQUIRED_SERVER_ENV = ['GUEST_TOKEN_SECRET'] as const;

--- a/lib/serverActionEncryptionKey.ts
+++ b/lib/serverActionEncryptionKey.ts
@@ -1,0 +1,12 @@
+export function isValidServerActionEncryptionKey(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+
+  const normalized = value.trim();
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(normalized)) return false;
+
+  try {
+    return Buffer.from(normalized, 'base64').byteLength === 32;
+  } catch {
+    return false;
+  }
+}

--- a/lib/writingDraft.ts
+++ b/lib/writingDraft.ts
@@ -1,0 +1,44 @@
+const WRITING_DRAFT_PREFIX = 'linejam:writing-draft';
+const MAX_DRAFT_LENGTH = 500;
+
+export function writingDraftKey(
+  roomCode: string,
+  poemId: string,
+  lineIndex: number
+) {
+  return `${WRITING_DRAFT_PREFIX}:${roomCode}:${poemId}:${lineIndex}`;
+}
+
+export function readWritingDraft(key: string) {
+  if (typeof window === 'undefined') return '';
+
+  try {
+    return window.sessionStorage.getItem(key) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+export function saveWritingDraft(key: string, value: string) {
+  if (typeof window === 'undefined') return;
+
+  try {
+    if (value.length === 0) {
+      window.sessionStorage.removeItem(key);
+      return;
+    }
+    window.sessionStorage.setItem(key, value.slice(0, MAX_DRAFT_LENGTH));
+  } catch {
+    // Storage can be disabled. The in-memory composer remains usable.
+  }
+}
+
+export function clearWritingDraft(key: string) {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    // A committed line must not fail because browser storage is unavailable.
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -56,7 +56,7 @@ if (isClerkConfigured) {
   upstreamMiddleware = passthroughMiddleware;
 }
 
-const SERVER_ACTION_ID = /^[a-f0-9]{40}$/;
+const SERVER_ACTION_ID = /^[a-f0-9]{40,64}$/;
 
 export default function middleware(req: NextRequest) {
   const actionId = req.headers.get('next-action');

--- a/middleware.ts
+++ b/middleware.ts
@@ -33,7 +33,7 @@ function passthroughMiddleware() {
 
 // Conditionally create middleware based on Clerk configuration
 // We use a dynamic approach to avoid importing Clerk when not configured
-let middleware: (
+let upstreamMiddleware: (
   req: NextRequest
 ) => Promise<NextResponse | Response> | NextResponse;
 
@@ -46,17 +46,29 @@ if (isClerkConfigured) {
     // session state (cookies/JWT) that useAuth()/ConvexProviderWithClerk
     // read client-side. It intentionally takes no handler — nothing calls
     // auth.protect() because no route is Clerk-only.
-    middleware = clerkMiddleware();
+    upstreamMiddleware = clerkMiddleware();
   } catch {
     // If Clerk initialization fails, fall back to guest-only mode
     console.warn('Clerk initialization failed, running in guest-only mode');
-    middleware = passthroughMiddleware;
+    upstreamMiddleware = passthroughMiddleware;
   }
 } else {
-  middleware = passthroughMiddleware;
+  upstreamMiddleware = passthroughMiddleware;
 }
 
-export default middleware;
+const SERVER_ACTION_ID = /^[a-f0-9]{40}$/;
+
+export default function middleware(req: NextRequest) {
+  const actionId = req.headers.get('next-action');
+  if (actionId && !SERVER_ACTION_ID.test(actionId)) {
+    return new NextResponse(null, {
+      status: 404,
+      headers: { 'Cache-Control': 'no-store' },
+    });
+  }
+
+  return upstreamMiddleware(req);
+}
 
 export const config = {
   matcher: [

--- a/next.config.ts
+++ b/next.config.ts
@@ -138,6 +138,10 @@ export function buildContentSecurityPolicy() {
     .join('; ');
 }
 
+export function resolveDeploymentId(value: string | undefined) {
+  return value?.trim() || undefined;
+}
+
 const securityHeaders = [
   {
     key: 'Content-Security-Policy',
@@ -177,6 +181,7 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  deploymentId: resolveDeploymentId(process.env.NEXT_DEPLOYMENT_ID),
   serverExternalPackages: ['pino', 'pino-pretty', 'thread-stream'],
   images: {
     remotePatterns: [

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from 'next';
+import { resolveDeploymentId } from './lib/deploymentId';
 import { validateEnv } from './lib/env';
 
 // Validate required env vars during production builds
@@ -136,10 +137,6 @@ export function buildContentSecurityPolicy() {
   return directives
     .map(([directive, sources]) => `${directive} ${sources.join(' ')}`)
     .join('; ');
-}
-
-export function resolveDeploymentId(value: string | undefined) {
-  return value?.trim() || undefined;
 }
 
 const securityHeaders = [

--- a/tests/app/api/deployment.test.ts
+++ b/tests/app/api/deployment.test.ts
@@ -1,0 +1,31 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '@/app/api/deployment/route';
+
+describe('/api/deployment', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns only the current values-free deployment receipt', async () => {
+    vi.stubEnv('NEXT_DEPLOYMENT_ID', '  release-abc123  ');
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    await expect(response.json()).resolves.toEqual({
+      deployment: { id: 'release-abc123' },
+    });
+  });
+
+  it('returns a null receipt when the build is unversioned', async () => {
+    vi.stubEnv('NEXT_DEPLOYMENT_ID', '');
+
+    const response = await GET();
+
+    await expect(response.json()).resolves.toEqual({
+      deployment: { id: null },
+    });
+  });
+});

--- a/tests/app/api/health.test.ts
+++ b/tests/app/api/health.test.ts
@@ -167,6 +167,24 @@ describe('/api/health', () => {
       expect(response.headers.get('Cache-Control')).toBe('no-store');
     });
 
+    it('fails production readiness for malformed Server Action key material', async () => {
+      const previousEnvironment = process.env.LINEJAM_DEPLOY_ENVIRONMENT;
+      const previousKey = process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY;
+      try {
+        process.env.LINEJAM_DEPLOY_ENVIRONMENT = 'production';
+        process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY = 'malformed-key';
+
+        const response = await GET();
+        const data = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(data.deployment.stableServerActions).toBe(false);
+      } finally {
+        process.env.LINEJAM_DEPLOY_ENVIRONMENT = previousEnvironment;
+        process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY = previousKey;
+      }
+    });
+
     it('returns connected when Convex ping succeeds', async () => {
       mockQuery.mockResolvedValue(HEALTHY_REPORT);
 

--- a/tests/app/api/health.test.ts
+++ b/tests/app/api/health.test.ts
@@ -18,6 +18,8 @@ const HEALTHY_ENV = {
   LINEJAM_DEPLOY_ENVIRONMENT: 'development',
   NEXT_PUBLIC_CONVEX_URL: 'https://test.convex.cloud',
   NEXT_PUBLIC_CANARY_API_KEY: 'sk_test_canary',
+  NEXT_DEPLOYMENT_ID: 'test-deployment',
+  NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: Buffer.alloc(32, 7).toString('base64'),
 };
 
 const HEALTHY_REPORT = {
@@ -78,6 +80,9 @@ describe('/api/health', () => {
       process.env.NEXT_PUBLIC_CONVEX_URL = HEALTHY_ENV.NEXT_PUBLIC_CONVEX_URL;
       process.env.NEXT_PUBLIC_CANARY_API_KEY =
         HEALTHY_ENV.NEXT_PUBLIC_CANARY_API_KEY;
+      process.env.NEXT_DEPLOYMENT_ID = HEALTHY_ENV.NEXT_DEPLOYMENT_ID;
+      process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY =
+        HEALTHY_ENV.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY;
 
       vi.doMock('convex/browser', () => ({
         ConvexHttpClient: MockConvexHttpClient,
@@ -112,6 +117,11 @@ describe('/api/health', () => {
       expect(data).toMatchObject({
         status: 'ok',
         timestamp: expect.any(String),
+        deployment: {
+          id: HEALTHY_ENV.NEXT_DEPLOYMENT_ID,
+          skewProtection: true,
+          stableServerActions: true,
+        },
         env: {
           nodeEnv: expect.stringMatching(/^(development|test|production)$/),
           guestTokenSecret: true,

--- a/tests/components/CanaryClientObserver.test.tsx
+++ b/tests/components/CanaryClientObserver.test.tsx
@@ -93,6 +93,29 @@ describe('CanaryClientObserver', () => {
     });
   });
 
+  it('classifies stale Server Actions as deploy skew without incident noise', async () => {
+    render(<CanaryClientObserver />);
+    const staleListener = vi.fn();
+    window.addEventListener('linejam:deployment-stale', staleListener);
+
+    const event = new Event('unhandledrejection', {
+      cancelable: true,
+    }) as PromiseRejectionEvent;
+    Object.defineProperty(event, 'reason', {
+      value: Object.assign(
+        new Error('Server Action "[redacted]" was not found on the server.'),
+        { name: 'UnrecognizedActionError' }
+      ),
+      configurable: true,
+    });
+    window.dispatchEvent(event);
+
+    await waitFor(() => expect(staleListener).toHaveBeenCalledTimes(1));
+    expect(event.defaultPrevented).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+    window.removeEventListener('linejam:deployment-stale', staleListener);
+  });
+
   it('falls back when unhandled rejection reason is missing', async () => {
     render(<CanaryClientObserver />);
 

--- a/tests/components/DeploymentSkewObserver.test.tsx
+++ b/tests/components/DeploymentSkewObserver.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { DeploymentSkewObserver } from '@/components/DeploymentSkewObserver';
+
+describe('DeploymentSkewObserver', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ deployment: { id: 'current-deployment' } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('offers one clear reload when the server deployment changed', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ deployment: { id: 'new-deployment' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    render(<DeploymentSkewObserver deploymentId="old-deployment" />);
+
+    expect(
+      await screen.findByRole('status', { name: /linejam was updated/i })
+    ).toHaveTextContent(/your draft is safe/i);
+    expect(
+      screen.getByRole('button', { name: /reload linejam/i })
+    ).toBeInTheDocument();
+  });
+
+  it('reacts immediately when the framework rejects a stale action', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ deployment: { id: 'same-deployment' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    render(<DeploymentSkewObserver deploymentId="same-deployment" />);
+
+    act(() => {
+      window.dispatchEvent(new Event('linejam:deployment-stale'));
+    });
+
+    expect(
+      await screen.findByRole('button', { name: /reload linejam/i })
+    ).toBeInTheDocument();
+  });
+
+  it('reloads only after the player chooses the recovery action', async () => {
+    const reload = vi.fn();
+    render(
+      <DeploymentSkewObserver deploymentId="old-deployment" reload={reload} />
+    );
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /reload linejam/i })
+    );
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays quiet when the deployment matches', async () => {
+    render(<DeploymentSkewObserver deploymentId="current-deployment" />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(
+      screen.queryByRole('button', { name: /reload linejam/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/DeploymentSkewObserver.test.tsx
+++ b/tests/components/DeploymentSkewObserver.test.tsx
@@ -42,13 +42,7 @@ describe('DeploymentSkewObserver', () => {
   });
 
   it('reacts immediately when the framework rejects a stale action', async () => {
-    fetchMock.mockResolvedValue(
-      new Response(JSON.stringify({ deployment: { id: 'same-deployment' } }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    );
-    render(<DeploymentSkewObserver deploymentId="same-deployment" />);
+    render(<DeploymentSkewObserver />);
 
     act(() => {
       window.dispatchEvent(new Event('linejam:deployment-stale'));
@@ -57,6 +51,7 @@ describe('DeploymentSkewObserver', () => {
     expect(
       await screen.findByRole('button', { name: /reload linejam/i })
     ).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('reloads only after the player chooses the recovery action', async () => {
@@ -75,6 +70,33 @@ describe('DeploymentSkewObserver', () => {
     render(<DeploymentSkewObserver deploymentId="current-deployment" />);
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(
+      screen.queryByRole('button', { name: /reload linejam/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('ignores a deployment check that finishes after unmount', async () => {
+    type Payload = { deployment: { id: string } };
+    let resolvePayload!: (payload: Payload) => void;
+    const payload = new Promise<Payload>((resolve) => {
+      resolvePayload = resolve;
+    });
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => payload,
+    });
+
+    const { unmount } = render(
+      <DeploymentSkewObserver deploymentId="old-deployment" />
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    unmount();
+    await act(async () => {
+      resolvePayload({ deployment: { id: 'new-deployment' } });
+      await payload;
+    });
+
     expect(
       screen.queryByRole('button', { name: /reload linejam/i })
     ).not.toBeInTheDocument();

--- a/tests/components/DeploymentSkewObserver.test.tsx
+++ b/tests/components/DeploymentSkewObserver.test.tsx
@@ -36,6 +36,10 @@ describe('DeploymentSkewObserver', () => {
     expect(
       await screen.findByRole('status', { name: /linejam was updated/i })
     ).toHaveTextContent(/your draft is safe/i);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/deployment',
+      expect.objectContaining({ cache: 'no-store' })
+    );
     expect(
       screen.getByRole('button', { name: /reload linejam/i })
     ).toBeInTheDocument();

--- a/tests/components/WritingScreen.test.tsx
+++ b/tests/components/WritingScreen.test.tsx
@@ -85,6 +85,7 @@ describe('WritingScreen component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    sessionStorage.clear();
     mockUseQuery.mockReset();
     mockSubmitLineMutation.mockReset();
     mockUseUserReturn.guestToken = 'mock-token';
@@ -113,6 +114,7 @@ describe('WritingScreen component', () => {
   afterEach(() => {
     global.fetch = originalFetch;
     localStorage.clear();
+    sessionStorage.clear();
   });
 
   it('keeps the word counter visible in the composer flow', () => {
@@ -218,6 +220,46 @@ describe('WritingScreen component', () => {
       expect(wordSlots).toHaveAttribute('aria-label', '1 of 1 words');
     });
     await flushDebounce();
+  });
+
+  it('keeps an in-progress line in session storage for reload recovery', async () => {
+    const user = setupUser();
+    render(<WritingScreen roomCode="ABCD" />);
+
+    await user.type(screen.getByRole('textbox'), 'Hello');
+
+    expect(
+      sessionStorage.getItem('linejam:writing-draft:ABCD:poem_123:0')
+    ).toBe('Hello');
+  });
+
+  it('restores the current assignment draft after a reload', () => {
+    sessionStorage.setItem(
+      'linejam:writing-draft:ABCD:poem_123:0',
+      'Recovered'
+    );
+
+    render(<WritingScreen roomCode="ABCD" />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('Recovered');
+    expect(screen.getByText('Draft restored')).toBeInTheDocument();
+  });
+
+  it('clears the saved draft once Convex confirms the line', async () => {
+    mockSubmitLineMutation.mockResolvedValue(undefined);
+    sessionStorage.setItem(
+      'linejam:writing-draft:ABCD:poem_123:0',
+      'Recovered'
+    );
+    const user = setupUser();
+    render(<WritingScreen roomCode="ABCD" />);
+
+    await user.click(screen.getByRole('button', { name: /^Submit$/i }));
+
+    await waitFor(() => expect(mockSubmitLineMutation).toHaveBeenCalled());
+    expect(
+      sessionStorage.getItem('linejam:writing-draft:ABCD:poem_123:0')
+    ).toBeNull();
   });
 
   it('submit button disabled when word count is wrong', () => {

--- a/tests/lib/env.test.ts
+++ b/tests/lib/env.test.ts
@@ -58,4 +58,46 @@ describe('validateEnv', () => {
       }
     );
   });
+
+  it('requires deployment skew controls for the real production target', async () => {
+    await withEnv(
+      {
+        NODE_ENV: 'production',
+        LINEJAM_DEPLOY_ENVIRONMENT: 'production',
+        GUEST_TOKEN_SECRET: 'guest-secret',
+        NEXT_PUBLIC_CONVEX_URL: 'https://convex.example',
+        NEXT_PUBLIC_CANARY_ENDPOINT: 'https://canary.example',
+        NEXT_PUBLIC_CANARY_API_KEY: 'sk_test_canary',
+        NEXT_DEPLOYMENT_ID: undefined,
+        NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: undefined,
+      },
+      async () => {
+        const { validateEnv } = await import('@/lib/env');
+        expect(() => validateEnv()).toThrow(
+          /NEXT_DEPLOYMENT_ID[\s\S]*NEXT_SERVER_ACTIONS_ENCRYPTION_KEY/
+        );
+      }
+    );
+  });
+
+  it('rejects a production Server Action key that is not 32-byte base64', async () => {
+    await withEnv(
+      {
+        NODE_ENV: 'production',
+        LINEJAM_DEPLOY_ENVIRONMENT: 'production',
+        GUEST_TOKEN_SECRET: 'guest-secret',
+        NEXT_PUBLIC_CONVEX_URL: 'https://convex.example',
+        NEXT_PUBLIC_CANARY_ENDPOINT: 'https://canary.example',
+        NEXT_PUBLIC_CANARY_API_KEY: 'sk_test_canary',
+        NEXT_DEPLOYMENT_ID: 'abc123',
+        NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: 'not-a-valid-key',
+      },
+      async () => {
+        const { validateEnv } = await import('@/lib/env');
+        expect(() => validateEnv()).toThrow(
+          /Invalid environment variables:[\s\S]*NEXT_SERVER_ACTIONS_ENCRYPTION_KEY/
+        );
+      }
+    );
+  });
 });

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -46,19 +46,22 @@ describe('middleware — guest-only mode (Clerk not configured)', () => {
     expect(res.headers.get('Cache-Control')).toBe('no-store');
   });
 
-  it('allows a well-formed Server Action identifier to reach Next.js', async () => {
-    delete process.env.CLERK_SECRET_KEY;
-    vi.resetModules();
+  it.each([40, 64])(
+    'allows a well-formed %i-character Server Action identifier to reach Next.js',
+    async (length) => {
+      delete process.env.CLERK_SECRET_KEY;
+      vi.resetModules();
 
-    const { default: middleware } = await import('../middleware');
-    const req = new NextRequest('http://localhost:3000/room/ABCD', {
-      method: 'POST',
-      headers: { 'next-action': 'a'.repeat(40) },
-    });
-    const res = await middleware(req);
+      const { default: middleware } = await import('../middleware');
+      const req = new NextRequest('http://localhost:3000/room/ABCD', {
+        method: 'POST',
+        headers: { 'next-action': 'a'.repeat(length) },
+      });
+      const res = await middleware(req);
 
-    expect(res.status).toBe(200);
-  });
+      expect(res.status).toBe(200);
+    }
+  );
 
   it('does not redirect /me/poems away', async () => {
     delete process.env.CLERK_SECRET_KEY;

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -31,6 +31,35 @@ afterEach(() => {
 });
 
 describe('middleware — guest-only mode (Clerk not configured)', () => {
+  it('drops malformed Server Action identifiers before Next.js logs them', async () => {
+    delete process.env.CLERK_SECRET_KEY;
+    vi.resetModules();
+
+    const { default: middleware } = await import('../middleware');
+    const req = new NextRequest('http://localhost:3000/room/ABCD', {
+      method: 'POST',
+      headers: { 'next-action': 'not-a-server-action-id' },
+    });
+    const res = await middleware(req);
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('allows a well-formed Server Action identifier to reach Next.js', async () => {
+    delete process.env.CLERK_SECRET_KEY;
+    vi.resetModules();
+
+    const { default: middleware } = await import('../middleware');
+    const req = new NextRequest('http://localhost:3000/room/ABCD', {
+      method: 'POST',
+      headers: { 'next-action': 'a'.repeat(40) },
+    });
+    const res = await middleware(req);
+
+    expect(res.status).toBe(200);
+  });
+
   it('does not redirect /me/poems away', async () => {
     delete process.env.CLERK_SECRET_KEY;
     vi.resetModules();

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import nextConfig, { buildContentSecurityPolicy } from '../next.config';
+import nextConfig, {
+  buildContentSecurityPolicy,
+  resolveDeploymentId,
+} from '../next.config';
 
 describe('nextConfig security headers', () => {
   afterEach(() => {
@@ -77,5 +80,16 @@ describe('nextConfig security headers', () => {
     expect(csp).not.toContain("'unsafe-eval'");
     expect(csp).not.toContain('localhost');
     expect(csp).not.toContain('127.0.0.1');
+  });
+});
+
+describe('nextConfig deployment skew protection', () => {
+  it('uses the provider commit as the deployment identifier', () => {
+    expect(resolveDeploymentId('  abc123_DEF-9  ')).toBe('abc123_DEF-9');
+  });
+
+  it('leaves local builds unversioned when the provider supplies no commit', () => {
+    expect(resolveDeploymentId(undefined)).toBeUndefined();
+    expect(resolveDeploymentId('   ')).toBeUndefined();
   });
 });

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import nextConfig, {
-  buildContentSecurityPolicy,
-  resolveDeploymentId,
-} from '../next.config';
+import nextConfig, { buildContentSecurityPolicy } from '../next.config';
+import { resolveDeploymentId } from '@/lib/deploymentId';
 
 describe('nextConfig security headers', () => {
   afterEach(() => {
@@ -90,6 +88,7 @@ describe('nextConfig deployment skew protection', () => {
 
   it('leaves local builds unversioned when the provider supplies no commit', () => {
     expect(resolveDeploymentId(undefined)).toBeUndefined();
+    expect(resolveDeploymentId(false)).toBeUndefined();
     expect(resolveDeploymentId('   ')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- stabilize Clerk-injected Server Action IDs across rolling builds with a fail-closed production key contract
- bind Next.js deployment skew detection to the provider commit and surface one accessible reload path
- preserve the active writing draft across reloads while bounding malformed action traffic before incident logging
- declare and document the values-free DigitalOcean topology and health receipt

## Root cause

Two clean historical builds produced three different Clerk-injected action IDs and different generated encryption keys. Rebuilding both with one test-only 32-byte key made every action ID identical. No application-owned Server Actions were present.

## Verification

- `pnpm ci:prepush` — 140 files, 1,587 tests passed, 1 skipped
- focused recovery suite — 82 tests passed
- DigitalOcean drift suite — 79 tests passed
- clean-room Sprite `pnpm ci:prepush` — 140 files, 1,587 tests passed, 1 skipped
- live values-free App Platform drift clean; prerequisite deployment `d9adce63-8d30-4a60-931f-e9e4c7e1086e` ACTIVE

## Rollout

The production web component already has `NEXT_DEPLOYMENT_ID=${_self.COMMIT_HASH}` and an encrypted stable `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY`. After merge: verify the health deployment receipt, activation logs, and two consecutive production smokes.

Powder: `linejam-984`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Writing drafts are now restored after refresh or navigation.
  * The app detects when the browser is out of sync with the current deployment and prompts users to reload.
  * Health checks now include deployment readiness and protection details.
* **Bug Fixes**
  * Improved handling of unrecognized server actions during rolling deployments.
  * Production readiness now returns 503 when deployment skew protection settings are missing or invalid.
* **Documentation**
  * Updated deployment setup and environment-variable guidance for rolling-deploy skew protection and stable server action encryption settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->