### PR TITLE
test(canary): isolate responder tests from ambient env

### DIFF
--- a/tests/scripts/canary-context.test.ts
+++ b/tests/scripts/canary-context.test.ts
@@ -1,4 +1,5 @@
 /** @vitest-environment node */
+import './canary-test-env';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   fetchCanaryContext,

--- a/tests/scripts/canary-responder-http.test.ts
+++ b/tests/scripts/canary-responder-http.test.ts
@@ -1,4 +1,5 @@
 /** @vitest-environment node */
+import './canary-test-env';
 import { createHmac } from 'node:crypto';
 import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
 import os from 'node:os';

--- a/tests/scripts/canary-responder.test.ts
+++ b/tests/scripts/canary-responder.test.ts
@@ -1,4 +1,5 @@
 /** @vitest-environment node */
+import './canary-test-env';
 import { createHmac } from 'node:crypto';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {

--- a/tests/scripts/canary-setup-webhook.test.ts
+++ b/tests/scripts/canary-setup-webhook.test.ts
@@ -1,4 +1,5 @@
 /** @vitest-environment node */
+import { buildCanarySubprocessEnv } from './canary-test-env';
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { execFile } from 'node:child_process';
@@ -141,13 +142,12 @@ describe('canary setup webhook script', () => {
 
     const { stdout, stderr } = await execFileAsync(scriptPath, {
       cwd: process.cwd(),
-      env: {
-        ...process.env,
+      env: buildCanarySubprocessEnv({
         CANARY_ENDPOINT: stub.baseUrl,
         CANARY_API_KEY: 'canary-secret',
         LINEJAM_CANARY_WEBHOOK_URL:
           'https://linejam.example.com/canary/webhook',
-      },
+      }),
     });
 
     const result = JSON.parse(stdout) as {
@@ -173,13 +173,12 @@ describe('canary setup webhook script', () => {
       ['--emit-secret'],
       {
         cwd: process.cwd(),
-        env: {
-          ...process.env,
+        env: buildCanarySubprocessEnv({
           CANARY_ENDPOINT: stub.baseUrl,
           CANARY_API_KEY: 'canary-secret',
           LINEJAM_CANARY_WEBHOOK_URL:
             'https://linejam.example.com/canary/webhook',
-        },
+        }),
       }
     );
 
@@ -213,13 +212,12 @@ describe('canary setup webhook script', () => {
 
     const { stdout, stderr } = await execFileAsync(scriptPath, {
       cwd: process.cwd(),
-      env: {
-        ...process.env,
+      env: buildCanarySubprocessEnv({
         CANARY_ENDPOINT: stub.baseUrl,
         CANARY_API_KEY: 'canary-secret',
         LINEJAM_CANARY_WEBHOOK_URL:
           'https://linejam.example.com/canary/webhook',
-      },
+      }),
     });
 
     const result = JSON.parse(stdout) as {
@@ -257,13 +255,12 @@ describe('canary setup webhook script', () => {
 
     const { stdout } = await execFileAsync(scriptPath, {
       cwd: process.cwd(),
-      env: {
-        ...process.env,
+      env: buildCanarySubprocessEnv({
         CANARY_ENDPOINT: stub.baseUrl,
         CANARY_API_KEY: 'canary-secret',
         LINEJAM_CANARY_WEBHOOK_URL:
           'https://linejam.example.com/canary/webhook',
-      },
+      }),
     });
 
     const result = JSON.parse(stdout) as {
@@ -295,13 +292,12 @@ describe('canary setup webhook script', () => {
     await expect(
       execFileAsync(scriptPath, {
         cwd: process.cwd(),
-        env: {
-          ...process.env,
+        env: buildCanarySubprocessEnv({
           CANARY_ENDPOINT: stub.baseUrl,
           CANARY_API_KEY: 'canary-secret',
           LINEJAM_CANARY_WEBHOOK_URL:
             'https://linejam.example.com/canary/webhook',
-        },
+        }),
       })
     ).rejects.toThrow(/Canary API POST \/api\/v1\/webhooks returned 500/);
 
@@ -314,14 +310,13 @@ describe('canary setup webhook script', () => {
 
     const { stdout } = await execFileAsync(scriptPath, {
       cwd: process.cwd(),
-      env: {
-        ...process.env,
+      env: buildCanarySubprocessEnv({
         CANARY_ENDPOINT: stub.baseUrl,
         CANARY_API_KEY: 'canary-secret',
         LINEJAM_CANARY_WEBHOOK_URL:
           'https://linejam.example.com/canary/webhook',
         CANARY_WEBHOOK_SEND_TEST: '1',
-      },
+      }),
     });
 
     const result = JSON.parse(stdout) as {

--- a/tests/scripts/canary-smoke-auth.test.ts
+++ b/tests/scripts/canary-smoke-auth.test.ts
@@ -1,3 +1,4 @@
+import './canary-test-env';
 import { describe, expect, it } from 'vitest';
 
 import { getSmokeClerkKeyError } from '@/scripts/canary/smoke-auth.mjs';

--- a/tests/scripts/canary-store.test.ts
+++ b/tests/scripts/canary-store.test.ts
@@ -1,4 +1,5 @@
 /** @vitest-environment node */
+import './canary-test-env';
 import { mkdtemp, readFile, rm, utimes } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';

--- a/tests/scripts/canary-test-env.ts
+++ b/tests/scripts/canary-test-env.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach } from 'vitest';
+
+const CANARY_ENV_PREFIXES = [
+  'CANARY_',
+  'NEXT_PUBLIC_CANARY_',
+  'LINEJAM_CANARY_',
+];
+
+function isCanaryEnvKey(key: string) {
+  return CANARY_ENV_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+/** Remove ambient Canary configuration before each test and after cleanup. */
+export function scrubAmbientCanaryEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (isCanaryEnvKey(key)) {
+      delete process.env[key];
+    }
+  }
+
+  // The responder falls back to PORT, so an operator's shared dev port must
+  // not change the test server's binding either.
+  delete process.env.PORT;
+}
+
+/**
+ * Keep Canary tests isolated from operator shell configuration. The module
+ * side effect runs before sibling imports in each test file, while the hooks
+ * cover values written by individual tests.
+ */
+scrubAmbientCanaryEnv();
+beforeEach(scrubAmbientCanaryEnv);
+afterEach(scrubAmbientCanaryEnv);
+
+/**
+ * Build a minimal environment for Canary subprocess tests. Only runtime
+ * lookup paths are inherited; all Canary configuration must be explicit.
+ */
+export function buildCanarySubprocessEnv(
+  overrides: Record<string, string | undefined> = {}
+): NodeJS.ProcessEnv {
+  const env = {} as NodeJS.ProcessEnv;
+
+  for (const key of ['PATH', 'HOME', 'NODE_PATH', 'TMPDIR']) {
+    const value = process.env[key];
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+
+  return env;
+}

--- a/tests/scripts/canary-trigger-smoke.test.ts
+++ b/tests/scripts/canary-trigger-smoke.test.ts
@@ -1,4 +1,5 @@
 /** @vitest-environment node */
+import './canary-test-env';
 import { EventEmitter } from 'node:events';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';


### PR DESCRIPTION
## Summary
- add shared prefix-based Canary and PORT env scrubbing for every Canary script test
- use an allowlisted subprocess environment for setup-webhook tests
- keep readiness and context tests deterministic when operator shells have Canary configuration

Card: linejam-905

## Evidence
- `env CANARY_API_KEY=ambient CANARY_ENDPOINT=http://127.0.0.1:9 NEXT_PUBLIC_CANARY_API_KEY=ambient-public NEXT_PUBLIC_CANARY_ENDPOINT=http://127.0.0.1:9 LINEJAM_CANARY_WEBHOOK_SECRET=ambient-secret LINEJAM_CANARY_WEBHOOK_PATH=/ambient LINEJAM_CANARY_RESPONDER_PORT=8787 PORT=8788 CANARY_WEBHOOK_SEND_TEST=1 CANARY_WEBHOOK_EVENTS=not-json pnpm vitest run tests/scripts/canary-context.test.ts tests/scripts/canary-responder.test.ts tests/scripts/canary-responder-http.test.ts tests/scripts/canary-setup-webhook.test.ts tests/scripts/canary-smoke-auth.test.ts tests/scripts/canary-store.test.ts tests/scripts/canary-trigger-smoke.test.ts` — 7 files, 93 tests passed
- same ambient env with `pnpm ci:prepush` — 149 files, 1648 passed, 1 skipped; typecheck and lint passed
- `pnpm exec tsc --noEmit` passed
