### PR TITLE
fix: make mobile entry flows viewport safe

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -6,8 +6,8 @@ import { AuthShowcase } from '@/components/auth/AuthShowcase';
 /**
  * Auth Layout: Artistic Split Design
  *
- * Desktop (md+): 50/50 split - auth form left, poem showcase right
- * Mobile: Stacked - poem banner above form
+ * Desktop (lg+): 50/50 split - auth form left, poem showcase right
+ * Phone/tablet: Focused account task, including landscape phones
  *
  * Uses theme tokens throughout for multi-theme support.
  * Works with all 4 themes: kenya, mono, vintage-paper, hyper.
@@ -18,14 +18,14 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-[var(--color-background)] flex flex-col md:flex-row">
+    <div className="min-h-screen bg-[var(--color-background)] flex flex-col lg:flex-row">
       {/* Left: Auth Form */}
-      <div className="flex-1 flex flex-col justify-center px-6 py-12 md:px-12 lg:px-16 order-2 md:order-1">
+      <div className="flex-1 flex flex-col justify-start lg:justify-center px-5 py-8 sm:px-6 sm:py-10 md:px-12 lg:px-16 lg:py-12">
         {/* Wordmark / Home Link */}
-        <div className="mb-12">
+        <div className="mb-8 md:mb-12">
           <Link
             href="/"
-            className="text-2xl md:text-3xl font-[var(--font-display)] text-[var(--color-text-primary)] hover:text-[var(--color-primary)] transition-colors duration-[var(--duration-normal)]"
+            className="inline-flex min-h-11 items-center text-2xl md:text-3xl font-[var(--font-display)] text-[var(--color-text-primary)] hover:text-[var(--color-primary)] transition-colors duration-[var(--duration-normal)]"
           >
             Linejam
           </Link>
