### PR TITLE
feat(ci): enforce safe schema migration sequencing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          # The schema sequencing guard compares HEAD with the PR merge base.
+          fetch-depth: 0
+
+      - name: Check schema migration sequencing
+        if: github.event_name == 'pull_request'
+        run: >-
+          node scripts/ci/check-schema-migration-sequencing.mjs
+          "origin/${{ github.event.pull_request.base.ref }}"
 
       - name: Set NEXT_PUBLIC_CONVEX_URL fallback
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,11 @@ jobs:
 
       - name: Check schema migration sequencing
         if: github.event_name == 'pull_request'
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: >-
           node scripts/ci/check-schema-migration-sequencing.mjs
-          "origin/${{ github.event.pull_request.base.ref }}"
+          "origin/$PR_BASE_REF"
 
       - name: Set NEXT_PUBLIC_CONVEX_URL fallback
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Compact router for repository agents. Read only the depth your lane needs.
 | CI and live-operation authority | `docs/ops/observability-ci.md`, `scripts/ci/dagger-call.sh`  |
 | Production operations           | `docs/deployment.md`                                         |
 | Convex environment contract     | `config/convex-env-manifest.json`                            |
+| Schema migration sequencing     | `docs/convex-migrations.md`                                  |
 | DigitalOcean topology contract  | `config/digitalocean-apps.json`, `pnpm ops:do-drift`         |
 | Agent CLI/MCP                   | `.agents/skills/linejam-cli/SKILL.md`, `docs/agent-faces.md` |
 

--- a/docs/convex-migrations.md
+++ b/docs/convex-migrations.md
@@ -46,7 +46,8 @@ failure shape without depending on historical Git objects.
 `scripts/ci/check-schema-migration-sequencing.mjs` compares a pull request with
 its base and blocks changes that both:
 
-- remove a Convex validator field from `convex/schema.ts`; and
+- remove a property from `convex/schema.ts`, including fields that use inline,
+  reusable, or multiline validators; and
 - add an exported Convex function to `convex/migrations.ts`.
 
 This is intentionally a conservative text-diff guard for the known outage

--- a/docs/convex-migrations.md
+++ b/docs/convex-migrations.md
@@ -1,0 +1,58 @@
+# Convex Schema Migrations
+
+Convex validates the declared schema against stored documents during a code
+push. A migration included in that push cannot repair documents that already
+violate a newly contracted schema: validation blocks the deployment before the
+migration becomes callable.
+
+Use expand, migrate, contract for every incompatible data-shape change.
+
+## Required sequence
+
+1. **Expand.** Make the schema accept both old and new shapes. Add new fields as
+   optional where necessary, and make application code tolerate both. Deploy.
+2. **Migrate.** Add an idempotent, bounded migration. Prove its logic with
+   `convex-test`, deploy it while the schema remains tolerant, then run it in
+   production under the authority rules in `docs/ops/observability-ci.md`.
+   Record examined and changed row counts and verify the postcondition.
+3. **Contract.** In a later PR and deployment, remove the retired fields and
+   compatibility paths. Only do this after production migration evidence
+   exists.
+
+The migration and the schema contraction must not share a PR. Expansion and a
+backfill may share a PR when the deployed application remains compatible with
+both shapes.
+
+## 2026-07-04 incident
+
+PR #298 introduced `dropLegacyModeColumns` while its schema diff removed
+`games.mode` and `rooms.selectedMode`. Convex rejected the contracted schema
+because production still contained 153 game documents and one room document
+with those fields. The rejected deployment also prevented the new migration
+from becoming callable, blocking unrelated production releases.
+
+Recovery required the full sequence that should have shipped originally:
+
+1. restore and deploy a schema that tolerated the legacy fields;
+2. deploy and run the migration, verifying 153 games and one room were cleared;
+3. deploy the strict schema only after the stored data was clean.
+
+The regression fixture in
+`tests/scripts/check-schema-migration-sequencing.test.ts` preserves this exact
+failure shape without depending on historical Git objects.
+
+## Automated guard
+
+`scripts/ci/check-schema-migration-sequencing.mjs` compares a pull request with
+its base and blocks changes that both:
+
+- remove a Convex validator field from `convex/schema.ts`; and
+- add an exported Convex function to `convex/migrations.ts`.
+
+This is intentionally a conservative text-diff guard for the known outage
+class, not a TypeScript schema parser. A false positive should be resolved by
+separating the migration and contraction, which is the safer release shape.
+The check fails closed if it cannot resolve or diff the base revision.
+
+If migrations move to multiple modules, update the guard and its regression
+tests in the same change.

