### PR TITLE
test: add rolling deployment recovery oracle

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -179,8 +179,10 @@ run two consecutive production smokes and inspect activation logs for any
 unclassified `Failed to find Server Action` burst.
 
 The deterministic production oracle stages that held room without logging its
-code or draft content, waits up to 30 minutes for a new deployment receipt, and
-verifies the banner, player-triggered reload, and restored draft:
+code or content, waits up to 30 minutes for a new deployment receipt, then
+enters the writing phase on the stale client and verifies the banner,
+player-triggered reload, and restored draft. Creating the draft only after the
+receipt changes keeps the proof inside the game's 90-second ghost-fill floor.
 
 ```bash
 PLAYWRIGHT_BASE_URL=https://www.linejam.app pnpm qa:deployment-skew

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -178,6 +178,14 @@ update banner, reload only on the player's action, and restore the draft. Then
 run two consecutive production smokes and inspect activation logs for any
 unclassified `Failed to find Server Action` burst.
 
+The deterministic production oracle stages that held room without logging its
+code or draft content, waits up to 30 minutes for a new deployment receipt, and
+verifies the banner, player-triggered reload, and restored draft:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://www.linejam.app pnpm qa:deployment-skew
+```
+
 ## Convex configuration
 
 Set backend-only values in the production Convex deployment. Omitting the

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:e2e:ui": "playwright test --ui --grep-invert \"@evidence|@slow\"",
     "qa:agentic:local": "node ./scripts/qa/agentic.mjs --target local",
     "qa:agentic:preview": "node ./scripts/qa/agentic.mjs --target preview",
+    "qa:deployment-skew": "node ./scripts/qa/deployment-skew-oracle.mjs",
     "ci:fast": "pnpm ci:prepush",
     "ci:dagger:all": "./scripts/ci/dagger-call.sh all",
     "ci:dagger:all-no-e2e": "./scripts/ci/dagger-call.sh all-no-e2e",

--- a/scripts/qa/deployment-skew-oracle.mjs
+++ b/scripts/qa/deployment-skew-oracle.mjs
@@ -1,0 +1,139 @@
+import { chromium } from '@playwright/test';
+
+const BASE_URL = new URL(
+  process.env.PLAYWRIGHT_BASE_URL || 'https://www.linejam.app'
+).origin;
+const TIMEOUT_MS = positiveInteger(
+  process.env.LINEJAM_SKEW_ORACLE_TIMEOUT_MS,
+  30 * 60 * 1000
+);
+const POLL_INTERVAL_MS = 5_000;
+const DRAFT = 'continuity';
+
+const TEST_ID = {
+  hostName: 'host-name-input',
+  createRoom: 'host-create-room-button',
+  joinName: 'join-name-input',
+  joinRoom: 'join-room-button',
+  startGame: 'lobby-start-game-button',
+  writingPhase: 'writing-phase',
+  writingInput: 'writing-line-input',
+};
+
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+async function readDeploymentId(page) {
+  const response = await page.request.get(`${BASE_URL}/api/deployment`, {
+    failOnStatusCode: true,
+    headers: { Accept: 'application/json' },
+  });
+  const payload = await response.json();
+  const id = payload?.deployment?.id;
+  if (typeof id !== 'string' || !id.trim()) {
+    throw new Error('Production returned no deployment receipt');
+  }
+  return id;
+}
+
+async function establishHeldDraft(browser) {
+  const hostContext = await browser.newContext();
+  const guestContext = await browser.newContext();
+  const hostPage = await hostContext.newPage();
+  const guestPage = await guestContext.newPage();
+
+  await hostPage.goto(`${BASE_URL}/host`);
+  await hostPage.getByTestId(TEST_ID.hostName).fill('Rollout Host');
+  await hostPage.getByTestId(TEST_ID.createRoom).click();
+  await hostPage.waitForURL(/\/room\/[A-Z]{4}$/);
+  const roomCode = new URL(hostPage.url()).pathname.split('/').pop();
+  if (!roomCode || !/^[A-Z]{4}$/.test(roomCode)) {
+    throw new Error('Host did not reach a valid room');
+  }
+
+  await guestPage.goto(`${BASE_URL}/join?code=${roomCode}`);
+  await guestPage.getByTestId(TEST_ID.joinName).fill('Rollout Guest');
+  await guestPage.getByTestId(TEST_ID.joinRoom).click();
+  await guestPage.waitForURL(new RegExp(`/room/${roomCode}$`));
+
+  const start = hostPage.getByTestId(TEST_ID.startGame).filter({
+    visible: true,
+  });
+  await start.waitFor({ state: 'visible' });
+  await start.click();
+  await hostPage
+    .getByTestId(TEST_ID.writingPhase)
+    .waitFor({ state: 'visible' });
+  await guestPage
+    .getByTestId(TEST_ID.writingPhase)
+    .waitFor({ state: 'visible' });
+
+  const input = hostPage.getByTestId(TEST_ID.writingInput);
+  await input.fill(DRAFT);
+  if ((await input.inputValue()) !== DRAFT) {
+    throw new Error('Draft was not accepted before rollout');
+  }
+
+  return { guestContext, hostContext, hostPage };
+}
+
+async function waitForNextDeployment(page, initialId) {
+  const deadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    const currentId = await readDeploymentId(page);
+    if (currentId !== initialId) return currentId;
+  }
+  throw new Error(`No new deployment became active within ${TIMEOUT_MS}ms`);
+}
+
+async function verifyRecovery(page) {
+  await page.bringToFront();
+  await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+
+  const banner = page.getByRole('status', { name: /linejam was updated/i });
+  await banner.waitFor({ state: 'visible', timeout: 30_000 });
+  await page.getByRole('button', { name: /reload linejam/i }).click();
+
+  const input = page.getByTestId(TEST_ID.writingInput);
+  await input.waitFor({ state: 'visible', timeout: 30_000 });
+  if ((await input.inputValue()) !== DRAFT) {
+    throw new Error('Draft did not survive the deployment reload');
+  }
+  await page.getByText('Draft restored', { exact: true }).waitFor({
+    state: 'visible',
+  });
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  let session;
+
+  try {
+    const receiptContext = await browser.newContext();
+    const receiptPage = await receiptContext.newPage();
+    const initialId = await readDeploymentId(receiptPage);
+    await receiptContext.close();
+    session = await establishHeldDraft(browser);
+    const stagedId = await readDeploymentId(session.hostPage);
+    if (stagedId !== initialId) {
+      throw new Error('Deployment changed while the held room was staged');
+    }
+
+    console.log(`READY deployment=${initialId}`);
+    const nextId = await waitForNextDeployment(session.hostPage, initialId);
+    console.log(`DETECTED deployment=${nextId}`);
+    await verifyRecovery(session.hostPage);
+    console.log('PASS stale client reloaded with its draft restored');
+  } finally {
+    await Promise.allSettled([
+      session?.guestContext.close(),
+      session?.hostContext.close(),
+    ]);
+    await browser.close();
+  }
+}
+
+await main();

