### PR TITLE
feat(onboarding): add verified-live doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,14 @@ bash scripts/setup.sh --write-env --skip-install
 
 # Add your Convex, Clerk, guest-token, and Canary values to .env.local
 
+# Verify configuration before starting services (fails on missing or invalid values)
+pnpm run doctor
+
 # Run development servers (parallel)
 pnpm dev # Next.js :3000 + Convex backend
+
+# Verify the live app and health path once the dev server is running
+pnpm run doctor
 ```
 
 Keep `NEXT_PUBLIC_CONVEX_URL` pointed at the same backend you're running. For local development, use `http://localhost:8187`; if you target a remote Convex deployment, local Dagger now syncs the active Convex dev backend before auth-heavy E2E runs so frontend/backend validators stay aligned.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "pnpm": ">=10.0.0"
   },
   "scripts": {
+    "doctor": "node ./scripts/doctor.mjs",
     "preinstall": "npx only-allow pnpm",
     "dev": "npm-run-all --parallel dev:next dev:convex",
     "dev:next": "next dev --turbopack",

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -40,8 +40,8 @@ export function readDotEnv(filePath = path.join(process.cwd(), '.env.local')) {
   let contents;
   try { contents = readFileSync(filePath, 'utf8'); } catch { return {}; }
   const parsed = {};
-  for (const line of contents.split(/\\r?\\n/u)) {
-    const match = line.match(/^\\s*(?:export\\s+)?([A-Za-z_][A-Za-z0-9_]*)\\s*=\\s*(.*?)\\s*$/u);
+  for (const line of contents.split(/\r?\n/u)) {
+    const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/u);
     if (!match) continue;
     let parsedValue = match[2];
     if ((parsedValue.startsWith('"') && parsedValue.endsWith('"')) || (parsedValue.startsWith("'") && parsedValue.endsWith("'"))) parsedValue = parsedValue.slice(1, -1);

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -50,6 +50,7 @@ export function readDotEnv(filePath = path.join(process.cwd(), '.env.local')) {
   return parsed;
 }
 
+/** @param {{ env?: Env, envFile?: string }} [options] */
 export function loadEnvironment({ env = process.env, envFile } = {}) {
   return { ...readDotEnv(envFile), ...env };
 }

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_HEALTH_URL = 'http://localhost:3000/api/health';
+const REQUIRED_ENV = [
+  'GUEST_TOKEN_SECRET',
+  'NEXT_PUBLIC_CONVEX_URL',
+  'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
+  'CLERK_SECRET_KEY',
+  'NEXT_PUBLIC_CANARY_ENDPOINT',
+  'NEXT_PUBLIC_CANARY_API_KEY',
+];
+const PLACEHOLDER_CANARY_KEYS = new Set([
+  'example_canary_server_key',
+  'example_canary_write_key',
+]);
+
+/** @typedef {{ name: string, status: 'pass'|'warn'|'fail'|'skip', message: string }} CheckResult */
+/** @typedef {Record<string, string | undefined>} Env */
+
+function value(env, name) {
+  return typeof env[name] === 'string' ? env[name].trim() : '';
+}
+
+function configuredUrl(raw, name, acceptedHost) {
+  if (!raw) return { status: 'fail', name, message: name + ' is not set' };
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') throw new Error('protocol');
+    if (!acceptedHost(url.hostname)) throw new Error('host');
+    return { status: 'pass', name, message: 'configured ' + url.origin };
+  } catch {
+    return { status: 'fail', name, message: name + ' must be a valid configured URL' };
+  }
+}
+
+export function readDotEnv(filePath = path.join(process.cwd(), '.env.local')) {
+  let contents;
+  try { contents = readFileSync(filePath, 'utf8'); } catch { return {}; }
+  const parsed = {};
+  for (const line of contents.split(/\\r?\\n/u)) {
+    const match = line.match(/^\\s*(?:export\\s+)?([A-Za-z_][A-Za-z0-9_]*)\\s*=\\s*(.*?)\\s*$/u);
+    if (!match) continue;
+    let parsedValue = match[2];
+    if ((parsedValue.startsWith('"') && parsedValue.endsWith('"')) || (parsedValue.startsWith("'") && parsedValue.endsWith("'"))) parsedValue = parsedValue.slice(1, -1);
+    parsed[match[1]] = parsedValue;
+  }
+  return parsed;
+}
+
+export function loadEnvironment({ env = process.env, envFile } = {}) {
+  return { ...readDotEnv(envFile), ...env };
+}
+
+/** @param {Env} [env] */
+export function checkRequiredEnv(env = process.env) {
+  const missing = REQUIRED_ENV.filter((name) => !value(env, name));
+  return missing.length === 0
+    ? { status: 'pass', message: 'all required values present' }
+    : { status: 'fail', message: 'missing required values: ' + missing.join(', ') };
+}
+
+/** @param {Env} [env] */
+export function checkConvexConfig(env = process.env) {
+  return configuredUrl(
+    value(env, 'NEXT_PUBLIC_CONVEX_URL'),
+    'Convex',
+    (hostname) => hostname === 'localhost' || hostname === '127.0.0.1' || hostname.endsWith('.convex.cloud')
+  );
+}
+
+function clerkOrigin(publishableKey) {
+  if (!/^pk_(?:test|live)_/u.test(publishableKey)) return null;
+  const encoded = publishableKey.split('_').at(-1);
+  if (!encoded) return null;
+  try {
+    const decoded = Buffer.from(encoded, 'base64url').toString('utf8').replace(/\$+$/u, '');
+    const url = new URL(decoded.startsWith('http') ? decoded : 'https://' + decoded);
+    if (url.protocol !== 'https:' || !url.hostname.includes('.')) return null;
+    return url.origin;
+  } catch { return null; }
+}
+
+/** @param {Env} [env] */
+export function checkClerkConfig(env = process.env) {
+  const publishableKey = value(env, 'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY');
+  const secretKey = value(env, 'CLERK_SECRET_KEY');
+  if (!publishableKey || !secretKey) {
+    const missing = [!publishableKey && 'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY', !secretKey && 'CLERK_SECRET_KEY'].filter(Boolean);
+    return { status: 'fail', message: 'missing Clerk values: ' + missing.join(', ') };
+  }
+  if (!/^sk_(?:test|live)_/u.test(secretKey)) return { status: 'fail', message: 'CLERK_SECRET_KEY has an invalid format' };
+  const origin = clerkOrigin(publishableKey);
+  return origin
+    ? { status: 'pass', message: 'configured ' + origin }
+    : { status: 'fail', message: 'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY does not identify a Clerk Frontend API' };
+}
+
+/** @param {Env} [env] */
+export function checkCanaryConfig(env = process.env) {
+  const endpoint = configuredUrl(value(env, 'NEXT_PUBLIC_CANARY_ENDPOINT'), 'Canary', (hostname) => hostname.length > 0);
+  if (endpoint.status === 'fail') return endpoint;
+  const apiKey = value(env, 'NEXT_PUBLIC_CANARY_API_KEY');
+  if (!apiKey) return { status: 'fail', name: 'Canary', message: 'NEXT_PUBLIC_CANARY_API_KEY is not set' };
+  if (PLACEHOLDER_CANARY_KEYS.has(apiKey)) return { status: 'fail', name: 'Canary', message: 'NEXT_PUBLIC_CANARY_API_KEY is still the .env.example placeholder' };
+  return endpoint;
+}
+
+function timeoutSignal(timeoutMs) {
+  return typeof AbortSignal.timeout === 'function' ? AbortSignal.timeout(timeoutMs) : undefined;
+}
+
+/** @param {{ url?: string, fetchImpl?: typeof fetch, timeoutMs?: number }} [options] */
+export async function checkCanaryReachable({ url, fetchImpl = globalThis.fetch, timeoutMs = 3_000 } = {}) {
+  if (!url) return { name: 'Canary reachability', status: 'skip', message: 'no endpoint configured' };
+  const statusUrl = new URL('/api/v1/status', url).toString();
+  try {
+    const response = await fetchImpl(statusUrl, { headers: { accept: 'application/json' }, signal: timeoutSignal(timeoutMs) });
+    return response.ok
+      ? { name: 'Canary reachability', status: 'pass', message: 'reachable' }
+      : { name: 'Canary reachability', status: 'warn', message: 'HTTP ' + response.status + ' from configured endpoint' };
+  } catch { return { name: 'Canary reachability', status: 'warn', message: 'configured endpoint is unreachable' }; }
+}
+
+/** @param {{ url?: string, fetchImpl?: typeof fetch, timeoutMs?: number }} [options] */
+export async function checkAppHealth({ url = DEFAULT_HEALTH_URL, fetchImpl = globalThis.fetch, timeoutMs = 3_000 } = {}) {
+  let response;
+  try {
+    response = await fetchImpl(url, { headers: { accept: 'application/json' }, signal: timeoutSignal(timeoutMs) });
+  } catch {
+    return { name: 'app health', status: 'warn', message: 'no app response at ' + url + ' (start pnpm dev and run pnpm run doctor again)' };
+  }
+  if (!response.ok) return { name: 'app health', status: 'fail', message: 'HTTP ' + response.status + ' from ' + url };
+  let body;
+  try { body = await response.json(); } catch { return { name: 'app health', status: 'fail', message: 'app health response was not valid JSON' }; }
+  return body?.status === 'ok'
+    ? { name: 'app health', status: 'pass', message: 'healthy at ' + url }
+    : { name: 'app health', status: 'fail', message: 'app health reported status ' + String(body?.status ?? 'missing') };
+}
+
+/** @param {{ env?: Env, fetchImpl?: typeof fetch, healthUrl?: string }} [options] */
+export async function runDoctor({ env = loadEnvironment(), fetchImpl = globalThis.fetch, healthUrl = value(env, 'LINEJAM_DOCTOR_HEALTH_URL') || DEFAULT_HEALTH_URL } = {}) {
+  const canary = checkCanaryConfig(env);
+  const results = [
+    { name: 'required env', ...checkRequiredEnv(env) },
+    { name: 'Convex', ...checkConvexConfig(env) },
+    { name: 'Clerk', ...checkClerkConfig(env) },
+    canary,
+  ];
+  if (canary.status === 'pass') results.push(await checkCanaryReachable({ url: value(env, 'NEXT_PUBLIC_CANARY_ENDPOINT'), fetchImpl }));
+  results.push(await checkAppHealth({ url: healthUrl, fetchImpl }));
+  return results;
+}
+
+async function main() {
+  const results = await runDoctor();
+  const icons = { pass: '✔', warn: '⚠', fail: '✖', skip: '·' };
+  for (const result of results) console.log(icons[result.status] + ' ' + result.name + ': ' + result.message);
+  const failures = results.filter((result) => result.status === 'fail');
+  if (failures.length > 0) {
+    console.error('\ndoctor failed ' + failures.length + ' check(s). Fix the reported configuration and run pnpm run doctor again.');
+    process.exitCode = 1;
+    return;
+  }
+  const warnings = results.filter((result) => result.status === 'warn');
+  console.log(warnings.length > 0 ? '\ndoctor passed with ' + warnings.length + ' warning(s).' : '\ndoctor: all checks green.');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error('doctor failed: ' + (error instanceof Error ? error.message : String(error)));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -95,3 +95,4 @@ else
 fi
 
 printf 'setup complete\n'
+printf 'next: fill in %s, then run pnpm run doctor to verify the workspace is configured and live\n' "$ENV_LOCAL"

--- a/tests/scripts/doctor.test.ts
+++ b/tests/scripts/doctor.test.ts
@@ -1,4 +1,6 @@
 /** @vitest-environment node */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
   checkAppHealth,
@@ -7,6 +9,8 @@ import {
   checkClerkConfig,
   checkConvexConfig,
   checkRequiredEnv,
+  loadEnvironment,
+  readDotEnv,
   runDoctor,
 } from '@/scripts/doctor.mjs';
 
@@ -132,6 +136,179 @@ describe('network probes', () => {
     expect(result.status).toBe('pass');
     expect(fetchImpl).toHaveBeenCalledWith(
       'http://localhost:3000/api/health',
+      expect.any(Object)
+    );
+  });
+});
+
+describe('environment loading', () => {
+  it('parses dotenv assignments, exports, quotes, and ignores malformed lines', () => {
+    const directory = mkdtempSync('/tmp/linejam-doctor-');
+    const filePath = path.join(directory, '.env.local');
+    writeFileSync(
+      filePath,
+      `# comment
+export FOO = "quoted value"
+BAR=plain
+INVALID
+SINGLE='single value'
+`
+    );
+
+    expect(readDotEnv(filePath)).toEqual({
+      FOO: 'quoted value',
+      BAR: 'plain',
+      SINGLE: 'single value',
+    });
+    expect(
+      loadEnvironment({
+        env: { FOO: 'override', EXTRA: 'yes' },
+        envFile: filePath,
+      })
+    ).toMatchObject({
+      FOO: 'override',
+      BAR: 'plain',
+      EXTRA: 'yes',
+    });
+    expect(readDotEnv(path.join(directory, 'missing'))).toEqual({});
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it('uses process environment when no options are provided', () => {
+    expect(loadEnvironment()).toEqual(expect.any(Object));
+    expect(readDotEnv()).toEqual(expect.any(Object));
+  });
+});
+
+describe('additional doctor failure paths', () => {
+  it('rejects unsupported Convex protocols and malformed Clerk secrets', () => {
+    expect(
+      checkConvexConfig({ NEXT_PUBLIC_CONVEX_URL: 'ftp://localhost' }).status
+    ).toBe('fail');
+    expect(
+      checkClerkConfig({
+        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
+          GOOD_ENV.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+        CLERK_SECRET_KEY: 'not-a-secret',
+      })
+    ).toEqual({
+      status: 'fail',
+      message: 'CLERK_SECRET_KEY has an invalid format',
+    });
+  });
+
+  it('rejects Clerk keys with empty, insecure, or hostless origins', () => {
+    expect(
+      checkClerkConfig({
+        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: 'pk_test_',
+        CLERK_SECRET_KEY: 'sk_test_something',
+      }).status
+    ).toBe('fail');
+    expect(
+      checkClerkConfig({
+        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: clerkKeyFor(
+          'http://great-moose.example'
+        ),
+        CLERK_SECRET_KEY: 'sk_test_something',
+      }).status
+    ).toBe('fail');
+    expect(
+      checkClerkConfig({
+        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: clerkKeyFor('localhost'),
+        CLERK_SECRET_KEY: 'sk_test_something',
+      }).status
+    ).toBe('fail');
+  });
+
+  it('requires a Canary key after validating its endpoint', () => {
+    expect(
+      checkCanaryConfig({
+        NEXT_PUBLIC_CANARY_ENDPOINT: 'https://canary.example.test',
+      })
+    ).toEqual({
+      status: 'fail',
+      name: 'Canary',
+      message: 'NEXT_PUBLIC_CANARY_API_KEY is not set',
+    });
+    expect(
+      checkCanaryConfig({
+        NEXT_PUBLIC_CANARY_ENDPOINT: 'not-a-url',
+        NEXT_PUBLIC_CANARY_API_KEY: 'real-key',
+      }).status
+    ).toBe('fail');
+  });
+});
+
+describe('network probe edge cases', () => {
+  it('skips an unconfigured Canary and warns on HTTP failures', async () => {
+    expect(await checkCanaryReachable()).toEqual({
+      name: 'Canary reachability',
+      status: 'skip',
+      message: 'no endpoint configured',
+    });
+    expect(
+      (
+        await checkCanaryReachable({
+          url: 'https://canary.example.test',
+          fetchImpl: vi.fn().mockResolvedValue({ ok: false, status: 503 }),
+        })
+      ).status
+    ).toBe('warn');
+  });
+
+  it('warns on an unavailable app and fails on invalid health JSON', async () => {
+    expect(
+      (
+        await checkAppHealth({
+          fetchImpl: vi.fn().mockRejectedValue(new Error('offline')),
+        })
+      ).status
+    ).toBe('warn');
+    expect(
+      (
+        await checkAppHealth({
+          fetchImpl: vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => {
+              throw new Error('bad json');
+            },
+          }),
+        })
+      ).status
+    ).toBe('fail');
+    expect(
+      (
+        await checkAppHealth({
+          url: 'http://localhost:3000/custom-health',
+          fetchImpl: vi
+            .fn()
+            .mockResolvedValue({ ok: true, json: async () => ({}) }),
+        })
+      ).message
+    ).toContain('missing');
+  });
+});
+
+describe('runDoctor configuration branches', () => {
+  it('does not probe Canary when its configuration fails and honors a custom health URL', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('app offline'));
+    const results = await runDoctor({
+      env: {
+        ...GOOD_ENV,
+        NEXT_PUBLIC_CANARY_API_KEY: '',
+        LINEJAM_DOCTOR_HEALTH_URL: 'http://127.0.0.1:9999/health',
+      },
+      fetchImpl,
+    });
+    expect(results.map((result) => result.name)).toEqual([
+      'required env',
+      'Convex',
+      'Clerk',
+      'Canary',
+      'app health',
+    ]);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://127.0.0.1:9999/health',
       expect.any(Object)
     );
   });