--- a/scripts/ci/check-schema-migration-sequencing.mjs
+++ b/scripts/ci/check-schema-migration-sequencing.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const SCHEMA_FILE = 'convex/schema.ts';
+const MIGRATIONS_FILE = 'convex/migrations.ts';
+const FIELD_DEFINITION = /^[A-Za-z_$][\w$]*:\s*v\./;
+const MIGRATION_EXPORT =
+  /^export const [A-Za-z_$][\w$]*\s*=\s*(internalMutation|mutation|internalAction|action)\s*\(/;
+
+function changedLines(diff, marker) {
+  const header = marker.repeat(3);
+
+  return diff
+    .split('\n')
+    .filter((line) => line.startsWith(marker) && !line.startsWith(header))
+    .map((line) => line.slice(1).trim());
+}
+
+/**
+ * Detect a schema field removal shipped beside a newly exported migration.
+ * This deliberately conservative diff heuristic guards the exact failure
+ * class described in docs/convex-migrations.md.
+ */
+export function detectSchemaContractionWithMigration({
+  schemaDiff,
+  migrationsDiff,
+}) {
+  const removedFields = changedLines(schemaDiff, '-').filter((line) =>
+    FIELD_DEFINITION.test(line)
+  );
+  const addedMigrations = changedLines(migrationsDiff, '+').filter((line) =>
+    MIGRATION_EXPORT.test(line)
+  );
+
+  return {
+    violation: removedFields.length > 0 && addedMigrations.length > 0,
+    removedFields,
+    addedMigrations,
+  };
+}
+
+function defaultExecute(command, args) {
+  return execFileSync(command, args, { encoding: 'utf8' });
+}
+
+function diffAgainstBase(baseRef, file, execute) {
+  try {
+    return execute('git', ['diff', `${baseRef}...HEAD`, '--', file]);
+  } catch (error) {
+    const detail = error instanceof Error ? `: ${error.message}` : '';
+    throw new Error(`Unable to inspect ${file} against ${baseRef}${detail}`);
+  }
+}
+
+/** Compare the pull request head with its base, failing closed on Git errors. */
+export function checkSchemaMigrationSequencing({
+  baseRef,
+  execute = defaultExecute,
+}) {
+  const schemaDiff = diffAgainstBase(baseRef, SCHEMA_FILE, execute);
+  const migrationsDiff = diffAgainstBase(baseRef, MIGRATIONS_FILE, execute);
+
+  return detectSchemaContractionWithMigration({
+    schemaDiff,
+    migrationsDiff,
+  });
+}
+
+function printViolation(result) {
+  const removedFields = result.removedFields
+    .map((line) => `  - ${line}`)
+    .join('\n');
+  const addedMigrations = result.addedMigrations
+    .map((line) => `  - ${line}`)
+    .join('\n');
+
+  console.error(`BLOCKED: schema contraction and migration share one change.
+
+Convex validates existing data before the migration can run. Ship the
+migration first, run and verify it in production, then remove the fields in a
+later deploy.
+
+Removed schema fields:
+${removedFields}
+
+Added migrations:
+${addedMigrations}
+
+See docs/convex-migrations.md.`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const baseRef = process.argv[2];
+
+  if (!baseRef) {
+    console.error(
+      'Usage: check-schema-migration-sequencing.mjs <base-ref>\n' +
+        'Example: check-schema-migration-sequencing.mjs origin/master'
+    );
+    process.exit(2);
+  }
+
+  const result = checkSchemaMigrationSequencing({ baseRef });
+  if (result.violation) {
+    printViolation(result);
+    process.exit(1);
+  }
+
+  console.log('OK: no schema contraction ships with a new migration.');
+}

--- a/scripts/ci/check-schema-migration-sequencing.mjs
+++ b/scripts/ci/check-schema-migration-sequencing.mjs
@@ -6,7 +6,7 @@ const SCHEMA_FILE = 'convex/schema.ts';
 const MIGRATIONS_FILE = 'convex/migrations.ts';
 const FIELD_DEFINITION = /^[A-Za-z_$][\w$]*:\s*v\./;
 const MIGRATION_EXPORT =
-  /^export const [A-Za-z_$][\w$]*\s*=\s*(internalMutation|mutation|internalAction|action)\s*\(/;
+  /^\+\s*export const ([A-Za-z_$][\w$]*)\s*=\s*(?:(?:\r?\n)\+\s*)?(internalMutation|mutation|internalAction|action)\s*\(/gm;
 
 function changedLines(diff, marker) {
   const header = marker.repeat(3);
@@ -15,6 +15,13 @@ function changedLines(diff, marker) {
     .split('\n')
     .filter((line) => line.startsWith(marker) && !line.startsWith(header))
     .map((line) => line.slice(1).trim());
+}
+
+function addedMigrationExports(diff) {
+  return Array.from(
+    diff.matchAll(MIGRATION_EXPORT),
+    ([, name, kind]) => `export const ${name} = ${kind}(`
+  );
 }
 
 /**
@@ -29,9 +36,7 @@ export function detectSchemaContractionWithMigration({
   const removedFields = changedLines(schemaDiff, '-').filter((line) =>
     FIELD_DEFINITION.test(line)
   );
-  const addedMigrations = changedLines(migrationsDiff, '+').filter((line) =>
-    MIGRATION_EXPORT.test(line)
-  );
+  const addedMigrations = addedMigrationExports(migrationsDiff);
 
   return {
     violation: removedFields.length > 0 && addedMigrations.length > 0,

--- a/scripts/ci/check-schema-migration-sequencing.mjs
+++ b/scripts/ci/check-schema-migration-sequencing.mjs
@@ -4,7 +4,7 @@ import { pathToFileURL } from 'node:url';
 
 const SCHEMA_FILE = 'convex/schema.ts';
 const MIGRATIONS_FILE = 'convex/migrations.ts';
-const FIELD_DEFINITION = /^[A-Za-z_$][\w$]*:\s*v\./;
+const SCHEMA_PROPERTY = /^([A-Za-z_$][\w$]*)\s*:/;
 const MIGRATION_EXPORT =
   /^\+\s*export const ([A-Za-z_$][\w$]*)\s*=\s*(?:(?:\r?\n)\+\s*)?(internalMutation|mutation|internalAction|action)\s*\(/gm;
 
@@ -33,9 +33,9 @@ export function detectSchemaContractionWithMigration({
   schemaDiff,
   migrationsDiff,
 }) {
-  const removedFields = changedLines(schemaDiff, '-').filter((line) =>
-    FIELD_DEFINITION.test(line)
-  );
+  const removedFields = changedLines(schemaDiff, '-')
+    .map((line) => SCHEMA_PROPERTY.exec(line)?.[1])
+    .filter((field) => field !== undefined);
   const addedMigrations = addedMigrationExports(migrationsDiff);
 
   return {

--- a/tests/scripts/check-schema-migration-sequencing.test.ts
+++ b/tests/scripts/check-schema-migration-sequencing.test.ts
@@ -34,7 +34,26 @@ describe('detectSchemaContractionWithMigration', () => {
         'selectedMode: v.optional(v.string()),',
       ],
       addedMigrations: [
-        'export const dropLegacyModeColumns = internalMutation({',
+        'export const dropLegacyModeColumns = internalMutation(',
+      ],
+    });
+  });
+
+  it('blocks a migration export that Prettier wraps after the assignment', () => {
+    const wrappedMigrationDiff = `@@ -1,3 +1,8 @@
++export const dropLegacyModeColumnsWithAnIntentionallyLongName =
++  internalMutation({
++    args: {},`;
+
+    expect(
+      detectSchemaContractionWithMigration({
+        schemaDiff: incidentSchemaDiff,
+        migrationsDiff: wrappedMigrationDiff,
+      })
+    ).toMatchObject({
+      violation: true,
+      addedMigrations: [
+        'export const dropLegacyModeColumnsWithAnIntentionallyLongName = internalMutation(',
       ],
     });
   });

--- a/tests/scripts/check-schema-migration-sequencing.test.ts
+++ b/tests/scripts/check-schema-migration-sequencing.test.ts
@@ -29,10 +29,7 @@ describe('detectSchemaContractionWithMigration', () => {
       })
     ).toEqual({
       violation: true,
-      removedFields: [
-        'mode: v.optional(v.string()),',
-        'selectedMode: v.optional(v.string()),',
-      ],
+      removedFields: ['mode', 'selectedMode'],
       addedMigrations: [
         'export const dropLegacyModeColumns = internalMutation(',
       ],
@@ -55,6 +52,24 @@ describe('detectSchemaContractionWithMigration', () => {
       addedMigrations: [
         'export const dropLegacyModeColumnsWithAnIntentionallyLongName = internalMutation(',
       ],
+    });
+  });
+
+  it.each([
+    ['reusable validator', '-    legacyMode: legacyModeValidator,'],
+    [
+      'multiline validator',
+      '-    legacyMode:\n-      v.optional(v.union(v.literal("solo"), v.literal("group"))),',
+    ],
+  ])('blocks a removed %s field', (_name, schemaDiff) => {
+    expect(
+      detectSchemaContractionWithMigration({
+        schemaDiff,
+        migrationsDiff: incidentMigrationDiff,
+      })
+    ).toMatchObject({
+      violation: true,
+      removedFields: ['legacyMode'],
     });
   });
 

--- a/tests/scripts/check-schema-migration-sequencing.test.ts
+++ b/tests/scripts/check-schema-migration-sequencing.test.ts
@@ -1,0 +1,109 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi } from 'vitest';
+import {
+  checkSchemaMigrationSequencing,
+  detectSchemaContractionWithMigration,
+} from '@/scripts/ci/check-schema-migration-sequencing.mjs';
+
+const incidentSchemaDiff = `diff --git a/convex/schema.ts b/convex/schema.ts
+--- a/convex/schema.ts
++++ b/convex/schema.ts
+@@ -30,8 +30,6 @@
+-    mode: v.optional(v.string()),
+-    selectedMode: v.optional(v.string()),
+     currentRound: v.number(),`;
+
+const incidentMigrationDiff = `diff --git a/convex/migrations.ts b/convex/migrations.ts
+--- a/convex/migrations.ts
++++ b/convex/migrations.ts
+@@ -1,3 +1,8 @@
++export const dropLegacyModeColumns = internalMutation({
++  args: {},`;
+
+describe('detectSchemaContractionWithMigration', () => {
+  it('blocks the 2026-07-04 schema contraction and migration shape', () => {
+    expect(
+      detectSchemaContractionWithMigration({
+        schemaDiff: incidentSchemaDiff,
+        migrationsDiff: incidentMigrationDiff,
+      })
+    ).toEqual({
+      violation: true,
+      removedFields: [
+        'mode: v.optional(v.string()),',
+        'selectedMode: v.optional(v.string()),',
+      ],
+      addedMigrations: [
+        'export const dropLegacyModeColumns = internalMutation({',
+      ],
+    });
+  });
+
+  it('allows additive schema and migration changes', () => {
+    const schemaDiff = incidentSchemaDiff.replaceAll('-', '+');
+
+    expect(
+      detectSchemaContractionWithMigration({
+        schemaDiff,
+        migrationsDiff: incidentMigrationDiff,
+      }).violation
+    ).toBe(false);
+  });
+
+  it('allows a contraction after its migration has already shipped', () => {
+    expect(
+      detectSchemaContractionWithMigration({
+        schemaDiff: incidentSchemaDiff,
+        migrationsDiff: '',
+      }).violation
+    ).toBe(false);
+  });
+
+  it('ignores removed comments and syntax', () => {
+    expect(
+      detectSchemaContractionWithMigration({
+        schemaDiff: '-    // legacy field\n-  }),',
+        migrationsDiff: incidentMigrationDiff,
+      }).violation
+    ).toBe(false);
+  });
+});
+
+describe('checkSchemaMigrationSequencing', () => {
+  it('diffs both authoritative files against the PR merge base', () => {
+    const execute = vi
+      .fn<(command: string, args: string[]) => string>()
+      .mockReturnValueOnce(incidentSchemaDiff)
+      .mockReturnValueOnce(incidentMigrationDiff);
+
+    expect(
+      checkSchemaMigrationSequencing({ baseRef: 'origin/master', execute })
+        .violation
+    ).toBe(true);
+    expect(execute).toHaveBeenNthCalledWith(1, 'git', [
+      'diff',
+      'origin/master...HEAD',
+      '--',
+      'convex/schema.ts',
+    ]);
+    expect(execute).toHaveBeenNthCalledWith(2, 'git', [
+      'diff',
+      'origin/master...HEAD',
+      '--',
+      'convex/migrations.ts',
+    ]);
+  });
+
+  it('fails closed when the comparison cannot be evaluated', () => {
+    const execute = vi.fn(() => {
+      throw new Error('missing merge base');
+    });
+
+    expect(() =>
+      checkSchemaMigrationSequencing({
+        baseRef: 'origin/master',
+        execute,
+      })
+    ).toThrow(/Unable to inspect convex\/schema\.ts.*missing merge base/);
+  });
+});


### PR DESCRIPTION
## Summary
- document the required Convex expand-migrate-contract deployment sequence and the 2026-07-04 outage
- add a fail-closed CI guard for schema contractions shipped beside new migrations
- cover the historical failure shape with stable unit fixtures and route agents to the migration authority

## Verification
- `pnpm ci:prepush` (146 files; 1,626 passed, 1 skipped)
- `pnpm vitest run tests/scripts/check-schema-migration-sequencing.test.ts` (6 passed)
- exact `684de32` schema/migration diff detected as a violation
- `node scripts/ci/check-schema-migration-sequencing.mjs origin/master`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

Powder: linejam-914

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automated checks to prevent schema fields from being removed before corresponding data migrations are deployed.
  * Pull requests now provide clear validation results when migration sequencing is blocked or cannot be evaluated.

* **Documentation**
  * Added guidance on the Expand → Migrate → Contract process and documented related operational risks.

* **Tests**
  * Added coverage for valid, invalid, and unevaluable schema migration sequencing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->