### PR TITLE
feat(reveal): present whole poems in ordered accessible ceremony

### DIFF
--- a/components/PoemDisplay.tsx
+++ b/components/PoemDisplay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Download, Heart, Volume2, VolumeX } from 'lucide-react';
 import { Button } from './ui/Button';
@@ -19,23 +19,13 @@ import { getUserColor, getUniqueColor } from '@/lib/avatarColor';
  *
  * Design:
  * - Author dots in left gutter (tap to reveal name)
- * - Wipe-reveal animation with rhythmic pacing
+ * - Whole-poem presentation with a deliberate reading order
  * - Poem identity: date + first line preview + contributor dots
  *
  * Variants:
  * - 'reveal': Full-screen overlay for post-game reveal (default)
  * - 'archive': Regular page flow for archive viewing
  */
-
-const REVEAL_DELAYS_MS = [560, 680, 800, 940, 1120, 900, 720, 520, 360];
-
-function getRevealDelay(lineIndex: number, totalLines: number) {
-  if (totalLines <= 1) return REVEAL_DELAYS_MS[0];
-  const shapeIndex = Math.round(
-    (lineIndex / Math.max(totalLines - 1, 1)) * (REVEAL_DELAYS_MS.length - 1)
-  );
-  return REVEAL_DELAYS_MS[shapeIndex] ?? REVEAL_DELAYS_MS.at(-1)!;
-}
 
 export interface PoemLine {
   text: string;
@@ -54,6 +44,8 @@ export interface PoemMetadata {
   backHref?: string;
   backLabel?: string;
   uniquePoets?: number;
+  readerName?: string;
+  poemNumber?: number;
 }
 
 interface PoemDisplayProps {
@@ -77,15 +69,12 @@ export function PoemDisplay({
   guestToken,
   lines,
   onDone,
-  alreadyRevealed = false,
   allStableIds,
   variant = 'reveal',
   metadata,
 }: PoemDisplayProps) {
   const isArchive = variant === 'archive';
 
-  // Archive variant is always fully revealed
-  const effectiveAlreadyRevealed = isArchive ? true : alreadyRevealed;
   const normalizedLines: PoemLine[] = lines.map((line) =>
     typeof line === 'string' ? { text: line } : line
   );
@@ -95,12 +84,16 @@ export function PoemDisplay({
   // x — no line's number or author dot can nudge the text that follows it.
   const lineNumberGutterWidth = `${String(normalizedLines.length).length + 1}ch`;
   const lineGridTemplate = `${lineNumberGutterWidth} 2.75rem 1fr`;
-  const { isMuted, prefersReducedMotion, punctuate, toggleMuted } =
-    useCeremonyEffects();
-
-  const [revealedCount, setRevealedCount] = useState(
-    effectiveAlreadyRevealed || prefersReducedMotion ? lines.length : 0
-  );
+  const { isMuted, toggleMuted } = useCeremonyEffects();
+  const poemHeadingRef = useRef<HTMLHeadingElement>(null);
+  const announcement = isArchive
+    ? ''
+    : metadata?.readerName && metadata.poemNumber
+      ? metadata.readerName +
+        ', poem ' +
+        metadata.poemNumber +
+        ' is ready. Read from line one.'
+      : 'Poem revealed. Read from line one.';
   const [selectedLine, setSelectedLine] = useState<number | null>(null);
   const { handleShare, copied, shared, shareError } = useSharePoem(
     poemId,
@@ -128,35 +121,12 @@ export function PoemDisplay({
       }));
   }, [normalizedLines]);
 
-  // Staggered reveal follows the 1,2,3,4,5,4,3,2,1 poem shape, then
-  // accelerates into the final one-word line.
+  // The ceremony presents each poem as one composition. Focus the reading
+  // target and announce only the transition, never the poem text itself.
   useEffect(() => {
-    if (effectiveAlreadyRevealed || prefersReducedMotion) {
-      if (revealedCount < lines.length) {
-        const timer = setTimeout(() => {
-          setRevealedCount(lines.length);
-        }, 0);
-        return () => clearTimeout(timer);
-      }
-      return;
-    }
-
-    if (revealedCount < lines.length) {
-      const delay = getRevealDelay(revealedCount, lines.length);
-      const timer = setTimeout(() => {
-        const nextCount = revealedCount + 1;
-        punctuate(nextCount >= lines.length ? 'final-line' : 'line');
-        setRevealedCount(nextCount);
-      }, delay);
-      return () => clearTimeout(timer);
-    }
-  }, [
-    revealedCount,
-    lines.length,
-    effectiveAlreadyRevealed,
-    prefersReducedMotion,
-    punctuate,
-  ]);
+    if (isArchive) return;
+    poemHeadingRef.current?.focus();
+  }, [isArchive, poemId]);
 
   // Clear selected line after 2s
   useEffect(() => {
@@ -166,7 +136,6 @@ export function PoemDisplay({
     }
   }, [selectedLine]);
 
-  const allRevealed = revealedCount >= lines.length;
   const shareStatus = shared
     ? 'Poem shared.'
     : copied
@@ -182,7 +151,7 @@ export function PoemDisplay({
     <button
       type="button"
       onClick={toggleMuted}
-      className="inline-flex h-9 items-center gap-2 rounded-full border border-border-subtle bg-background/80 px-3 text-xs font-mono uppercase tracking-wider text-text-muted backdrop-blur-sm transition-colors hover:border-primary hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring"
+      className="inline-flex h-11 min-w-11 items-center gap-2 rounded-full border border-border-subtle bg-background/80 px-3 text-xs font-mono uppercase tracking-wider text-text-muted backdrop-blur-sm transition-colors hover:border-primary hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring"
       aria-label={isMuted ? 'Turn ceremony sound on' : 'Mute ceremony sound'}
       title={isMuted ? 'Turn ceremony sound on' : 'Mute ceremony'}
     >
@@ -204,7 +173,30 @@ export function PoemDisplay({
       )}
 
       {/* Poem Content */}
-      <div className="lj-safe-inline mx-auto w-full max-w-3xl flex-1 pt-[max(3rem,env(safe-area-inset-top))] pb-[max(3rem,env(safe-area-inset-bottom))] md:[--lj-safe-inline-space:3rem] md:py-16 lg:[--lj-safe-inline-space:6rem] lg:py-24">
+      <div
+        className="lj-safe-inline mx-auto w-full max-w-3xl flex-1 pt-[max(3rem,env(safe-area-inset-top))] pb-[max(3rem,env(safe-area-inset-bottom))] md:[--lj-safe-inline-space:3rem] md:py-16 lg:[--lj-safe-inline-space:6rem] lg:py-24"
+        aria-labelledby={!isArchive ? 'poem-display-title' : undefined}
+      >
+        {!isArchive && (
+          <>
+            <h1
+              id="poem-display-title"
+              ref={poemHeadingRef}
+              tabIndex={-1}
+              className="sr-only"
+            >
+              Poem ready to read
+            </h1>
+            <p
+              role="status"
+              aria-live="polite"
+              aria-label={announcement}
+              className="sr-only"
+            >
+              {announcement}
+            </p>
+          </>
+        )}
         {/* Header: Poem Identity + Controls */}
         {metadata && (
           <header className="mb-12">
@@ -240,7 +232,7 @@ export function PoemDisplay({
                   <button
                     onClick={metadata.onToggleFavorite}
                     className={cn(
-                      'print:hidden transition-colors',
+                      'print:hidden inline-flex min-h-11 min-w-11 items-center justify-center transition-colors',
                       metadata.isFavorited
                         ? 'text-[var(--color-primary)]'
                         : 'text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]'
@@ -297,15 +289,7 @@ export function PoemDisplay({
         {/* The Poem - Grid with dot gutter */}
         <div className="space-y-6">
           {normalizedLines.map((line, index) => {
-            const isVisible = index < revealedCount;
             const isSelected = selectedLine === index;
-            const isFinalLine = index === normalizedLines.length - 1;
-            const revealAnimation =
-              isVisible && !prefersReducedMotion
-                ? isFinalLine
-                  ? 'wipe-reveal 800ms ease-out forwards, final-line-settle 700ms cubic-bezier(0.22, 1, 0.36, 1) forwards'
-                  : 'wipe-reveal 800ms ease-out forwards'
-                : 'none';
             const dotColor = line.authorStableId
               ? allStableIds
                 ? getUniqueColor(line.authorStableId, allStableIds)
@@ -331,13 +315,12 @@ export function PoemDisplay({
                   {/* Author Dot (Hanko) — 8px ink mark inside a 44px tap target */}
                   <button
                     type="button"
-                    tabIndex={isVisible ? 0 : -1}
-                    disabled={!isVisible}
+                    tabIndex={0}
                     className={cn(
                       'flex h-11 w-11 items-center justify-center rounded-full',
                       '-ml-1.5 cursor-pointer transition-opacity',
                       'focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring',
-                      isVisible ? 'opacity-100' : 'opacity-0'
+                      'opacity-100'
                     )}
                     onClick={() => setSelectedLine(index)}
                     title={line.authorName}
@@ -355,16 +338,8 @@ export function PoemDisplay({
                       className={cn(
                         'font-[var(--font-display)] leading-relaxed',
                         'text-lg md:text-xl lg:text-2xl',
-                        'text-text-primary',
-                        isVisible &&
-                          isFinalLine &&
-                          !prefersReducedMotion &&
-                          'animate-final-line-settle'
+                        'text-text-primary'
                       )}
-                      style={{
-                        animation: revealAnimation,
-                        clipPath: isVisible ? undefined : 'inset(0 100% 0 0)',
-                      }}
                     >
                       {line.text}
                     </p>
@@ -379,9 +354,7 @@ export function PoemDisplay({
                           'absolute top-full left-0 text-sm italic',
                           'transition-opacity duration-500',
                           line.isBot ? 'text-primary' : 'text-text-muted',
-                          isSelected || (line.isBot && isVisible)
-                            ? 'opacity-100'
-                            : 'opacity-0'
+                          isSelected || line.isBot ? 'opacity-100' : 'opacity-0'
                         )}
                       >
                         {line.isBot ? '✦ ' : '— '}
@@ -403,8 +376,7 @@ export function PoemDisplay({
         className={cn(
           'print:hidden px-space-3 pt-space-3 pb-[max(var(--space-3),env(safe-area-inset-bottom))] md:px-space-5 lg:px-space-6 border-t border-border-subtle',
           'flex flex-col items-center gap-space-3',
-          'transition-opacity duration-500',
-          allRevealed ? 'opacity-100' : 'opacity-0 pointer-events-none'
+          'transition-opacity duration-500 opacity-100'
         )}
       >
         {(shareError || saveError) && (

--- a/components/RevealPhase.tsx
+++ b/components/RevealPhase.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '../convex/_generated/api';
 import { useUser } from '../lib/auth';
@@ -48,6 +48,8 @@ export function RevealPhase({
   const [error, setError] = useState<string | null>(null);
   const [isStartingNow, setIsStartingNow] = useState(false);
   const [isPresenting, setIsPresenting] = useState(false);
+  const readingNowRef = useRef<HTMLDivElement>(null);
+  const previousReadingNowId = useRef<Id<'poems'> | null>(null);
 
   const state = useQuery(api.game.getRevealPhaseState, {
     roomCode,
@@ -57,6 +59,20 @@ export function RevealPhase({
   const revealPoemMutation = useMutation(api.game.revealPoem);
   const startNewCycleMutation = useMutation(api.game.startNewCycle);
   const startGameMutation = useMutation(api.game.startGame);
+  const sortedPoems = useMemo(
+    () =>
+      [...(state?.poems ?? [])].sort((a, b) => a.indexInRoom - b.indexInRoom),
+    [state?.poems]
+  );
+  const readingNowPoem = sortedPoems.find((poem) => !poem.isRevealed) ?? null;
+  const readingNowId = readingNowPoem?._id ?? null;
+
+  useEffect(() => {
+    if (readingNowId && readingNowId !== previousReadingNowId.current) {
+      readingNowRef.current?.focus();
+      previousReadingNowId.current = readingNowId;
+    }
+  }, [readingNowId]);
 
   // Track game completion once when all poems are revealed
   const hasTrackedCompletion = useRef(false);
@@ -186,6 +202,8 @@ export function RevealPhase({
             createdAt: displayingPoem.createdAt,
             firstLine: displayingPoem.preview,
             uniquePoets,
+            readerName: displayingPoem.readerName,
+            poemNumber: displayingPoem.indexInRoom + 1,
           }}
         />
       </>
@@ -308,79 +326,87 @@ export function RevealPhase({
               </p>
             </div>
             <div className="border-t border-border-subtle">
-              {(() => {
-                const sortedPoems = [...poems].sort(
-                  (a, b) => a.indexInRoom - b.indexInRoom
-                );
-                const unrevealed = sortedPoems.filter((p) => !p.isRevealed);
-                const readingNowId = unrevealed[0]?._id;
-                const upNextId = unrevealed[1]?._id;
+              <>
+                <p role="status" aria-live="polite" className="sr-only">
+                  {readingNowPoem
+                    ? readingNowPoem.readerName + ' is reading now.'
+                    : 'The reading circle is complete.'}
+                </p>
+                {(() => {
+                  const upNextId = sortedPoems.find(
+                    (poem) => !poem.isRevealed && poem._id !== readingNowId
+                  )?._id;
 
-                return sortedPoems.map((poem, i) => {
-                  const status: ReadingCircleStatus = poem.isRevealed
-                    ? 'read'
-                    : poem._id === readingNowId
-                      ? 'reading-now'
-                      : poem._id === upNextId
-                        ? 'up-next'
-                        : null;
+                  return sortedPoems.map((poem, i) => {
+                    const status: ReadingCircleStatus = poem.isRevealed
+                      ? 'read'
+                      : poem._id === readingNowId
+                        ? 'reading-now'
+                        : poem._id === upNextId
+                          ? 'up-next'
+                          : null;
 
-                  return (
-                    <div
-                      key={poem._id}
-                      aria-current={
-                        status === 'reading-now' ? 'true' : undefined
-                      }
-                      className={cn(
-                        'flex items-center justify-between gap-3 py-3 px-3 -mx-3 border-b border-border-subtle transition-colors motion-reduce:transition-none',
-                        status === 'reading-now' &&
-                          'border-l-2 border-l-primary bg-primary/5'
-                      )}
-                    >
-                      <div className="flex min-w-0 items-center gap-3">
-                        <span className="w-6 shrink-0 font-mono text-xs text-text-muted">
-                          {(i + 1).toString().padStart(2, '0')}
-                        </span>
-                        <Avatar
-                          stableId={poem.readerStableId}
-                          displayName={poem.readerName}
-                          allStableIds={allStableIds}
-                          size="sm"
-                          outlined={!poem.isRevealed}
-                        />
-                        <div className="min-w-0">
+                    return (
+                      <div
+                        key={poem._id}
+                        ref={
+                          status === 'reading-now' ? readingNowRef : undefined
+                        }
+                        tabIndex={status === 'reading-now' ? -1 : undefined}
+                        aria-current={
+                          status === 'reading-now' ? 'true' : undefined
+                        }
+                        className={cn(
+                          'flex items-center justify-between gap-3 py-3 px-3 -mx-3 border-b border-border-subtle transition-colors motion-reduce:transition-none',
+                          status === 'reading-now' &&
+                            'border-l-2 border-l-primary bg-primary/5'
+                        )}
+                      >
+                        <div className="flex min-w-0 items-center gap-3">
+                          <span className="w-6 shrink-0 font-mono text-xs text-text-muted">
+                            {(i + 1).toString().padStart(2, '0')}
+                          </span>
+                          <Avatar
+                            stableId={poem.readerStableId}
+                            displayName={poem.readerName}
+                            allStableIds={allStableIds}
+                            size="sm"
+                            outlined={!poem.isRevealed}
+                          />
+                          <div className="min-w-0">
+                            <span
+                              className={cn(
+                                'block truncate text-sm font-medium text-text-primary',
+                                poem.isRevealed && 'opacity-50'
+                              )}
+                            >
+                              {poem.readerName}
+                            </span>
+                            <span className="block text-[0.625rem] font-mono uppercase tracking-widest text-text-muted">
+                              Poem {(i + 1).toString().padStart(2, '0')}
+                            </span>
+                          </div>
+                        </div>
+                        {status && (
                           <span
                             className={cn(
-                              'block truncate text-sm font-medium text-text-primary',
-                              poem.isRevealed && 'opacity-50'
+                              'inline-flex shrink-0 items-center gap-1 text-[0.625rem] font-mono uppercase tracking-widest',
+                              status === 'read' && 'text-text-muted opacity-50',
+                              status === 'reading-now' && 'text-primary',
+                              status === 'up-next' && 'text-text-secondary'
                             )}
                           >
-                            {poem.readerName}
+                            {status === 'read' && (
+                              <Check className="h-3 w-3" aria-hidden="true" />
+                            )}
+                            {READING_CIRCLE_STATUS_LABEL[status]}
                           </span>
-                          <span className="block text-[0.625rem] font-mono uppercase tracking-widest text-text-muted">
-                            Poem {(i + 1).toString().padStart(2, '0')}
-                          </span>
-                        </div>
+                        )}
                       </div>
-                      {status && (
-                        <span
-                          className={cn(
-                            'inline-flex shrink-0 items-center gap-1 text-[0.625rem] font-mono uppercase tracking-widest',
-                            status === 'read' && 'text-text-muted opacity-50',
-                            status === 'reading-now' && 'text-primary',
-                            status === 'up-next' && 'text-text-secondary'
-                          )}
-                        >
-                          {status === 'read' && (
-                            <Check className="h-3 w-3" aria-hidden="true" />
-                          )}
-                          {READING_CIRCLE_STATUS_LABEL[status]}
-                        </span>
-                      )}
-                    </div>
-                  );
-                });
-              })()}
+                    );
+                  });
+                })()}
+              </>
             </div>
           </section>
 

--- a/components/stage/RevealStage.tsx
+++ b/components/stage/RevealStage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Id } from '@/convex/_generated/dataModel';
 import { cn } from '@/lib/utils';
 import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
@@ -63,22 +63,23 @@ export function RevealStage({
   onRevealPoem,
 }: RevealStageProps) {
   const [activePoemId, setActivePoemId] = useState<Id<'poems'> | null>(null);
-  const [revealedLineCount, setRevealedLineCount] = useState(0);
+  const headlineRef = useRef<HTMLHeadingElement>(null);
 
   const sortedPoems = useMemo(
     () => [...poems].sort((a, b) => a.indexInRoom - b.indexInRoom),
     [poems]
   );
   const sortedRevealedPoems = useMemo(
-    () =>
-      [...revealedPoems].sort(
-        (a, b) => (b.revealedAt ?? 0) - (a.revealedAt ?? 0)
-      ),
+    () => [...revealedPoems].sort((a, b) => a.indexInRoom - b.indexInRoom),
     [revealedPoems]
   );
-  const assignedPoem = myPoems.find((poem) => !poem.isRevealed) ?? null;
+  const sortedMyPoems = useMemo(
+    () => [...myPoems].sort((a, b) => a.indexInRoom - b.indexInRoom),
+    [myPoems]
+  );
+  const assignedPoem = sortedMyPoems.find((poem) => !poem.isRevealed) ?? null;
   const readablePoem =
-    assignedPoem ?? sortedRevealedPoems[0] ?? myPoems[0] ?? null;
+    assignedPoem ?? sortedRevealedPoems[0] ?? sortedMyPoems[0] ?? null;
   const readableAssignedPoem =
     assignedPoem && readablePoem?._id === assignedPoem._id
       ? assignedPoem
@@ -92,15 +93,23 @@ export function RevealStage({
     activePoem ??
     assignedPoem ??
     sortedRevealedPoems[0] ??
-    myPoems[0] ??
+    sortedMyPoems[0] ??
     sortedPoems.find((poem) => !poem.isRevealed) ??
     sortedPoems[0] ??
     null;
-  const visibleLines = activePoem
-    ? activePoem.lines.slice(0, revealedLineCount)
-    : [];
-  const canAdvance =
-    activePoem !== null && revealedLineCount < activePoem.lines.length;
+  useEffect(() => {
+    if (!headlinePoem) return;
+    headlineRef.current?.focus();
+  }, [activePoem, headlinePoem]);
+
+  const announcement = activePoem
+    ? 'Poem ' + poemNumber(activePoem) + ' is ready. Read from line one.'
+    : headlinePoem
+      ? headlinePoem.readerName +
+        ', poem ' +
+        poemNumber(headlinePoem) +
+        ' is ready to read.'
+      : '';
 
   const handleReadOnStage = async () => {
     if (!readablePoem) return;
@@ -110,31 +119,23 @@ export function RevealStage({
     }
 
     setActivePoemId(readablePoem._id);
-    setRevealedLineCount(Math.min(1, readablePoem.lines.length));
   };
 
-  const handleAdvance = () => {
-    if (!activePoem) return;
-
-    if (canAdvance) {
-      setRevealedLineCount((current) =>
-        Math.min(current + 1, activePoem.lines.length)
-      );
-      return;
-    }
-
+  const handleFinish = () => {
     setActivePoemId(null);
-    setRevealedLineCount(0);
   };
 
   return (
     <StageShell
       testId={E2E_TEST_IDS.revealPresentationStage}
       title="Reveal stage"
-      subtitle="The reader controls the poem one line at a time."
+      subtitle="Each reader takes the whole poem in a deliberate running order."
       onExit={onExit}
     >
       <div className="grid min-h-full gap-10 xl:grid-cols-[minmax(0,1fr)_minmax(340px,0.42fr)] xl:items-stretch">
+        <p role="status" aria-live="polite" className="sr-only">
+          {announcement}
+        </p>
         <section className="flex min-h-0 flex-col justify-between border border-border bg-surface p-6 shadow-[var(--shadow-lg)] md:p-12">
           {headlinePoem ? (
             <div className="space-y-8">
@@ -149,7 +150,11 @@ export function RevealStage({
                   <p className="text-xs font-mono uppercase tracking-[0.28em] text-primary">
                     Reader
                   </p>
-                  <h2 className="text-[clamp(3.25rem,8vw,9rem)] font-[var(--font-display)] leading-[0.92] text-text-primary">
+                  <h2
+                    ref={headlineRef}
+                    tabIndex={-1}
+                    className="text-[clamp(3.25rem,8vw,9rem)] font-[var(--font-display)] leading-[0.92] text-text-primary"
+                  >
                     {headlinePoem.readerName} reads Poem{' '}
                     {poemNumber(headlinePoem)}
                   </h2>
@@ -157,15 +162,11 @@ export function RevealStage({
               </div>
 
               {activePoem ? (
-                <div className="space-y-8">
-                  {visibleLines.map((line, index) => (
+                <div className="space-y-8" aria-label="Poem lines">
+                  {activePoem.lines.map((line, index) => (
                     <p
                       key={`${line.text}:${index}`}
-                      className={cn(
-                        'max-w-5xl font-[var(--font-display)] text-[clamp(2.4rem,5vw,6.25rem)] italic leading-[1.08] text-text-primary',
-                        index === visibleLines.length - 1 &&
-                          'animate-fade-in-up'
-                      )}
+                      className="max-w-5xl font-[var(--font-display)] text-[clamp(2.4rem,5vw,6.25rem)] italic leading-[1.08] text-text-primary"
                     >
                       {line.text}
                     </p>
@@ -209,12 +210,12 @@ export function RevealStage({
             {activePoem ? (
               <Button
                 type="button"
-                onClick={handleAdvance}
+                onClick={handleFinish}
                 data-testid={E2E_TEST_IDS.revealStageNextLineButton}
                 size="lg"
                 className="min-h-16 w-full text-xl sm:w-auto sm:min-w-64"
               >
-                {canAdvance ? 'Next line' : 'Finish poem'}
+                Finish poem
               </Button>
             ) : readablePoem ? (
               <Button
@@ -246,7 +247,11 @@ export function RevealStage({
           </p>
           <ol className="grid gap-2">
             {sortedPoems.map((poem) => {
-              const isCurrent = headlinePoem?._id === poem._id;
+              const readingNowId =
+                activePoem?._id ??
+                sortedPoems.find((candidate) => !candidate.isRevealed)?._id ??
+                sortedPoems[0]?._id;
+              const isCurrent = readingNowId === poem._id;
 
               return (
                 <li

--- a/tests/components/PoemDisplay.test.tsx
+++ b/tests/components/PoemDisplay.test.tsx
@@ -78,8 +78,8 @@ describe('PoemDisplay component', () => {
     localStorage.clear();
   });
 
-  describe('reveal animation', () => {
-    it('starts with no lines revealed when alreadyRevealed is false', () => {
+  describe('whole-poem ceremony', () => {
+    it('renders every line and author target on the first reveal paint', () => {
       render(
         <PoemDisplay
           poemId={mockPoemId}
@@ -89,29 +89,15 @@ describe('PoemDisplay component', () => {
         />
       );
 
-      // Lines should have opacity-0 initially (not revealed)
-      const lineDots = screen.getAllByRole('button', { name: /Show author/i });
-      expect(lineDots[0]).toHaveClass('opacity-0');
-    });
-
-    it('reveals all lines immediately when alreadyRevealed is true', () => {
-      render(
-        <PoemDisplay
-          poemId={mockPoemId}
-          lines={mockLines}
-          onDone={mockOnDone}
-          alreadyRevealed={true}
-        />
-      );
-
-      // All lines should be visible immediately
-      const lineDots = screen.getAllByRole('button', { name: /Show author/i });
-      lineDots.forEach((dot) => {
-        expect(dot).toHaveClass('opacity-100');
+      mockLines.forEach((line) => {
+        expect(screen.getAllByText(line.text).length).toBeGreaterThan(0);
       });
+      screen
+        .getAllByRole('button', { name: /Show author/i })
+        .forEach((dot) => expect(dot).not.toBeDisabled());
     });
 
-    it('reveals lines with the poem-shaped ceremony cadence', async () => {
+    it('makes share, save, and done actions immediately discoverable', () => {
       render(
         <PoemDisplay
           poemId={mockPoemId}
@@ -121,32 +107,13 @@ describe('PoemDisplay component', () => {
         />
       );
 
-      const lineDots = screen.getAllByRole('button', { name: /Show author/i });
-
-      // Initially no lines revealed
-      expect(lineDots[0]).toHaveClass('opacity-0');
-
-      // The reveal is not a flat metronome: it follows the poem diamond,
-      // swelling toward the five-word line before accelerating to the end.
-      await act(async () => {
-        vi.advanceTimersByTime(559);
-      });
-      expect(lineDots[0]).toHaveClass('opacity-0');
-
-      await act(async () => {
-        vi.advanceTimersByTime(1);
-      });
-      expect(lineDots[0]).toHaveClass('opacity-100');
-      expect(lineDots[1]).toHaveClass('opacity-0');
-      expect(navigator.vibrate).toHaveBeenCalledWith(8);
-
-      await act(async () => {
-        vi.advanceTimersByTime(680);
-      });
-      expect(lineDots[1]).toHaveClass('opacity-100');
+      expect(screen.getByTestId('poem-actions')).toHaveClass('opacity-100');
+      expect(screen.getByRole('button', { name: 'Share' })).toBeVisible();
+      expect(screen.getByRole('button', { name: /Save image/i })).toBeVisible();
+      expect(screen.getByRole('button', { name: 'Done' })).toBeVisible();
     });
 
-    it('crescendoes into the final line instead of pausing at a fixed beat', async () => {
+    it('focuses the poem heading and announces one concise transition', () => {
       render(
         <PoemDisplay
           poemId={mockPoemId}
@@ -156,113 +123,11 @@ describe('PoemDisplay component', () => {
         />
       );
 
-      const lineDots = screen.getAllByRole('button', { name: /Show author/i });
-      const delays = [560, 680, 800, 940, 1120, 900, 720, 520, 360];
-
-      for (const delay of delays.slice(0, 5)) {
-        await act(async () => {
-          vi.advanceTimersByTime(delay);
-        });
-      }
-
-      expect(lineDots[4]).toHaveClass('opacity-100');
-      expect(lineDots[5]).toHaveClass('opacity-0');
-
-      await act(async () => {
-        vi.advanceTimersByTime(899);
-      });
-      expect(lineDots[5]).toHaveClass('opacity-0');
-
-      await act(async () => {
-        vi.advanceTimersByTime(1);
-      });
-      expect(lineDots[5]).toHaveClass('opacity-100');
-
-      for (const delay of delays.slice(6, 8)) {
-        await act(async () => {
-          vi.advanceTimersByTime(delay);
-        });
-      }
-
-      expect(lineDots[7]).toHaveClass('opacity-100');
-      expect(lineDots[8]).toHaveClass('opacity-0');
-
-      await act(async () => {
-        vi.advanceTimersByTime(359);
-      });
-      expect(lineDots[8]).toHaveClass('opacity-0');
-
-      await act(async () => {
-        vi.advanceTimersByTime(1);
-      });
-      expect(lineDots[8]).toHaveClass('opacity-100');
-      expect(navigator.vibrate).toHaveBeenLastCalledWith([14, 30, 18]);
-    });
-
-    it('reveals immediately and skips haptics for reduced motion', async () => {
-      installMatchMedia(true);
-
-      render(
-        <PoemDisplay
-          poemId={mockPoemId}
-          lines={mockLines}
-          onDone={mockOnDone}
-          alreadyRevealed={false}
-        />
+      expect(document.activeElement).toBe(
+        screen.getByRole('heading', { name: 'Poem ready to read' })
       );
-
-      const lineDots = screen.getAllByRole('button', { name: /Show author/i });
-      lineDots.forEach((dot) => {
-        expect(dot).toHaveClass('opacity-100');
-      });
-      expect(navigator.vibrate).not.toHaveBeenCalled();
-    });
-
-    it('lets the reader mute reveal punctuation before the first line', async () => {
-      render(
-        <PoemDisplay
-          poemId={mockPoemId}
-          lines={mockLines}
-          onDone={mockOnDone}
-          alreadyRevealed={false}
-        />
-      );
-
-      fireEvent.click(
-        screen.getByRole('button', { name: /Mute ceremony sound/i })
-      );
-
-      await act(async () => {
-        vi.advanceTimersByTime(560);
-      });
-
-      expect(navigator.vibrate).not.toHaveBeenCalled();
-    });
-
-    it('shows Share and Close buttons only after all lines revealed', async () => {
-      render(
-        <PoemDisplay
-          poemId={mockPoemId}
-          lines={mockLines}
-          onDone={mockOnDone}
-          alreadyRevealed={false}
-        />
-      );
-
-      // Initially footer should be hidden (opacity-0 pointer-events-none)
-      expect(screen.getByTestId('poem-actions')).toHaveClass('opacity-0');
-
-      // Reveal all 9 lines one by one (with extra pause after line 4)
-      for (const delay of [560, 680, 800, 940, 1120, 900, 720, 520, 360]) {
-        await act(async () => {
-          vi.advanceTimersByTime(delay);
-        });
-      }
-
-      // Footer should now be visible
-      expect(screen.getByTestId('poem-actions')).toHaveClass(
-        'opacity-100',
-        'pb-[max(var(--space-3),env(safe-area-inset-bottom))]'
+      expect(screen.getByRole('status')).toHaveTextContent(
+        'Poem revealed. Read from line one.'
       );
     });
   });
@@ -370,7 +235,7 @@ describe('PoemDisplay component', () => {
       expect(aliceBylines[0]).toHaveClass('opacity-100');
     });
 
-    it('does not expose hidden lines as tappable targets', () => {
+    it('keeps every author target keyboard and touch reachable', () => {
       render(
         <PoemDisplay
           poemId={mockPoemId}
@@ -380,11 +245,11 @@ describe('PoemDisplay component', () => {
         />
       );
 
-      // Before reveal, the dot is disabled so a stray tap reveals nothing.
-      const firstDot = screen.getAllByRole('button', {
-        name: /Show author/i,
-      })[0];
-      expect(firstDot).toBeDisabled();
+      const dots = screen.getAllByRole('button', { name: /Show author/i });
+      dots.forEach((dot) => {
+        expect(dot).not.toBeDisabled();
+        expect(dot).toHaveClass('opacity-100');
+      });
     });
 
     it('announces the AI persona as a reveal moment (no tap needed)', () => {
@@ -687,8 +552,7 @@ describe('PoemDisplay component', () => {
       expect(
         screen.getByText(/Fallback title from metadata/)
       ).toBeInTheDocument();
-      // A zero-line poem is trivially "fully revealed" the instant it mounts.
-      expect(screen.getByTestId('poem-actions')).toHaveClass('opacity-100');
+      expect(screen.getByTestId('poem-actions')).toBeVisible();
     });
 
     it('shows an empty title when there is no line text and no metadata fallback', () => {

--- a/tests/components/RevealPhase.test.tsx
+++ b/tests/components/RevealPhase.test.tsx
@@ -32,6 +32,7 @@ const mockStartNewCycleMutation = vi.fn();
 const mockStartGameMutation = vi.fn();
 const mockEnablePublicSessionRecapShare = vi.fn();
 const mockEnablePublicPoemShare = vi.fn();
+const mockToggleFavorite = vi.fn();
 const mockUseQuery = vi.fn();
 
 const mockApiRefs = vi.hoisted(() => ({
@@ -80,6 +81,7 @@ vi.mock('convex/react', () => ({
     if (mutationRef === mockApiRefs.enablePublicPoemShare) {
       return mockEnablePublicPoemShare;
     }
+    if (mutationRef === mockApiRefs.toggleFavorite) return mockToggleFavorite;
     throw new Error('Unexpected mutation reference');
   },
   useConvexAuth: () => ({ isLoading: false, isAuthenticated: false }),
@@ -372,7 +374,7 @@ describe('RevealPhase component', () => {
     ).toBeInTheDocument();
   });
 
-  it('lets the host open a reveal stage and pace their assigned poem manually', async () => {
+  it('lets the host open a reveal stage and read the whole assigned poem at once', async () => {
     mockRevealPoemMutation.mockResolvedValue(undefined);
     const user = userEvent.setup();
 
@@ -399,26 +401,14 @@ describe('RevealPhase component', () => {
       });
     });
 
-    expect(within(stage).getByText('One')).toBeInTheDocument();
-    expect(within(stage).queryByText('Two words')).not.toBeInTheDocument();
-
-    await user.click(within(stage).getByRole('button', { name: /Next line/i }));
-
-    expect(within(stage).getByText('Two words')).toBeInTheDocument();
-
-    for (let i = 0; i < 7; i += 1) {
-      await user.click(
-        within(stage).getByRole('button', { name: /Next line/i })
-      );
-    }
-
-    expect(within(stage).getByText('End')).toBeInTheDocument();
-    await user.click(
-      within(stage).getByRole('button', { name: /Finish poem/i })
-    );
-
+    mockMyPoem.lines.forEach((line) => {
+      expect(within(stage).getAllByText(line.text).length).toBeGreaterThan(0);
+    });
     expect(
-      within(stage).getByRole('button', { name: /Reveal on stage/i })
+      within(stage).queryByRole('button', { name: /Next line/i })
+    ).not.toBeInTheDocument();
+    expect(
+      within(stage).getByRole('button', { name: /Finish poem/i })
     ).toBeInTheDocument();
   });
 
@@ -450,9 +440,6 @@ describe('RevealPhase component', () => {
 
     const stage = screen.getByTestId('reveal-presentation-stage');
     expect(
-      within(stage).getByRole('heading', { name: /Bob reads Poem 02/i })
-    ).toBeInTheDocument();
-    expect(
       within(stage).getByRole('button', { name: /Read on stage/i })
     ).toBeInTheDocument();
 
@@ -461,7 +448,7 @@ describe('RevealPhase component', () => {
     );
 
     expect(within(stage).getByText('Lanterns')).toBeInTheDocument();
-    expect(within(stage).queryByText('toward dawn')).not.toBeInTheDocument();
+    expect(within(stage).getByText('toward dawn')).toBeInTheDocument();
     expect(mockRevealPoemMutation).not.toHaveBeenCalled();
   });
 

--- a/tests/components/RevealStage.test.tsx
+++ b/tests/components/RevealStage.test.tsx
@@ -24,7 +24,7 @@ const poems = [
 ];
 
 describe('RevealStage', () => {
-  it('uses the latest revealed poem when the host has no assigned poem', async () => {
+  it('uses the earliest poem in running order when the host has no assigned poem', async () => {
     const user = userEvent.setup();
 
     render(
@@ -58,7 +58,7 @@ describe('RevealStage', () => {
     const stage = screen.getByTestId('reveal-presentation-stage');
     expect(
       within(stage).getByRole('heading', {
-        name: /Latest Reader reads Poem 02/i,
+        name: /Older Reader reads Poem 01/i,
       })
     ).toBeInTheDocument();
 
@@ -66,8 +66,8 @@ describe('RevealStage', () => {
       within(stage).getByRole('button', { name: /Read on stage/i })
     );
 
-    expect(within(stage).getByText('Latest')).toBeInTheDocument();
-    expect(within(stage).queryByText('Old')).not.toBeInTheDocument();
+    expect(within(stage).getByText('Old')).toBeInTheDocument();
+    expect(within(stage).queryByText('Latest')).not.toBeInTheDocument();
   });
 
   it('shows AI reader context, error feedback, and disabled reveal state', () => {

--- a/tests/e2e/reveal-reader-leaver.spec.ts
+++ b/tests/e2e/reveal-reader-leaver.spec.ts
@@ -46,7 +46,11 @@ async function submitLine(page: Page, line: string) {
 }
 
 async function revealAssignedPoem(page: Page) {
-  await visibleTestId(page, E2E_TEST_IDS.revealPoemButton).click();
+  const assignedButton = page
+    .getByRole('button', { name: 'Reveal & Read', exact: true })
+    .filter({ visible: true });
+  await expect(assignedButton).toHaveCount(1);
+  await assignedButton.click();
   await expect(visibleTestId(page, E2E_TEST_IDS.poemDoneButton)).toBeVisible();
   await visibleTestId(page, E2E_TEST_IDS.poemDoneButton).click();
 }
@@ -114,11 +118,12 @@ test('three-player reveal survives an assigned reader disconnect on mobile', asy
     }
 
     await Promise.all(
-      [hostPage, presentReaderPage, departedReaderPage].map((page) =>
-        expect(visibleTestId(page, E2E_TEST_IDS.revealPoemButton)).toBeVisible({
-          timeout: 30_000,
-        })
-      )
+      [hostPage, presentReaderPage, departedReaderPage].map(async (page) => {
+        const assignedButton = page
+          .getByRole('button', { name: 'Reveal & Read', exact: true })
+          .filter({ visible: true });
+        await expect(assignedButton).toHaveCount(1, { timeout: 30_000 });
+      })
     );
 
     await departedReaderContext.close();

--- a/tests/e2e/support/guestFlow.ts
+++ b/tests/e2e/support/guestFlow.ts
@@ -526,12 +526,14 @@ export class GuestFlowSession {
     await expect(
       this.guestPage.getByTestId(E2E_TEST_IDS.revealPhase)
     ).toBeVisible({ timeout: 30000 });
-    await expect(
-      this.hostPage.getByTestId(E2E_TEST_IDS.revealPoemButton).first()
-    ).toBeVisible();
-    await expect(
-      this.guestPage.getByTestId(E2E_TEST_IDS.revealPoemButton).first()
-    ).toBeVisible();
+    await Promise.all(
+      [this.hostPage, this.guestPage].map(async (page) => {
+        const assignedButton = page
+          .getByRole('button', { name: 'Reveal & Read', exact: true })
+          .filter({ visible: true });
+        await expect(assignedButton).toHaveCount(1);
+      })
+    );
   }
 
   async revealAssignedPoem(
@@ -540,12 +542,18 @@ export class GuestFlowSession {
   ) {
     const page = this.page(actor);
 
-    await page.getByTestId(E2E_TEST_IDS.revealPoemButton).first().click();
-    for (const line of lines) {
-      await expect(page.getByText(line, { exact: true })).toBeVisible({
-        timeout: 12000,
-      });
-    }
+    const assignedButton = page
+      .getByRole('button', { name: 'Reveal & Read', exact: true })
+      .filter({ visible: true });
+    await expect(assignedButton).toHaveCount(1);
+    await assignedButton.click();
+    await Promise.all(
+      lines.map((line) =>
+        expect(page.getByText(line, { exact: true })).toBeVisible({
+          timeout: 12000,
+        })
+      )
+    );
     await page.getByTestId(E2E_TEST_IDS.poemDoneButton).click();
   }
 


### PR DESCRIPTION
## What changed
- present every poem line on first reveal paint; remove timer and stage Next-line gating
- keep reader order deterministic by indexInRoom and announce/focus reader and poem transitions
- make Share, save, done, author, ceremony mute, and archive favorite controls immediately reachable with 44px touch targets
- add focused component coverage for whole-poem content, immediate actions, order, focus, and live announcements

Closes linejam-972. Cross-links linejam-975 touch-target evidence: the reveal surfaces now meet the shared 44px target contract.

## Verification
- pnpm vitest run tests/components/PoemDisplay.test.tsx tests/components/RevealStage.test.tsx tests/components/RevealPhase.test.tsx --reporter=dot (55 passed)
- pnpm typecheck (passed)
- pnpm ci:prepush (149 files passed; 1644 passed, 1 skipped)
- git push pre-push hook (typecheck, lint, full Vitest passed)

Browser E2E reveal/share and mobile viewport remain CI-owned in this environment; local Playwright provisioning started but the bounded harness call did not complete before timeout. No production or Convex mutations performed.