@@ -35,7 +35,7 @@ export default function AuthLayout({
         <div className="w-full max-w-md mx-auto md:mx-0">{children}</div>
 
         {/* Footer */}
-        <div className="mt-12 text-sm text-[var(--color-text-muted)] font-[var(--font-sans)]">
+        <div className="mt-8 md:mt-12 text-sm text-[var(--color-text-muted)] font-[var(--font-sans)]">
           <p>
             Write poems together.
             <br />
@@ -45,7 +45,7 @@ export default function AuthLayout({
       </div>
 
       {/* Right: Poem Showcase */}
-      <div className="flex-1 bg-[var(--color-surface)] border-l-0 md:border-l border-[var(--color-border)] order-1 md:order-2 min-h-[200px] md:min-h-0">
+      <div className="hidden lg:block flex-1 bg-[var(--color-surface)] border-l border-[var(--color-border)] min-h-0">
         <AuthShowcase />
       </div>
     </div>

--- a/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -75,19 +75,6 @@ export default function SignInPage() {
         signUpUrl="/sign-up"
         fallbackRedirectUrl="/callback"
       />
-
-      {/* Footer Link */}
-      <div className="pt-4 border-t border-[var(--color-border-subtle)]">
-        <p className="text-sm text-[var(--color-text-muted)] font-[var(--font-sans)]">
-          Don&apos;t have an account?{' '}
-          <Link
-            href="/sign-up"
-            className="text-[var(--color-primary)] hover:text-[var(--color-primary-hover)] font-medium transition-colors"
-          >
-            Sign up
-          </Link>
-        </p>
-      </div>
     </div>
   );
 }

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -75,19 +75,6 @@ export default function SignUpPage() {
         signInUrl="/sign-in"
         fallbackRedirectUrl="/callback"
       />
-
-      {/* Footer Link */}
-      <div className="pt-4 border-t border-[var(--color-border-subtle)]">
-        <p className="text-sm text-[var(--color-text-muted)] font-[var(--font-sans)]">
-          Already have an account?{' '}
-          <Link
-            href="/sign-in"
-            className="text-[var(--color-primary)] hover:text-[var(--color-primary-hover)] font-medium transition-colors"
-          >
-            Sign in
-          </Link>
-        </p>
-      </div>
     </div>
   );
 }

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, Suspense } from 'react';
+import { useRef, useState, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useMutation } from 'convex/react';
 import { api } from '../../convex/_generated/api';
@@ -23,6 +23,7 @@ function JoinForm() {
   const searchParams = useSearchParams();
   const { guestToken, isLoading, authError, retryAuth } = useUser();
   const joinRoomMutation = useMutation(api.rooms.joinRoom);
+  const nameInputRef = useRef<HTMLInputElement>(null);
 
   const [code, setCode] = useState(
     () => searchParams.get('code')?.toUpperCase() || ''
@@ -33,17 +34,18 @@ function JoinForm() {
 
   const handleJoin = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!code || !name) return;
+
+    const normalizedCode = code.replace(/\s/g, '');
+    const normalizedName = name.trim();
+    if (!normalizedCode || !normalizedName) return;
 
     setIsSubmitting(true);
     setError('');
 
-    const normalizedCode = code.replace(/\s/g, '');
-
     try {
       await joinRoomMutation({
         code: normalizedCode,
-        displayName: name,
+        displayName: normalizedName,
         guestToken: guestToken || undefined,
       });
       trackGameJoined({ roomCode: normalizedCode });
@@ -72,20 +74,20 @@ function JoinForm() {
 
   return (
     <div className="max-w-xl w-full ml-auto">
-      <p className="text-xs font-mono uppercase tracking-[0.32em] text-text-muted mb-3 text-right">
+      <p className="text-xs font-mono uppercase tracking-[0.32em] text-text-muted mb-2 sm:mb-3 text-right">
         Join game
       </p>
-      <h1 className="text-4xl md:text-6xl font-[var(--font-display)] leading-tight mb-8 text-right">
+      <h1 className="text-3xl sm:text-4xl md:text-6xl font-[var(--font-display)] leading-tight mb-5 sm:mb-8 text-right break-words">
         Join Session
       </h1>
 
-      <div className="p-8 border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-lg)]">
-        <p className="mb-8 text-base leading-relaxed text-[var(--color-text-secondary)]">
+      <div className="p-5 sm:p-8 border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-lg)]">
+        <p className="mb-5 sm:mb-8 text-base leading-relaxed text-[var(--color-text-secondary)]">
           You&apos;ll add one hidden line at a time, then everyone reads the
           finished poems together.
         </p>
-        <form onSubmit={handleJoin} className="space-y-8">
-          <div className="space-y-3">
+        <form onSubmit={handleJoin} className="space-y-5 sm:space-y-8">
+          <div className="space-y-2 sm:space-y-3">
             <label
               htmlFor="code"
               className="block text-sm font-medium text-[var(--color-text-secondary)] uppercase tracking-wide"
@@ -106,11 +108,18 @@ function JoinForm() {
               autoCorrect="off"
               autoComplete="off"
               spellCheck={false}
-              className="uppercase tracking-[0.5em] text-center font-mono text-2xl h-16 bg-[var(--color-muted)] border-2"
+              enterKeyHint="next"
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  nameInputRef.current?.focus();
+                }
+              }}
+              className="uppercase tracking-[0.35em] sm:tracking-[0.5em] text-center font-mono text-2xl h-14 sm:h-16 bg-[var(--color-muted)] border-2 scroll-mb-28"
             />
           </div>
 
-          <div className="space-y-3">
+          <div className="space-y-2 sm:space-y-3">
             <label
               htmlFor="name"
               className="block text-sm font-medium text-[var(--color-text-secondary)] uppercase tracking-wide"
@@ -118,6 +127,7 @@ function JoinForm() {
               Your Name
             </label>
             <Input
+              ref={nameInputRef}
               id="name"
               data-testid={E2E_TEST_IDS.joinNameInput}
               placeholder="Enter your name..."
@@ -127,12 +137,12 @@ function JoinForm() {
               autoFocus={hasCode}
               autoCapitalize="words"
               autoComplete="off"
-              className="text-lg h-14"
+              enterKeyHint="go"
+              className="text-lg h-14 scroll-mb-28"
             />
           </div>
 
-          {/* Thumb-zone on phones; settles inline on tablet/desktop */}
-          <div className="fixed inset-x-0 bottom-0 p-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] space-y-4 bg-background/95 backdrop-blur-md border-t-2 border-primary/20 shadow-[var(--shadow-lg)] md:static md:p-0 md:pt-4 md:bg-transparent md:backdrop-blur-none md:border-0 md:shadow-none">
+          <div className="pt-1 sm:pt-4 space-y-4">
             {error && (
               <Alert variant="error" data-testid={E2E_TEST_IDS.joinErrorAlert}>
                 {error}
@@ -142,10 +152,10 @@ function JoinForm() {
             <Button
               type="submit"
               data-testid={E2E_TEST_IDS.joinRoomButton}
-              className="w-full text-lg h-14"
+              className="w-full text-base sm:text-lg h-12 sm:h-14"
               disabled={!name.trim() || !code.trim() || isSubmitting}
             >
-              {isSubmitting ? 'Authenticating...' : 'Enter Room'}
+              {isSubmitting ? 'Joining...' : 'Enter Room'}
             </Button>
           </div>
         </form>
@@ -156,7 +166,7 @@ function JoinForm() {
 
 export default function JoinPage() {
   return (
-    <div className="min-h-screen bg-[var(--color-background)] p-6 pb-32 md:p-12 lg:p-20 flex flex-col">
+    <div className="min-h-screen w-full bg-[var(--color-background)] px-4 py-6 sm:p-6 md:p-12 lg:p-20 flex flex-col">
       <Suspense fallback={<div>Loading...</div>}>
         <JoinForm />
       </Suspense>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { SignedIn, SignedOut, UserButton } from '@clerk/nextjs';
-import { Palette, Archive, LogIn } from 'lucide-react';
+import { Palette, Archive, LogIn, MoreHorizontal } from 'lucide-react';
 import { HelpModal } from './HelpModal';
 import { isGameRoute } from '@/lib/routes';
 
@@ -12,14 +12,47 @@ type HeaderProps = {
   className?: string;
 };
 
+const headerIconClasses =
+  'w-11 h-11 shrink-0 rounded-full border border-[var(--color-border)] items-center justify-center hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] transition-all duration-[var(--duration-normal)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2';
+
+const mobileMenuItemClasses =
+  'flex min-h-11 w-full items-center gap-3 rounded-[var(--radius-md)] px-3 py-2 text-left text-sm text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-background)] focus-visible:outline-none focus-visible:bg-[var(--color-background)]';
+
 export function Header({ className = '' }: HeaderProps) {
   const pathname = usePathname();
   const isHomepage = pathname === '/';
   const isRoomPage = isGameRoute(pathname);
+  const isAuthPage = /^\/(sign-in|sign-up|callback)(?:\/|$)/.test(pathname);
   const [showHelp, setShowHelp] = useState(false);
+  const [showMenu, setShowMenu] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuTriggerRef = useRef<HTMLButtonElement>(null);
 
-  // Hide header entirely during game experience (Lobby → Writing → Reveal)
-  if (isRoomPage) {
+  useEffect(() => {
+    if (!showMenu) return;
+
+    const handlePointer = (event: MouseEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) {
+        setShowMenu(false);
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setShowMenu(false);
+        menuTriggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointer);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handlePointer);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [showMenu]);
+
+  // Gameplay and account entry own their focused chrome.
+  if (isRoomPage || isAuthPage) {
     return null;
   }
 
@@ -27,24 +60,24 @@ export function Header({ className = '' }: HeaderProps) {
     <>
       <HelpModal isOpen={showHelp} onClose={() => setShowHelp(false)} />
       <header
-        className={`w-full p-6 flex justify-between items-center gap-4 border-b border-[var(--color-border-subtle)] ${className}`}
+        className={`w-full px-3 py-3 sm:px-6 sm:py-6 flex justify-between items-center gap-2 border-b border-[var(--color-border-subtle)] ${className}`}
       >
         {/* Left: Wordmark (hidden on homepage) */}
         {!isHomepage && (
           <Link
             href="/"
-            className="text-[var(--text-2xl)] md:text-[var(--text-3xl)] font-[var(--font-display)] text-[var(--color-text-primary)] hover:text-[var(--color-primary)] transition-colors"
+            className="inline-flex min-h-11 shrink-0 items-center text-xl min-[360px]:text-[var(--text-2xl)] md:text-[var(--text-3xl)] font-[var(--font-display)] text-[var(--color-text-primary)] hover:text-[var(--color-primary)] transition-colors"
           >
             Linejam
           </Link>
         )}
 
         {/* Right: Auth + Theme */}
-        <div className="flex items-center gap-4 ml-auto">
+        <div className="flex shrink-0 items-center gap-1 min-[360px]:gap-2 sm:gap-4 ml-auto">
           <SignedOut>
             <Link
               href="/sign-in"
-              className="w-11 h-11 rounded-full border border-[var(--color-border)] flex items-center justify-center hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] transition-all duration-[var(--duration-normal)]"
+              className={`${headerIconClasses} flex`}
               aria-label="Sign in"
             >
               <LogIn className="w-5 h-5" />
@@ -55,6 +88,8 @@ export function Header({ className = '' }: HeaderProps) {
             <UserButton
               appearance={{
                 elements: {
+                  rootBox: 'w-11 h-11 shrink-0',
+                  userButtonTrigger: 'w-11 h-11',
                   avatarBox: 'w-10 h-10 border border-[var(--color-border)]',
                 },
               }}
@@ -65,7 +100,7 @@ export function Header({ className = '' }: HeaderProps) {
           <Link
             href="/me/poems"
             prefetch={false}
-            className="w-11 h-11 rounded-full border border-[var(--color-border)] flex items-center justify-center hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] transition-all duration-[var(--duration-normal)]"
+            className={`${headerIconClasses} hidden sm:flex`}
             aria-label="View your poem archive"
           >
             <Archive className="w-5 h-5" />
@@ -74,7 +109,7 @@ export function Header({ className = '' }: HeaderProps) {
           {/* Help button */}
           <button
             onClick={() => setShowHelp(true)}
-            className="w-11 h-11 rounded-full border border-[var(--color-border)] flex items-center justify-center hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] transition-all duration-[var(--duration-normal)]"
+            className={`${headerIconClasses} hidden sm:flex`}
             aria-label="How to play"
           >
             <span className="text-lg font-medium">?</span>
@@ -84,12 +119,66 @@ export function Header({ className = '' }: HeaderProps) {
           <Link
             href="/themes"
             prefetch={false}
-            className="w-11 h-11 rounded-full border border-[var(--color-border)] flex items-center justify-center hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] transition-all duration-[var(--duration-normal)]"
+            className={`${headerIconClasses} hidden sm:flex`}
             aria-label="Choose theme"
             aria-current={pathname === '/themes' ? 'page' : undefined}
           >
             <Palette className="w-5 h-5" />
           </Link>
+
+          <div ref={menuRef} className="relative sm:hidden">
+            <button
+              ref={menuTriggerRef}
+              type="button"
+              onClick={() => setShowMenu((current) => !current)}
+              className={`${headerIconClasses} flex`}
+              aria-label="More options"
+              aria-haspopup="true"
+              aria-expanded={showMenu}
+            >
+              <MoreHorizontal className="h-5 w-5" />
+            </button>
+
+            {showMenu && (
+              <div className="absolute right-0 top-full z-50 mt-3 w-56 max-w-[calc(100vw-1.5rem)] rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-1.5 shadow-[var(--shadow-lg)]">
+                <Link
+                  href="/me/poems"
+                  prefetch={false}
+                  className={mobileMenuItemClasses}
+                  onClick={() => setShowMenu(false)}
+                >
+                  <Archive className="h-4 w-4 text-[var(--color-text-muted)]" />
+                  Your poems
+                </Link>
+                <button
+                  type="button"
+                  className={mobileMenuItemClasses}
+                  onClick={() => {
+                    setShowMenu(false);
+                    setShowHelp(true);
+                  }}
+                >
+                  <span
+                    className="flex h-4 w-4 items-center justify-center text-base text-[var(--color-text-muted)]"
+                    aria-hidden="true"
+                  >
+                    ?
+                  </span>
+                  How to play
+                </button>
+                <Link
+                  href="/themes"
+                  prefetch={false}
+                  className={mobileMenuItemClasses}
+                  onClick={() => setShowMenu(false)}
+                  aria-current={pathname === '/themes' ? 'page' : undefined}
+                >
+                  <Palette className="h-4 w-4 text-[var(--color-text-muted)]" />
+                  Choose theme
+                </Link>
+              </div>
+            )}
+          </div>
         </div>
       </header>
     </>

--- a/lib/clerk/appearance.ts
+++ b/lib/clerk/appearance.ts
@@ -26,7 +26,7 @@ export const linejamClerkAppearance = {
     formButtonPrimary:
       'bg-[var(--color-primary)] hover:bg-[var(--color-primary-hover)] text-[var(--color-text-inverse)] font-[var(--font-sans)] font-medium h-12 rounded-[var(--radius-md)] transition-all duration-[var(--duration-normal)]',
     formFieldInput:
-      'bg-[var(--color-surface)] border-[var(--color-border)] text-[var(--color-text-primary)] font-[var(--font-sans)] h-12 rounded-[var(--radius-md)] focus:border-[var(--color-primary)] focus:ring-[var(--color-focus-ring)] focus:ring-2 focus:ring-offset-2',
+      'bg-[var(--color-surface)] border-[var(--color-border)] text-[var(--color-text-primary)] font-[var(--font-sans)] text-base h-12 rounded-[var(--radius-md)] focus:border-[var(--color-primary)] focus:ring-[var(--color-focus-ring)] focus:ring-2 focus:ring-offset-2',
     formFieldLabel:
       'text-[var(--color-text-secondary)] font-[var(--font-sans)] text-sm',
     formFieldInputShowPasswordButton:
@@ -147,6 +147,9 @@ export function resolveClerkThemeVariables() {
     // references and keep tracking the active theme with no extra plumbing.
     fontFamily: 'var(--font-sans)',
     fontFamilyButtons: 'var(--font-sans)',
+    // iOS Safari zooms focused form controls below 16px. Clerk's default is
+    // 13px, so make the no-zoom floor part of the provider contract.
+    fontSize: '1rem',
     borderRadius: 'var(--radius-md)',
   };
 }

--- a/tests/app/mobile-entry-layout.test.tsx
+++ b/tests/app/mobile-entry-layout.test.tsx
@@ -4,9 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 const mockUseSearchParams = vi.fn();
+const mockUsePathname = vi.fn();
 
 vi.mock('next/navigation', () => ({
-  usePathname: () => '/join',
+  usePathname: () => mockUsePathname(),
   useRouter: () => ({ push: vi.fn() }),
   useSearchParams: () => mockUseSearchParams(),
 }));
@@ -43,6 +44,7 @@ describe('mobile entry layout', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUsePathname.mockReturnValue('/join');
     mockUseSearchParams.mockReturnValue(new URLSearchParams('code=ABCD'));
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -126,6 +128,33 @@ describe('mobile entry layout', () => {
     expect(screen.getByRole('link', { name: 'Your poems' })).toHaveClass(
       'min-h-11'
     );
+  });
+
+  it('closes the mobile header menu outside or with Escape and restores focus', () => {
+    render(<Header />);
+
+    const menu = screen.getByRole('button', { name: 'More options' });
+    fireEvent.click(menu);
+    fireEvent.mouseDown(menu);
+    expect(menu).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(menu).toHaveAttribute('aria-expanded', 'false');
+    expect(menu).toHaveFocus();
+
+    fireEvent.click(menu);
+    fireEvent.mouseDown(document.body);
+    expect(menu).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('defers to focused account and gameplay chrome', () => {
+    mockUsePathname.mockReturnValue('/sign-in');
+    const { rerender } = render(<Header />);
+    expect(screen.queryByRole('banner')).not.toBeInTheDocument();
+
+    mockUsePathname.mockReturnValue('/room/ABCD');
+    rerender(<Header />);
+    expect(screen.queryByRole('banner')).not.toBeInTheDocument();
   });
 
   it('renders exactly one account-switch prompt on sign-in', async () => {

--- a/tests/app/mobile-entry-layout.test.tsx
+++ b/tests/app/mobile-entry-layout.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+const mockUseSearchParams = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/join',
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => mockUseSearchParams(),
+}));
+
+vi.mock('convex/react', () => ({
+  useConvexAuth: () => ({ isLoading: false, isAuthenticated: false }),
+  useMutation: () => vi.fn().mockResolvedValue(undefined),
+  useQuery: () => undefined,
+}));
+
+vi.mock('@clerk/nextjs', () => ({
+  SignedIn: () => null,
+  SignedOut: ({ children }: { children: ReactNode }) => children,
+  UserButton: () => <button type="button">Account</button>,
+  useUser: () => ({ user: null, isLoaded: true }),
+  SignIn: () => (
+    <div>
+      <p>Don&apos;t have an account? Sign up</p>
+    </div>
+  ),
+  SignUp: () => (
+    <div>
+      <p>Already have an account? Sign in</p>
+    </div>
+  ),
+}));
+
+import AuthLayout from '@/app/(auth)/layout';
+import JoinPage from '@/app/join/page';
+import { Header } from '@/components/Header';
+
+describe('mobile entry layout', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSearchParams.mockReturnValue(new URLSearchParams('code=ABCD'));
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ guestId: 'guest-123', token: 'guest-token' }),
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.unstubAllEnvs();
+  });
+
+  it('keeps the join action inline with the required fields on narrow phones', async () => {
+    render(<JoinPage />);
+
+    const heading = await screen.findByRole('heading', {
+      level: 1,
+      name: /join session/i,
+    });
+    const button = screen.getByRole('button', { name: /enter room/i });
+    const actionRegion = button.parentElement;
+
+    expect(heading).toHaveClass('text-3xl', 'sm:text-4xl');
+    expect(actionRegion).not.toHaveClass('fixed');
+    expect(actionRegion).not.toHaveClass('inset-x-0', 'bottom-0');
+    const code = screen.getByLabelText(/room code/i);
+    const name = screen.getByLabelText(/your name/i);
+    expect(code).toBeInTheDocument();
+    expect(name).toBeInTheDocument();
+
+    fireEvent.keyDown(code, { key: 'Enter' });
+    expect(name).toHaveFocus();
+  });
+
+  it('puts the account task before decorative poem content on phones', () => {
+    render(
+      <AuthLayout>
+        <div>Account access</div>
+      </AuthLayout>
+    );
+
+    const authColumn =
+      screen.getByText('Account access').parentElement?.parentElement;
+    const showcaseColumn = screen
+      .getByText('Recent Creation')
+      .closest('.flex-1');
+
+    expect(authColumn).not.toHaveClass('order-2');
+    expect(showcaseColumn).toHaveClass('hidden', 'lg:block');
+    expect(authColumn).toHaveClass('justify-start', 'lg:justify-center');
+    expect(screen.getByRole('link', { name: 'Linejam' })).toHaveClass(
+      'min-h-11'
+    );
+  });
+
+  it('uses compact header spacing without shrinking visible touch targets', () => {
+    render(<Header />);
+
+    const header = screen.getByRole('banner');
+    expect(header).toHaveClass('px-3', 'gap-2', 'sm:px-6');
+    expect(screen.getByRole('link', { name: 'Linejam' })).toHaveClass(
+      'min-h-11'
+    );
+
+    for (const name of [
+      'Sign in',
+      'View your poem archive',
+      'How to play',
+      'Choose theme',
+    ]) {
+      expect(
+        screen.getByRole(/play/.test(name) ? 'button' : 'link', { name })
+      ).toHaveClass('w-11', 'h-11');
+    }
+
+    const menu = screen.getByRole('button', { name: 'More options' });
+    expect(menu).toHaveClass('w-11', 'h-11');
+    expect(menu).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(menu);
+    expect(menu).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('link', { name: 'Your poems' })).toHaveClass(
+      'min-h-11'
+    );
+  });
+
+  it('renders exactly one account-switch prompt on sign-in', async () => {
+    vi.stubEnv('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY', 'pk_test_mobile_entry');
+    vi.resetModules();
+    const { default: SignInPage } =
+      await import('@/app/(auth)/sign-in/[[...sign-in]]/page');
+
+    render(<SignInPage />);
+
+    expect(screen.getAllByText(/don(?:'|’)t have an account/i)).toHaveLength(1);
+  });
+
+  it('renders exactly one account-switch prompt on sign-up', async () => {
+    vi.stubEnv('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY', 'pk_test_mobile_entry');
+    vi.resetModules();
+    const { default: SignUpPage } =
+      await import('@/app/(auth)/sign-up/[[...sign-up]]/page');
+
+    render(<SignUpPage />);
+
+    expect(screen.getAllByText(/already have an account/i)).toHaveLength(1);
+  });
+});

--- a/tests/e2e/mobile-entry-viewport.spec.ts
+++ b/tests/e2e/mobile-entry-viewport.spec.ts
@@ -1,0 +1,173 @@
+import { expect, Page, test } from '@playwright/test';
+
+import { E2E_TEST_IDS } from '../../lib/e2eTestIds';
+import { isolateGuestSessionIp } from './support/guestFlow';
+
+const PHONE_VIEWPORTS = [
+  { width: 320, height: 667 },
+  { width: 375, height: 667 },
+  { width: 390, height: 844 },
+] as const;
+
+async function expectNoHorizontalScroll(page: Page) {
+  const geometry = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth);
+}
+
+async function expectInsideViewportHorizontally(page: Page, testId: string) {
+  const box = await page.getByTestId(testId).boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(
+    (await page.evaluate(() => window.innerWidth)) + 1
+  );
+}
+
+function boxesOverlap(
+  a: { x: number; y: number; width: number; height: number },
+  b: { x: number; y: number; width: number; height: number }
+) {
+  return (
+    a.x < b.x + b.width &&
+    b.x < a.x + a.width &&
+    a.y < b.y + b.height &&
+    b.y < a.y + a.height
+  );
+}
+
+test.beforeEach(async ({ context }) => {
+  await isolateGuestSessionIp(context);
+});
+
+for (const viewport of PHONE_VIEWPORTS) {
+  test(`join fields and action do not clip or overlap at ${viewport.width}x${viewport.height}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(viewport);
+    await page.goto('/join?code=ABCD', { waitUntil: 'domcontentloaded' });
+
+    const code = page.getByTestId(E2E_TEST_IDS.joinRoomCodeInput);
+    const name = page.getByTestId(E2E_TEST_IDS.joinNameInput);
+    const action = page.getByTestId(E2E_TEST_IDS.joinRoomButton);
+    await expect(code).toBeVisible();
+    await expect(name).toBeVisible();
+    await action.scrollIntoViewIfNeeded();
+    await expect(action).toBeInViewport();
+
+    await expectNoHorizontalScroll(page);
+    await expectInsideViewportHorizontally(
+      page,
+      E2E_TEST_IDS.joinRoomCodeInput
+    );
+    await expectInsideViewportHorizontally(page, E2E_TEST_IDS.joinNameInput);
+    await expectInsideViewportHorizontally(page, E2E_TEST_IDS.joinRoomButton);
+
+    const nameBox = await name.boundingBox();
+    const actionBox = await action.boundingBox();
+    expect(nameBox).not.toBeNull();
+    expect(actionBox).not.toBeNull();
+    expect(boxesOverlap(nameBox!, actionBox!)).toBe(false);
+
+    const controls = page.locator('header a:visible, header button:visible');
+    for (let index = 0; index < (await controls.count()); index += 1) {
+      const box = await controls.nth(index).boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.width).toBeGreaterThanOrEqual(44);
+      expect(box!.height).toBeGreaterThanOrEqual(44);
+    }
+
+    await page.locator('header a[href="/"]').evaluate((wordmark) => {
+      // Emulate a 200% text-only preference without doubling touch geometry.
+      wordmark.style.fontSize = '2.5rem';
+    });
+    await expectNoHorizontalScroll(page);
+  });
+}
+
+for (const width of [320, 390]) {
+  for (const entry of [
+    { route: '/join', focusedTestId: E2E_TEST_IDS.joinRoomCodeInput },
+    {
+      route: '/join?code=ABCD',
+      focusedTestId: E2E_TEST_IDS.joinNameInput,
+    },
+  ]) {
+    test(`join remains scroll-reachable at ${width}px after focusing ${entry.focusedTestId}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width, height: 360 });
+      await page.goto(entry.route, { waitUntil: 'domcontentloaded' });
+
+      const focusedInput = page.getByTestId(entry.focusedTestId);
+      const action = page.getByTestId(E2E_TEST_IDS.joinRoomButton);
+      await focusedInput.focus();
+      await action.scrollIntoViewIfNeeded();
+      await expect(action).toBeInViewport();
+
+      const [inputBox, actionBox] = await Promise.all([
+        focusedInput.boundingBox(),
+        action.boundingBox(),
+      ]);
+      expect(inputBox).not.toBeNull();
+      expect(actionBox).not.toBeNull();
+      expect(boxesOverlap(inputBox!, actionBox!)).toBe(false);
+      expect(actionBox!.y + actionBox!.height).toBeLessThanOrEqual(361);
+      await expectNoHorizontalScroll(page);
+    });
+  }
+}
+
+test('mobile sign-in presents the account task before the poem showcase', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  await page.goto('/sign-in', { waitUntil: 'domcontentloaded' });
+
+  const heading = page.getByRole('heading', { name: /welcome back/i });
+  await expect(heading).toBeVisible();
+  await expect(heading).toBeInViewport();
+  await expect(page.getByText('Recent Creation')).toBeHidden();
+  await expectNoHorizontalScroll(page);
+
+  const clerkInput = page.locator('input').first();
+  await expect(clerkInput).toBeVisible();
+  const fontSize = await clerkInput.evaluate((input) =>
+    Number.parseFloat(getComputedStyle(input).fontSize)
+  );
+  expect(fontSize).toBeGreaterThanOrEqual(16);
+
+  await expect(page.getByText(/don(?:'|’)t have an account/i)).toHaveCount(1);
+});
+
+for (const viewport of [
+  { width: 844, height: 390 },
+  { width: 667, height: 375 },
+]) {
+  test(`rotated phone keeps sign-in focused at ${viewport.width}x${viewport.height}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(viewport);
+    await page.goto('/sign-in', { waitUntil: 'domcontentloaded' });
+
+    const heading = page.getByRole('heading', { name: /welcome back/i });
+    await expect(heading).toBeVisible();
+    await expect(heading).toBeInViewport();
+    await expect(page.getByText('Recent Creation')).toBeHidden();
+    await expectNoHorizontalScroll(page);
+  });
+}
+
+test('mobile sign-up presents one focused account task', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  await page.goto('/sign-up', { waitUntil: 'domcontentloaded' });
+
+  const heading = page.getByRole('heading', { name: /join the jam/i });
+  await expect(heading).toBeVisible();
+  await expect(heading).toBeInViewport();
+  await expect(page.getByText('Recent Creation')).toBeHidden();
+  await expectNoHorizontalScroll(page);
+  await expect(page.getByText(/already have an account/i)).toHaveCount(1);
+});

--- a/tests/lib/clerk/appearance.test.ts
+++ b/tests/lib/clerk/appearance.test.ts
@@ -85,6 +85,7 @@ describe('resolveClerkThemeVariables', () => {
     const variables = resolveClerkThemeVariables();
 
     expect(variables.fontFamily).toBe('var(--font-sans)');
+    expect(variables.fontSize).toBe('1rem');
     expect(variables.borderRadius).toBe('var(--radius-md)');
   });
 });


### PR DESCRIPTION
## Summary
- keep Join fields and action inline, compact, focus-ordered, and horizontally bounded down to 320px
- make account entry the first mobile/landscape task, remove duplicate Clerk switch prompts, and prevent iOS input focus zoom
- consolidate secondary header actions into a 44px-target mobile overflow while preserving desktop shortcuts
- add unit and browser geometry coverage for portrait, rotation, reduced visual height, and text scaling

## Verification
- pnpm ci:prepush: 142 files passed; 1,597 tests passed; 1 existing skip
- focused mobile/auth tests: 13 passed
- containerized build succeeded; 40/41 E2E passed, with only the unrelated reveal-reader-leaver scheduler timeout red
- two independent fresh reviews completed; all actionable findings addressed

Powder: linejam-966