--- a/scripts/qa/deployment-skew-oracle.mjs
+++ b/scripts/qa/deployment-skew-oracle.mjs
@@ -38,7 +38,7 @@ async function readDeploymentId(page) {
   return id;
 }
 
-async function establishHeldDraft(browser) {
+async function establishHeldRoom(browser) {
   const hostContext = await browser.newContext();
   const guestContext = await browser.newContext();
   const hostPage = await hostContext.newPage();
@@ -48,7 +48,10 @@ async function establishHeldDraft(browser) {
   await hostPage.getByTestId(TEST_ID.hostName).fill('Rollout Host');
   await hostPage.getByTestId(TEST_ID.createRoom).click();
   await hostPage.waitForURL(/\/room\/[A-Z]{4}$/);
-  const roomCode = new URL(hostPage.url()).pathname.split('/').pop();
+  const roomCode = new URL(hostPage.url()).pathname
+    .replace(/\/+$/, '')
+    .split('/')
+    .pop();
   if (!roomCode || !/^[A-Z]{4}$/.test(roomCode)) {
     throw new Error('Host did not reach a valid room');
   }
@@ -58,25 +61,27 @@ async function establishHeldDraft(browser) {
   await guestPage.getByTestId(TEST_ID.joinRoom).click();
   await guestPage.waitForURL(new RegExp(`/room/${roomCode}$`));
 
-  const start = hostPage.getByTestId(TEST_ID.startGame).filter({
+  return { guestContext, guestPage, hostContext, hostPage };
+}
+
+async function stageDraft(session) {
+  const start = session.hostPage.getByTestId(TEST_ID.startGame).filter({
     visible: true,
   });
   await start.waitFor({ state: 'visible' });
   await start.click();
-  await hostPage
+  await session.hostPage
     .getByTestId(TEST_ID.writingPhase)
     .waitFor({ state: 'visible' });
-  await guestPage
+  await session.guestPage
     .getByTestId(TEST_ID.writingPhase)
     .waitFor({ state: 'visible' });
 
-  const input = hostPage.getByTestId(TEST_ID.writingInput);
+  const input = session.hostPage.getByTestId(TEST_ID.writingInput);
   await input.fill(DRAFT);
   if ((await input.inputValue()) !== DRAFT) {
-    throw new Error('Draft was not accepted before rollout');
+    throw new Error('Draft was not accepted on the stale client');
   }
-
-  return { guestContext, hostContext, hostPage };
 }
 
 async function waitForNextDeployment(page, initialId) {
@@ -116,7 +121,7 @@ async function main() {
     const receiptPage = await receiptContext.newPage();
     const initialId = await readDeploymentId(receiptPage);
     await receiptContext.close();
-    session = await establishHeldDraft(browser);
+    session = await establishHeldRoom(browser);
     const stagedId = await readDeploymentId(session.hostPage);
     if (stagedId !== initialId) {
       throw new Error('Deployment changed while the held room was staged');
@@ -125,6 +130,7 @@ async function main() {
     console.log(`READY deployment=${initialId}`);
     const nextId = await waitForNextDeployment(session.hostPage, initialId);
     console.log(`DETECTED deployment=${nextId}`);
+    await stageDraft(session);
     await verifyRecovery(session.hostPage);
     console.log('PASS stale client reloaded with its draft restored');
   } finally {


### PR DESCRIPTION
## Summary
- add a deterministic two-player production oracle for held drafts across deploys
- wait on the values-free deployment receipt, then assert banner, player reload, and draft restoration
- document the rollout command without logging room or draft content

## Verification
- `node --check scripts/qa/deployment-skew-oracle.mjs`
- `pnpm exec eslint scripts/qa/deployment-skew-oracle.mjs`
- normal pre-push contract

Powder: linejam-984