--- a/tests/scripts/doctor.test.ts
+++ b/tests/scripts/doctor.test.ts
@@ -1,0 +1,158 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi } from 'vitest';
+import {
+  checkAppHealth,
+  checkCanaryConfig,
+  checkCanaryReachable,
+  checkClerkConfig,
+  checkConvexConfig,
+  checkRequiredEnv,
+  runDoctor,
+} from '@/scripts/doctor.mjs';
+
+function clerkKeyFor(host: string): string {
+  return 'pk_test_' + Buffer.from(host + '$').toString('base64url');
+}
+
+const GOOD_ENV = {
+  GUEST_TOKEN_SECRET: 'x'.repeat(32),
+  NEXT_PUBLIC_CONVEX_URL: 'https://exuberant-bloodhound-885.convex.cloud',
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: clerkKeyFor(
+    'great-moose-1.clerk.accounts.dev'
+  ),
+  CLERK_SECRET_KEY: 'sk_test_something',
+  NEXT_PUBLIC_CANARY_ENDPOINT: 'https://canary.example.test',
+  NEXT_PUBLIC_CANARY_API_KEY: 'real-key',
+};
+
+describe('checkRequiredEnv', () => {
+  it('passes with the onboarding env contract', () => {
+    expect(checkRequiredEnv(GOOD_ENV)).toEqual({
+      status: 'pass',
+      message: 'all required values present',
+    });
+  });
+
+  it('fails loudly and names missing values without exposing secrets', () => {
+    const result = checkRequiredEnv({});
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('GUEST_TOKEN_SECRET');
+    expect(result.message).toContain('CLERK_SECRET_KEY');
+    expect(result.message).not.toContain('x'.repeat(32));
+  });
+});
+
+describe('checkConvexConfig', () => {
+  it('accepts a remote deployment URL', () => {
+    expect(checkConvexConfig(GOOD_ENV).status).toBe('pass');
+  });
+
+  it('accepts the local Convex dev URL', () => {
+    expect(
+      checkConvexConfig({ NEXT_PUBLIC_CONVEX_URL: 'http://localhost:8187' })
+        .status
+    ).toBe('pass');
+  });
+
+  it('rejects malformed or unrelated URLs', () => {
+    expect(
+      checkConvexConfig({ NEXT_PUBLIC_CONVEX_URL: 'not a url' }).status
+    ).toBe('fail');
+    expect(
+      checkConvexConfig({ NEXT_PUBLIC_CONVEX_URL: 'https://example.test' })
+        .status
+    ).toBe('fail');
+  });
+});
+
+describe('checkClerkConfig', () => {
+  it('validates the publishable key and reports only its derived origin', () => {
+    const result = checkClerkConfig(GOOD_ENV);
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('great-moose-1.clerk.accounts.dev');
+    expect(result.message).not.toContain('sk_test_something');
+  });
+
+  it('rejects missing or malformed authentication keys', () => {
+    expect(checkClerkConfig({}).status).toBe('fail');
+    expect(
+      checkClerkConfig({
+        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: 'not-a-key',
+        CLERK_SECRET_KEY: 'sk_test_something',
+      }).status
+    ).toBe('fail');
+  });
+});
+
+describe('checkCanaryConfig', () => {
+  it('rejects the public placeholder key', () => {
+    expect(
+      checkCanaryConfig({
+        NEXT_PUBLIC_CANARY_ENDPOINT: 'https://canary.example.test',
+        NEXT_PUBLIC_CANARY_API_KEY: 'example_canary_write_key',
+      }).status
+    ).toBe('fail');
+  });
+
+  it('requires a valid endpoint and non-placeholder key', () => {
+    expect(checkCanaryConfig(GOOD_ENV).status).toBe('pass');
+    expect(
+      checkCanaryConfig({ NEXT_PUBLIC_CANARY_API_KEY: 'real-key' }).status
+    ).toBe('fail');
+  });
+});
+
+describe('network probes', () => {
+  it('warns when Canary is unreachable', async () => {
+    const result = await checkCanaryReachable({
+      url: 'https://canary.example.test',
+      fetchImpl: vi.fn().mockRejectedValue(new Error('fetch failed')),
+    });
+    expect(result.status).toBe('warn');
+  });
+
+  it('fails when the running app health route is unhealthy', async () => {
+    const result = await checkAppHealth({
+      fetchImpl: vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({ status: 'unhealthy' }),
+      }),
+    });
+    expect(result.status).toBe('fail');
+  });
+
+  it('uses the local dev health path and passes healthy responses', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok' }),
+    });
+    const result = await checkAppHealth({ fetchImpl });
+    expect(result.status).toBe('pass');
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://localhost:3000/api/health',
+      expect.any(Object)
+    );
+  });
+});
+
+describe('runDoctor', () => {
+  it('runs config and live probes without leaking values', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: 'ok' }),
+    });
+    const results = await runDoctor({ env: GOOD_ENV, fetchImpl });
+    expect(results.map((result) => result.name)).toEqual([
+      'required env',
+      'Convex',
+      'Clerk',
+      'Canary',
+      'Canary reachability',
+      'app health',
+    ]);
+    expect(results.every((result) => result.status === 'pass')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `pnpm run doctor` to validate required guest, Convex, Clerk, and Canary configuration without printing secret values
- probe Canary reachability and local `/api/health`, failing unhealthy responses while warning when services are not running yet
- document pre/post-dev onboarding and point setup completion at the doctor

## Card
linejam-909

## Evidence
- `pnpm exec vitest run tests/scripts/doctor.test.ts` (13 passed)
- `pnpm exec vitest run tests/scripts/setup.test.ts` (4 passed)
- `bash -n scripts/setup.sh`
- missing-env smoke: nonzero with named missing checks
- configured smoke: exit 0 with one expected Canary reachability warning
- pre-push hook: typecheck, lint, and 150 test files (1661 passed, 1 skipped) green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration “doctor” command to validate environment settings and service health.
  * Added checks for required credentials, service connectivity, and application health with clear status results.
  * Setup instructions now guide you to run configuration verification after setup.

* **Documentation**
  * Updated Getting Started instructions to run configuration checks before and after starting development servers.

* **Tests**
  * Added coverage for configuration parsing, validation, service checks, and safe diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->