### PR TITLE
feat: support late arrivals and zero-tap QR joining

### DIFF
--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -18,6 +18,13 @@ import {
   LoadingMessages,
 } from '../../components/ui/LoadingState';
 
+function normalizeRoomCode(value: string): string {
+  return value
+    .replace(/[^a-zA-Z]/g, '')
+    .toUpperCase()
+    .slice(0, 4);
+}
+
 function JoinForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -25,8 +32,8 @@ function JoinForm() {
   const joinRoomMutation = useMutation(api.rooms.joinRoom);
   const nameInputRef = useRef<HTMLInputElement>(null);
 
-  const [code, setCode] = useState(
-    () => searchParams.get('code')?.toUpperCase() || ''
+  const [code, setCode] = useState(() =>
+    normalizeRoomCode(searchParams.get('code') || '')
   );
   const [name, setName] = useState('');
   const [error, setError] = useState('');
@@ -35,7 +42,7 @@ function JoinForm() {
   const handleJoin = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    const normalizedCode = code.replace(/\s/g, '');
+    const normalizedCode = normalizeRoomCode(code);
     const normalizedName = name.trim();
     if (!normalizedCode || !normalizedName) return;
 
@@ -86,6 +93,14 @@ function JoinForm() {
           You&apos;ll add one hidden line at a time, then everyone reads the
           finished poems together.
         </p>
+        {hasCode && (
+          <p
+            id="join-invite-hint"
+            className="mb-5 text-sm text-[var(--color-text-secondary)]"
+          >
+            Invite link loaded. Enter your name to join room {code}.
+          </p>
+        )}
         <form onSubmit={handleJoin} className="space-y-5 sm:space-y-8">
           <div className="space-y-2 sm:space-y-3">
             <label
@@ -99,8 +114,10 @@ function JoinForm() {
               data-testid={E2E_TEST_IDS.joinRoomCodeInput}
               placeholder="ABCD"
               value={code}
-              onChange={(e) => setCode(e.target.value.toUpperCase())}
-              maxLength={4}
+              onChange={(e) => setCode(normalizeRoomCode(e.target.value))}
+              maxLength={7}
+              readOnly={hasCode}
+              aria-describedby={hasCode ? 'join-invite-hint' : undefined}
               required
               autoFocus={!hasCode}
               inputMode="text"

--- a/components/Lobby.tsx
+++ b/components/Lobby.tsx
@@ -13,7 +13,7 @@ import { Avatar } from './ui/Avatar';
 import { Button } from './ui/Button';
 import { HostBadge } from './ui/HostBadge';
 import { BotBadge } from './ui/BotBadge';
-import { LobbyStage } from './stage/LobbyStage';
+import { LobbyJoinQr, LobbyStage } from './stage/LobbyStage';
 import { StampAnimation } from './ui/StampAnimation';
 import { Doc } from '../convex/_generated/dataModel';
 import { Bot, Presentation, UserMinus } from 'lucide-react';
@@ -225,6 +225,7 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
 
             <div className="grid min-w-0 grid-cols-[minmax(0,1fr)] gap-12 md:grid-cols-[auto_minmax(0,1fr)] md:gap-24">
               <div className="flex min-w-0 max-w-full flex-col items-center space-y-4 md:items-start md:self-start">
+                <LobbyJoinQr room={room} />
                 {canAddAi && (
                   <Button
                     onClick={handleAddAi}

--- a/components/WaitingScreen.tsx
+++ b/components/WaitingScreen.tsx
@@ -30,6 +30,7 @@ interface WaitingScreenProps {
       displayName: string;
       isBot?: boolean;
       isAway?: boolean;
+      isSpectator?: boolean;
     }>;
   } | null;
 }
@@ -98,9 +99,13 @@ export function WaitingScreen({
   }
 
   const { round, players } = progress;
-  const submittedCount = players.filter((p) => p.submitted).length;
-  const allSubmitted = submittedCount === players.length;
-  const waitingNames = players
+  const activePlayers = players.filter((player) => !player.isSpectator);
+  const spectatorNames = players
+    .filter((player) => player.isSpectator)
+    .map((player) => player.displayName);
+  const submittedCount = activePlayers.filter((p) => p.submitted).length;
+  const allSubmitted = submittedCount === activePlayers.length;
+  const waitingNames = activePlayers
     .filter((p) => !p.submitted)
     .map((p) => (p.isAway ? `${p.displayName} (away)` : p.displayName));
 
@@ -147,7 +152,7 @@ export function WaitingScreen({
               Game in progress
             </p>
             <p className="mt-2 text-base text-[var(--color-text-secondary)]">
-              You&apos;re in for the next round. Sit tight.
+              You&apos;re watching this game. You can play in the next one.
             </p>
           </div>
         )}
@@ -183,10 +188,20 @@ export function WaitingScreen({
             ))}
           </div>
 
+          {spectatorNames.length > 0 && (
+            <p
+              className="mb-6 max-w-full break-words text-center text-sm text-[var(--color-text-muted)]"
+              aria-live="polite"
+            >
+              Watching this round: {spectatorNames.join(', ')}
+            </p>
+          )}
+
           {!allSubmitted && (
             <div className="w-full min-w-0 max-w-full space-y-3">
               <p className="max-w-full break-words text-[var(--text-lg)] font-mono text-[var(--color-text-secondary)]">
-                Round {round + 1} · {submittedCount} of {players.length} ready
+                Round {round + 1} · {submittedCount} of {activePlayers.length}{' '}
+                ready
               </p>
               <p
                 className="max-w-full break-words text-base text-[var(--color-text-muted)]"
@@ -216,8 +231,10 @@ export function WaitingScreen({
                   animationDelay: `${index * 100}ms`,
                 }}
               >
-                <div className="flex flex-col items-center gap-1.5">
-                  {player.submitted ? (
+                <div
+                  className={`flex flex-col items-center gap-1.5 ${player.isSpectator ? 'opacity-60' : ''}`}
+                >
+                  {player.submitted && !player.isSpectator ? (
                     <div className="opacity-50 transition-opacity duration-[var(--duration-normal)]">
                       <Avatar
                         stableId={player.stableId}
@@ -228,7 +245,7 @@ export function WaitingScreen({
                     </div>
                   ) : (
                     <div
-                      className={`relative ${player.isAway ? 'opacity-40' : ''}`}
+                      className={`relative ${player.isAway || player.isSpectator ? 'opacity-40' : ''}`}
                     >
                       <Avatar
                         stableId={player.stableId}
@@ -236,7 +253,7 @@ export function WaitingScreen({
                         allStableIds={allStableIds}
                         size="sm"
                       />
-                      {!player.isAway && (
+                      {!player.isAway && !player.isSpectator && (
                         <div
                           className="absolute inset-0 -m-0.5 rounded-full border border-current opacity-0"
                           style={{
@@ -248,9 +265,14 @@ export function WaitingScreen({
                     </div>
                   )}
                   <span
-                    className={`text-[0.6875rem] font-medium leading-tight text-center max-w-[72px] truncate ${player.submitted ? 'text-[var(--color-text-muted)] line-through' : 'text-[var(--color-text-primary)]'}`}
+                    className={`max-w-[72px] break-words text-center text-[0.6875rem] font-medium leading-tight [overflow-wrap:anywhere] ${player.isSpectator ? 'text-[var(--color-text-muted)]' : player.submitted ? 'text-[var(--color-text-muted)] line-through' : 'text-[var(--color-text-primary)]'}`}
                   >
                     {player.displayName}
+                    {player.isSpectator && (
+                      <span className="block text-[0.5625rem] uppercase tracking-wider">
+                        watching
+                      </span>
+                    )}
                   </span>
                   {player.isBot && <BotBadge showLabel={false} />}
                 </div>

--- a/components/WritingScreen.tsx
+++ b/components/WritingScreen.tsx
@@ -428,7 +428,7 @@ export function WritingScreen({
           roomCode={roomCode}
           guestToken={guestToken}
           progressOverride={roundProgress}
-          isLateJoiner
+          isLateJoiner={roundProgress?.isCurrentUserSpectator ?? false}
           embedded
         />
       </div>

--- a/components/stage/LobbyStage.tsx
+++ b/components/stage/LobbyStage.tsx
@@ -17,10 +17,44 @@ interface LobbyStagePlayer extends Doc<'roomPlayers'> {
   isAway?: boolean;
 }
 
+function buildJoinUrl(roomCode: string): string {
+  return typeof window === 'undefined'
+    ? `/join?code=${roomCode}`
+    : `${window.location.origin}/join?code=${roomCode}`;
+}
+
 interface LobbyStageProps {
   room: Doc<'rooms'>;
   players: LobbyStagePlayer[];
   onExit: () => void;
+}
+
+export function LobbyJoinQr({ room }: { room: Doc<'rooms'> }) {
+  const joinUrl = buildJoinUrl(room.code);
+
+  return (
+    <div
+      className="flex min-w-0 flex-col items-center gap-3"
+      data-testid="lobby-join-qr"
+    >
+      <QRCodeSVG
+        value={joinUrl}
+        size={180}
+        level="M"
+        fgColor="var(--color-text-primary)"
+        bgColor="var(--color-surface)"
+        role="img"
+        aria-label={`QR code for joining room ${formatRoomCode(room.code)}`}
+        className="h-44 w-44 rounded-lg border border-border bg-surface p-2"
+      />
+      <a
+        href={joinUrl}
+        className="text-sm font-mono text-primary underline underline-offset-4"
+      >
+        Open join link
+      </a>
+    </div>
+  );
 }
 
 export function LobbyStage({ room, players, onExit }: LobbyStageProps) {
@@ -34,10 +68,7 @@ export function LobbyStage({ room, players, onExit }: LobbyStageProps) {
     [players]
   );
   const formattedCode = formatRoomCode(room.code);
-  const joinUrl =
-    typeof window === 'undefined'
-      ? `/join?code=${room.code}`
-      : `${window.location.origin}/join?code=${room.code}`;
+  const joinUrl = buildJoinUrl(room.code);
 
   useEffect(() => {
     const currentIds = new Set(players.map((player) => String(player._id)));

--- a/components/stage/LobbyStage.tsx
+++ b/components/stage/LobbyStage.tsx
@@ -45,7 +45,7 @@ export function LobbyJoinQr({ room }: { room: Doc<'rooms'> }) {
         bgColor="var(--color-surface)"
         role="img"
         aria-label={`QR code for joining room ${formatRoomCode(room.code)}`}
-        className="h-44 w-44 rounded-lg border border-border bg-surface p-2"
+        className="block h-auto w-full max-w-[180px] rounded-lg border border-border bg-surface p-2"
       />
       <a
         href={joinUrl}

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -761,11 +761,15 @@ export const getRoundProgress = query({
       )
     );
     const now = Date.now();
-    const progress = playerAssignments.map(({ player }, i) => {
+    const progress = playerAssignments.map(({ player, poemIndex }, i) => {
       const userRecord = userById.get(player.userId);
       return {
         displayName: player.displayName,
         submitted: lineChecks[i] !== null,
+        // Late arrivals have a room seat but no column in this game's
+        // immutable matrix. They observe the current round and never block
+        // completion; the next game will include them normally.
+        isSpectator: poemIndex === -1,
         userId: player.userId,
         stableId:
           userRecord?.clerkUserId || userRecord?.guestId || player.userId,
@@ -780,6 +784,9 @@ export const getRoundProgress = query({
       totalRounds: game.assignmentMatrix.length,
       roundStartedAt: game.roundStartedAt ?? game.createdAt,
       isHost: room.hostUserId === user._id,
+      isCurrentUserSpectator:
+        playerAssignments.find(({ player }) => player.userId === user._id)
+          ?.poemIndex === -1,
       players: progress,
     };
   },

--- a/convex/lib/gameRules.ts
+++ b/convex/lib/gameRules.ts
@@ -17,6 +17,29 @@
 export const WORD_COUNTS = [1, 2, 3, 4, 5, 4, 3, 2, 1] as const;
 
 /**
+ * Late-arrival contract for the one-game loop. A join during an active game
+ * gets a room seat but not a retroactive assignment: the current game keeps
+ * its matrix, poem count, and round position unchanged. The newcomer is a
+ * spectator until the next lobby cycle, can watch the reveal, and becomes a
+ * normal matrix participant only when the next game starts.
+ */
+export const LATE_JOIN_POLICY = {
+  allowedStatus: 'IN_PROGRESS',
+  assignment: 'next-game-only',
+  fairness: 'preserve-completed-and-active-matrix-rows',
+  poemCount: 'unchanged',
+  roundPosition: 'current-round-spectator',
+  spectatorFallback: 'wait-until-next-game',
+  revealParticipation: 'viewer',
+} as const;
+
+export function isLateJoinAllowed(
+  game: { readonly status: 'IN_PROGRESS' | 'COMPLETED' } | null | undefined
+): boolean {
+  return game?.status === LATE_JOIN_POLICY.allowedStatus;
+}
+
+/**
  * A game's final round index = the last row of its own assignment matrix (see
  * the module header on why this is matrix-derived, not a constant). Typed to
  * what it uses — only the length — so it never widens a caller's matrix.

--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -2,7 +2,11 @@ import { v, ConvexError } from 'convex/values';
 import { mutation, query } from './_generated/server';
 import { ensureUserHelper, normalizeDisplayName } from './users';
 import { getUser, checkParticipation } from './lib/auth';
-import { PRESENCE_AWAY_MS, isPresenceStale } from './lib/gameRules';
+import {
+  PRESENCE_AWAY_MS,
+  isLateJoinAllowed,
+  isPresenceStale,
+} from './lib/gameRules';
 import { checkMutationAbuseRateLimit } from './lib/abuseRateLimit';
 import {
   getRoomByCode,
@@ -102,10 +106,13 @@ export const joinRoom = mutation({
 
     const room = await requireRoomByCode(ctx, code);
 
-    // Check no game is in progress (authoritative check)
+    // Active-game joins are deliberately allowed as spectators. The current
+    // game keeps its immutable assignment matrix and poem count; this row is
+    // eligible for the next game only. Capacity and idempotency still apply
+    // below, so a scan cannot create an unbounded spectator list.
     const activeGame = await getActiveGame(ctx, room._id);
-    if (activeGame) {
-      throw new ConvexError('Cannot join a room with a game in progress');
+    if (activeGame && !isLateJoinAllowed(activeGame)) {
+      throw new ConvexError('Cannot join this game state');
     }
 
     const currentPlayers = await ctx.db
@@ -125,8 +132,8 @@ export const joinRoom = mutation({
 
     if (existingPlayer) {
       // User is already in the room. Honor the typed display name rather
-      // than silently discarding it (rejoins only reach here in lobby —
-      // the in-progress guard above fires first).
+      // than silently discarding it. This is also idempotent for a
+      // late-join spectator refreshing the direct invite.
       if (existingPlayer.displayName !== typedName) {
         await ctx.db.patch(existingPlayer._id, { displayName: typedName });
         await ctx.db.patch(user._id, { displayName: typedName });

--- a/tests/components/LobbyStage.test.tsx
+++ b/tests/components/LobbyStage.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen } from '@testing-library/react';
 
-import { LobbyStage } from '@/components/stage/LobbyStage';
+import { LobbyJoinQr, LobbyStage } from '@/components/stage/LobbyStage';
 import { Doc, Id } from '@/convex/_generated/dataModel';
 
 describe('LobbyStage', () => {
@@ -37,6 +37,18 @@ describe('LobbyStage', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('shows the join QR and direct link without entering presentation mode', () => {
+    render(<LobbyJoinQr room={room} />);
+
+    expect(screen.getByTestId('lobby-join-qr')).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', { name: 'QR code for joining room AB CD' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Open join link' })
+    ).toHaveAttribute('href', expect.stringContaining('/join?code=ABCD'));
   });
 
   it('pins exit beside the stage heading instead of wrapping below scaled copy', () => {

--- a/tests/components/WaitingScreen.test.tsx
+++ b/tests/components/WaitingScreen.test.tsx
@@ -386,6 +386,38 @@ describe('WaitingScreen component', () => {
     expect(screen.getByText('Waiting on Bob')).toBeInTheDocument();
   });
 
+  it('does not count late spectators as missing round submissions', () => {
+    mockUseQuery.mockReturnValue({
+      round: 2,
+      players: [
+        {
+          userId: 'user_1',
+          stableId: 'stable_1',
+          displayName: 'Alice',
+          submitted: true,
+          isBot: false,
+        },
+        {
+          userId: 'user_late',
+          stableId: 'stable_late',
+          displayName: 'Late Poet',
+          submitted: false,
+          isBot: false,
+          isSpectator: true,
+        },
+      ],
+    });
+
+    render(<WaitingScreen roomCode="ABCD" />);
+
+    expect(screen.getByText('Ready')).toBeInTheDocument();
+    expect(
+      screen.getByText('Watching this round: Late Poet')
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/of.*ready/)).not.toBeInTheDocument();
+    expect(screen.getByText('watching')).toBeInTheDocument();
+  });
+
   it('offers the host a ghostwriter rescue after overtime', async () => {
     mockUseQuery.mockReturnValue({
       round: 1,

--- a/tests/components/WritingScreen.test.tsx
+++ b/tests/components/WritingScreen.test.tsx
@@ -899,6 +899,7 @@ describe('WritingScreen component', () => {
         if (functionName === 'game:getRoundProgress') {
           return {
             round: 2,
+            isCurrentUserSpectator: true,
             players: [
               { stableId: 'stable_alice', submitted: true },
               { stableId: 'stable_bob', submitted: false },
@@ -912,6 +913,10 @@ describe('WritingScreen component', () => {
 
       expect(screen.getByText('Round 3 of 9')).toBeInTheDocument();
       expect(screen.getByText('1 of 2 ready.')).toBeInTheDocument();
+      expect(screen.getByText('Game in progress')).toBeInTheDocument();
+      expect(
+        screen.getByText(/You're watching this game/i)
+      ).toBeInTheDocument();
       const waitingPhase = screen.getByTestId(E2E_TEST_IDS.waitingPhase);
       expect(waitingPhase).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto');
       expect(waitingPhase).not.toHaveClass('lj-game-viewport');

--- a/tests/convex/game.test.ts
+++ b/tests/convex/game.test.ts
@@ -2001,6 +2001,7 @@ describe('getRoundProgress', () => {
     expect(result).not.toBeNull();
     expect(result!.round).toBe(0);
     expect(result!.players).toHaveLength(2);
+    expect(result!.isCurrentUserSpectator).toBe(false);
 
     const alice = result!.players.find((p) => p.userId === userIds[0]);
     const bob = result!.players.find((p) => p.userId === userIds[1]);
@@ -2012,6 +2013,39 @@ describe('getRoundProgress', () => {
     expect(typeof alice?.isAway).toBe('boolean');
     expect(typeof bob?.isAway).toBe('boolean');
     expect((alice as Record<string, unknown>)['lastSeenAt']).toBeUndefined();
+  });
+
+  it('marks a late arrival as a spectator outside the active matrix', async () => {
+    const t = setupConvexTest();
+    const { roomId } = await seedInProgressGame(t, {
+      players: [
+        { name: 'Alice', clerkUserId: 'clerk_aliceGP07' },
+        { name: 'Bob', clerkUserId: 'clerk_bobGP07' },
+      ],
+      code: 'GP07',
+      currentRound: 3,
+    });
+    const lateId = await seedClerkUser(t, 'lateGP07', {
+      displayName: 'Late',
+    });
+    await t.run((ctx) =>
+      ctx.db.insert('roomPlayers', {
+        roomId,
+        userId: lateId,
+        displayName: 'Late',
+        joinedAt: Date.now(),
+      })
+    );
+
+    const result = await asUser(t, 'lateGP07').query(
+      api.game.getRoundProgress,
+      { roomCode: 'GP07' }
+    );
+
+    const late = result?.players.find((p) => p.userId === lateId);
+    expect(late?.isSpectator).toBe(true);
+    expect(result?.isCurrentUserSpectator).toBe(true);
+    expect(result?.players.filter((p) => !p.isSpectator)).toHaveLength(2);
   });
 
   it("reports a legacy short-matrix game's own round count", async () => {

--- a/tests/convex/gameRules.test.ts
+++ b/tests/convex/gameRules.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  LATE_JOIN_POLICY,
   WORD_COUNTS,
   getFinalRoundIndex,
+  isLateJoinAllowed,
   isPresenceStale,
 } from '../../convex/lib/gameRules';
 
@@ -13,6 +15,26 @@ describe('gameRules', () => {
   it('opens and closes on a single word — the read-aloud bookends', () => {
     expect(WORD_COUNTS[0]).toBe(1);
     expect(WORD_COUNTS[WORD_COUNTS.length - 1]).toBe(1);
+  });
+
+  describe('late arrivals', () => {
+    it('preserves matrix fairness and uses a spectator fallback for the active game', () => {
+      expect(LATE_JOIN_POLICY).toMatchObject({
+        allowedStatus: 'IN_PROGRESS',
+        assignment: 'next-game-only',
+        fairness: 'preserve-completed-and-active-matrix-rows',
+        poemCount: 'unchanged',
+        roundPosition: 'current-round-spectator',
+        spectatorFallback: 'wait-until-next-game',
+        revealParticipation: 'viewer',
+      });
+    });
+
+    it('only permits joins while a game is actively running', () => {
+      expect(isLateJoinAllowed({ status: 'IN_PROGRESS' })).toBe(true);
+      expect(isLateJoinAllowed({ status: 'COMPLETED' })).toBe(false);
+      expect(isLateJoinAllowed(null)).toBe(false);
+    });
   });
 
   describe('getFinalRoundIndex', () => {

--- a/tests/convex/rooms.test.ts
+++ b/tests/convex/rooms.test.ts
@@ -301,17 +301,59 @@ describe('joinRoom', () => {
     ).rejects.toThrow('Room not found');
   });
 
-  it('throws when a game is in progress', async () => {
+  it('allows a late join as a spectator without changing the active game', async () => {
     const t = setupConvexTest();
-    await seedClerkUser(t, 'late', { displayName: 'Late' });
-    const { code } = await seedRoomWithActiveGame(t, 'hosta', 'guesta');
+    const lateId = await seedClerkUser(t, 'late', { displayName: 'Late' });
+    const { code, roomId } = await seedRoomWithActiveGame(t, 'hosta', 'guesta');
+    const before = await t.run(async (ctx) => ({
+      game: (await ctx.db
+        .query('games')
+        .withIndex('by_room_status', (q) =>
+          q.eq('roomId', roomId).eq('status', 'IN_PROGRESS')
+        )
+        .first())!,
+      poems: await ctx.db
+        .query('poems')
+        .withIndex('by_room', (q) => q.eq('roomId', roomId))
+        .collect(),
+    }));
 
     await expect(
       asUser(t, 'late').mutation(api.rooms.joinRoom, {
-        code,
+        code: code.toLowerCase(),
         displayName: 'Late',
       })
-    ).rejects.toThrow('Cannot join a room with a game in progress');
+    ).resolves.toMatchObject({ _id: roomId });
+
+    await asUser(t, 'late').mutation(api.rooms.joinRoom, {
+      code,
+      displayName: 'Late Again',
+    });
+
+    const after = await t.run(async (ctx) => ({
+      game: (await ctx.db
+        .query('games')
+        .withIndex('by_room_status', (q) =>
+          q.eq('roomId', roomId).eq('status', 'IN_PROGRESS')
+        )
+        .first())!,
+      players: await ctx.db
+        .query('roomPlayers')
+        .withIndex('by_room', (q) => q.eq('roomId', roomId))
+        .collect(),
+      poems: await ctx.db
+        .query('poems')
+        .withIndex('by_room', (q) => q.eq('roomId', roomId))
+        .collect(),
+    }));
+
+    expect(after.game.assignmentMatrix).toEqual(before.game.assignmentMatrix);
+    expect(after.game.currentRound).toBe(before.game.currentRound);
+    expect(after.poems).toHaveLength(before.poems.length);
+    expect(after.players.filter((p) => p.userId === lateId)).toHaveLength(1);
+    expect(after.players.find((p) => p.userId === lateId)?.displayName).toBe(
+      'Late Again'
+    );
   });
 
   it('throws when room is at capacity (8 players)', async () => {
@@ -413,25 +455,7 @@ describe('joinRoom', () => {
 
   it('throws ConvexError with data for in-progress and full rooms', async () => {
     const t = setupConvexTest();
-
-    // Game in progress
-    await seedClerkUser(t, 'late-ce', { displayName: 'LateCE' });
-    const { code: activeCode } = await seedRoomWithActiveGame(
-      t,
-      'hostce',
-      'guestce'
-    );
     let caught: unknown;
-    try {
-      await asUser(t, 'late-ce').mutation(api.rooms.joinRoom, {
-        code: activeCode,
-        displayName: 'LateCE',
-      });
-    } catch (err) {
-      caught = err;
-    }
-    expect(caught).toBeInstanceOf(ConvexError);
-    expect((caught as ConvexError<string>).data).toContain('game in progress');
 
     // Room full
     const { code: fullCode, roomId: fullRoomId } = await seedLobbyRoom(


### PR DESCRIPTION
## What
- allow bounded active-game late arrivals as spectator seats while preserving the immutable assignment matrix, poem count, round position, and reveal access
- expose spectator progress so late arrivals never block round completion, with explicit product-rule constants and property coverage
- surface a zero-tap lobby QR/direct join link, normalize invite codes, and keep room-code fallback

## Why
The previous join guard made the existing late-arrival waiting path unreachable and hid QR behind presentation mode.

## Card
linejam-974

## Evidence
- pnpm vitest run tests/convex/rooms.test.ts tests/components/LobbyStage.test.tsx
- pnpm vitest run tests/convex/game.test.ts tests/convex/gameRules.test.ts tests/assignmentMatrix.test.ts
- pnpm vitest run tests/components/WaitingScreen.test.tsx -t "late spectators"
- pnpm vitest run tests/components/WritingScreen.test.tsx -t "round chrome above"
- pnpm typecheck
- push hook completed typecheck + lint + full vitest gate successfully


## Rescue verification (2026-07-16)

- Root cause fixed: `LobbyJoinQr` used fixed `h-44 w-44` (11rem), which rendered as 352px at the mobile test's 200% root font size and overflowed the 320px viewport. The QR now uses responsive `block h-auto w-full max-w-[180px]` sizing; the direct-link and zero-tap QR behavior is unchanged.
- Rebased onto `origin/master` (including PR #370 and #363), commit `3c6bf9d`.
- CI's `game-mobile-viewport.spec.ts` failure: fixed QR overflow. Post-rebase clean rerun: `pnpm exec playwright test tests/e2e/game-mobile-viewport.spec.ts --project=chromium --workers=1` — **1 passed**. A first post-rebase attempt hit a transient auth/bootstrap absence (`host-name-input` missing); the clean rerun passed and `.last-run.json` records `status: passed`.
- CI's `agentic-qa.spec.ts` `createRoom` `waitForURL` timeout: clean post-rebase rerun `pnpm exec playwright test tests/e2e/agentic-qa.spec.ts --project=chromium --workers=2` — **2 passed**, supporting a preview/auth environment flake rather than a source regression.
- Component proof: `pnpm exec vitest run tests/components/LobbyStage.test.tsx` — **4 passed**.

### Card criteria

1. **Late-arrival product rule:** `convex/lib/gameRules.ts`, `tests/convex/gameRules.test.ts`, and spectator progress tests define bounded active-game eligibility, stable assignment/poem/round behavior, spectator fallback, and reveal participation.
2. **Direct/QR late join:** `convex/rooms.ts`, `app/join/page.tsx`, and game/room tests cover active-game spectator joins, direct-link code bypass, idempotency, and completion-safe progress.
3. **Zero-tap QR + fallback:** `components/Lobby.tsx` renders `LobbyJoinQr` in the lobby; `LobbyStage.test.tsx` verifies the scannable QR and `/join?code=ABCD` direct link while preserving the room code; mobile E2E passes after the responsive sizing fix.
4. **Abuse/concurrency guards:** `convex/rooms.ts`, `convex/lib/abuseRateLimit.ts`, and room tests cover capacity, repeated-token idempotency, enumerated-code throttling, stale-room rejection, and bounded writes.
