### PR TITLE
fix: polish mobile game core loop

### DIFF
--- a/app/room/[code]/page.tsx
+++ b/app/room/[code]/page.tsx
@@ -131,6 +131,7 @@ function ResolvedRoomPage({
 }
 
 function RoomPageContent({ code }: { code: string }) {
+  const router = useRouter();
   const { isLoading, guestToken, authError, retryAuth } = useUser();
   const roomState = useQuery(api.rooms.getRoomState, {
     code,
@@ -154,13 +155,20 @@ function RoomPageContent({ code }: { code: string }) {
 
   if (roomState === null) {
     return (
-      <div className="lj-game-viewport lj-safe-inline flex flex-col items-center justify-center gap-4 bg-[var(--color-background)] text-center">
-        <span className="text-[var(--color-text-primary)] text-xl">
+      <div className="lj-game-viewport lj-safe-inline flex flex-col items-center justify-center gap-4 bg-[var(--color-background)] px-4 py-6 text-center">
+        <span className="break-words text-[var(--color-text-primary)] text-xl">
           Room not found
         </span>
-        <span className="max-w-md text-[var(--color-text-muted)] text-sm">
-          The room code may be incorrect or the room has expired.
+        <span className="max-w-md break-words text-[var(--color-text-muted)] text-sm [overflow-wrap:anywhere]">
+          This room code is incorrect or the room has expired.
         </span>
+        <button
+          type="button"
+          className="min-h-11 w-full max-w-xs rounded-md border border-transparent bg-[var(--color-surface)] px-4 py-2 font-medium text-[var(--color-text-primary)] shadow-sm"
+          onClick={() => router.push('/join')}
+        >
+          Return to join
+        </button>
       </div>
     );
   }

--- a/components/Lobby.tsx
+++ b/components/Lobby.tsx
@@ -289,7 +289,7 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
                                 <button
                                   onClick={() => handleRemoveAi(player.userId)}
                                   disabled={aiLoading}
-                                  className="p-1.5 text-text-muted hover:text-primary transition-colors disabled:opacity-50"
+                                  className="flex h-11 w-11 items-center justify-center rounded-md text-text-muted transition-colors hover:text-primary disabled:opacity-50"
                                   aria-label="Remove AI player"
                                 >
                                   <UserMinus className="w-4 h-4" />

--- a/components/RoomChrome.tsx
+++ b/components/RoomChrome.tsx
@@ -60,6 +60,7 @@ export function RoomChrome({
   const [showMenu, setShowMenu] = useState(false);
   const [showQr, setShowQr] = useState(false);
   const [codeCopied, setCodeCopied] = useState(false);
+  const [codeCopyError, setCodeCopyError] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const menuTriggerRef = useRef<HTMLButtonElement>(null);
   const { handleShare, copied, shared, shareError } = useShareLink({
@@ -77,12 +78,15 @@ export function RoomChrome({
   const joinUrl = `${window.location.origin}/join?code=${roomCode}`;
 
   const handleCopyCode = async () => {
+    setCodeCopyError(false);
     try {
+      if (!navigator.clipboard) throw new Error('Clipboard unavailable');
       await navigator.clipboard.writeText(roomCode);
       setCodeCopied(true);
       setTimeout(() => setCodeCopied(false), 2000);
     } catch {
-      // Clipboard unavailable — no-op
+      setCodeCopied(false);
+      setCodeCopyError(true);
     }
   };
 
@@ -162,18 +166,18 @@ export function RoomChrome({
                       setShowMenu(false);
                     }}
                     className={cn(
-                      'rounded-full border border-[var(--color-border)] bg-[var(--color-background)]/72 text-[0.6875rem] font-mono uppercase tracking-[0.28em] text-[var(--color-text-muted)] hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] transition-colors cursor-pointer',
+                      'min-h-[44px] rounded-full border border-[var(--color-border)] bg-[var(--color-background)]/72 text-[0.6875rem] font-mono uppercase tracking-[0.28em] text-[var(--color-text-muted)] hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] transition-colors cursor-pointer',
                       compact
                         ? 'max-w-full truncate px-[10px] py-[2px]'
                         : 'shrink-0 px-2.5 py-0.5'
                     )}
-                    aria-label={`Room code ${formatRoomCode(roomCode)} — tap to copy or scan QR`}
+                    aria-label={`Open QR and copy options for room code ${formatRoomCode(roomCode)}`}
                   >
                     Room {formatRoomCode(roomCode)}
                   </button>
 
                   {showQr && (
-                    <div className="lj-room-popover absolute left-0 top-full z-50 mt-3 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-lg)]">
+                    <div className="lj-room-popover absolute left-0 top-full z-50 mt-3 max-w-[calc(100vw-2rem)] rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-[var(--shadow-lg)]">
                       <div className="flex flex-col items-center gap-3">
                         <QRCodeSVG
                           value={joinUrl}
@@ -182,20 +186,32 @@ export function RoomChrome({
                           fgColor="var(--color-text-primary)"
                           bgColor="transparent"
                         />
-                        <div className="flex items-center gap-2 w-full">
+                        {codeCopyError && (
+                          <Alert variant="error" className="w-full text-xs">
+                            Couldn&apos;t copy the room code. Try again.
+                          </Alert>
+                        )}
+                        <div className="flex w-full items-center gap-2">
                           <button
                             type="button"
                             onClick={() => {
                               void handleCopyCode();
                             }}
-                            className="flex-1 rounded-full border border-[var(--color-border)] bg-[var(--color-background)] px-3 py-1.5 text-xs font-mono uppercase tracking-wider text-[var(--color-text-primary)] hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] transition-colors cursor-pointer"
+                            className="min-h-[44px] min-w-0 flex-1 rounded-full border border-[var(--color-border)] bg-[var(--color-background)] px-3 py-1.5 text-xs font-mono uppercase tracking-wider text-[var(--color-text-primary)] hover:border-[var(--color-primary)] hover:text-[var(--color-primary)] transition-colors cursor-pointer"
+                            aria-label={
+                              codeCopyError
+                                ? 'Retry copying room code'
+                                : codeCopied
+                                  ? 'Room code copied'
+                                  : 'Copy room code'
+                            }
                           >
-                            {codeCopied ? 'Copied!' : `Copy ${roomCode}`}
+                            {codeCopied ? 'Copied!' : 'Copy code'}
                           </button>
                           <button
                             type="button"
                             onClick={() => setShowQr(false)}
-                            className="shrink-0 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] p-1.5"
+                            className="flex h-[44px] w-[44px] shrink-0 items-center justify-center text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
                             aria-label="Close QR"
                           >
                             ✕

--- a/components/WaitingScreen.tsx
+++ b/components/WaitingScreen.tsx
@@ -296,7 +296,7 @@ export function WaitingScreen({
                   disabled={ghostState === 'summoning'}
                   variant="outline"
                   size="md"
-                  className="w-full"
+                  className="min-h-11 w-full"
                 >
                   {ghostState === 'summoning'
                     ? 'Summoning…'

--- a/components/WritingScreen.tsx
+++ b/components/WritingScreen.tsx
@@ -10,6 +10,7 @@ import { captureError } from '@/lib/error';
 import { errorToFeedback } from '@/lib/errorFeedback';
 import { cn } from '@/lib/utils';
 import { countWords } from '@/lib/wordCount';
+import { normalizeLineText } from '@/convex/lib/lineText';
 import { Alert } from '@/components/ui/Alert';
 import { RoomChrome } from '@/components/RoomChrome';
 import { Button } from '@/components/ui/Button';
@@ -89,7 +90,9 @@ function WritingComposer({
     assignment.poemId,
     assignment.lineIndex
   );
-  const [text, setText] = useState(() => readWritingDraft(draftKey));
+  const [text, setText] = useState(() =>
+    normalizeLineText(readWritingDraft(draftKey))
+  );
   const [draftWasRestored] = useState(() => text.length > 0);
   const [submissionState, setSubmissionState] = useState<
     'idle' | 'submitting' | 'confirmed'
@@ -137,6 +140,13 @@ function WritingComposer({
   const isValid = currentWordCount === targetCount;
   const isReady = isValid && submissionState === 'idle';
   const placeholderText = `write ${numberToWord(targetCount)} word${targetCount === 1 ? '' : 's'}…`;
+
+  const handleTextChange = (value: string) => {
+    // Keep the client contract one-line while preserving pasted content. The
+    // mutation applies the same whitespace collapse before storing the line.
+    setText(value.replace(/[\r\n]+/g, ' '));
+    setError(null);
+  };
 
   // Announce validation state changes to screen readers (debounced)
   useEffect(() => {
@@ -196,7 +206,7 @@ function WritingComposer({
       await submitLine({
         poemId: assignment.poemId,
         lineIndex: assignment.lineIndex,
-        text,
+        text: normalizeLineText(text),
         guestToken: guestToken || undefined,
       });
       clearWritingDraft(draftKey);
@@ -296,7 +306,7 @@ function WritingComposer({
                 <p className="mb-3 text-[0.625rem] font-mono uppercase tracking-widest text-primary">
                   Received line
                 </p>
-                <p className="text-2xl md:text-4xl lg:text-5xl font-[var(--font-display)] italic leading-relaxed text-text-secondary">
+                <p className="break-words text-2xl leading-relaxed [overflow-wrap:anywhere] md:text-4xl lg:text-5xl font-[var(--font-display)] italic text-text-secondary">
                   {assignment.previousLineText}
                 </p>
               </div>
@@ -315,7 +325,7 @@ function WritingComposer({
                     Reveal is next.
                   </p>
                 )}
-                <p className="text-lg italic font-[var(--font-display)] text-text-primary">
+                <p className="break-words text-lg italic font-[var(--font-display)] text-text-primary [overflow-wrap:anywhere]">
                   &ldquo;{text}&rdquo;
                 </p>
               </div>
@@ -332,7 +342,7 @@ function WritingComposer({
                 ref={textareaRef}
                 data-testid={E2E_TEST_IDS.writingLineInput}
                 className={cn(
-                  'w-full min-w-0 max-w-full min-h-[64px] md:min-h-[320px] lg:min-h-[360px] field-sizing-content overflow-x-hidden bg-transparent border-none outline-none resize-none',
+                  'w-full min-w-0 max-w-full min-h-[64px] md:min-h-[320px] lg:min-h-[360px] field-sizing-content overflow-x-hidden [overflow-wrap:anywhere] bg-transparent border-none outline-none resize-none',
                   'text-3xl md:text-5xl lg:text-6xl font-[var(--font-display)] leading-tight',
                   'text-text-primary',
                   'placeholder:text-text-muted/20',
@@ -340,18 +350,32 @@ function WritingComposer({
                 )}
                 placeholder={placeholderText}
                 value={text}
-                onChange={(e) => {
-                  setText(e.target.value);
-                  setError(null);
+                onChange={(e) => handleTextChange(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') e.preventDefault();
                 }}
                 onFocus={handleTextareaFocus}
                 onBlur={() => setHasFocus(false)}
                 spellCheck={false}
+                maxLength={500}
+                inputMode="text"
+                autoCapitalize="sentences"
+                autoCorrect="on"
+                enterKeyHint="done"
+                wrap="soft"
                 aria-label={`Write your line for round ${assignment.lineIndex + 1}. Target: ${targetCount} ${targetCount === 1 ? 'word' : 'words'}.`}
                 aria-required="true"
                 aria-invalid={!isValid}
-                aria-describedby="word-slots"
+                aria-describedby="word-slots line-length"
               />
+
+              <p
+                id="line-length"
+                aria-live="polite"
+                className="mt-2 pl-6 text-xs font-mono text-text-muted"
+              >
+                {text.length}/500 characters
+              </p>
 
               {/*
             Word chips sit tight against the line, left-aligned with the

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -16,6 +16,7 @@ import {
   isPresenceStale,
 } from './lib/gameRules';
 import { countWords } from './lib/wordCount';
+import { MAX_LINE_LENGTH, normalizeLineText } from './lib/lineText';
 import { getUser, checkParticipation } from './lib/auth';
 import {
   getRoomByCode,
@@ -34,8 +35,6 @@ import {
   buildRevealParticipants,
   selectRevealAuthority,
 } from './lib/revealAuthorization';
-
-const MAX_LINE_LENGTH = 500; // More than enough for 5 words
 
 export const startGame = mutation({
   args: {
@@ -316,15 +315,18 @@ export const submitLine = mutation({
     ];
     if (assignedUserId !== user._id) throw new ConvexError('Not your turn');
 
-    // Validate line length (prevent storage abuse)
+    // Validate line length (prevent storage abuse) before normalization.
     if (text.length > MAX_LINE_LENGTH) {
       throw new ConvexError(
         `Line must be ${MAX_LINE_LENGTH} characters or less`
       );
     }
 
+    // Collapse pasted tabs/newlines before counting and storing.
+    const normalizedText = normalizeLineText(text);
+
     // Validate word count against the poem shape
-    const wordCount = countWords(text);
+    const wordCount = countWords(normalizedText);
     const expectedCount = WORD_COUNTS[lineIndex];
     if (wordCount !== expectedCount) {
       throw new ConvexError(
@@ -335,7 +337,7 @@ export const submitLine = mutation({
     await ctx.db.insert('lines', {
       poemId,
       indexInPoem: lineIndex,
-      text: text.trim(),
+      text: normalizedText,
       wordCount,
       authorUserId: user._id,
       authorDisplayName: user.displayName,

--- a/convex/lib/lineText.ts
+++ b/convex/lib/lineText.ts
@@ -1,0 +1,6 @@
+export const MAX_LINE_LENGTH = 500;
+
+/** Collapse all whitespace so stored lines satisfy the one-line contract. */
+export function normalizeLineText(text: string): string {
+  return text.trim().replace(/\s+/g, ' ');
+}

--- a/tests/app/room-page.test.tsx
+++ b/tests/app/room-page.test.tsx
@@ -148,9 +148,13 @@ describe('RoomPage', () => {
     renderRoomPage();
 
     const title = await screen.findByText('Room not found');
-    const detail = screen.getByText(/room code may be incorrect/i);
+    const detail = screen.getByText(/room code is incorrect/i);
+    const recovery = screen.getByRole('button', { name: /return to join/i });
     expect(title.parentElement).toHaveClass('lj-safe-inline', 'text-center');
     expect(detail).toHaveClass('max-w-md');
+    expect(recovery).toHaveClass('min-h-11', 'w-full');
+    recovery.click();
+    expect(mockPush).toHaveBeenCalledWith('/join');
   });
 
   it('renders an explicit recovery state when room status is unknown', async () => {

--- a/tests/components/Lobby.test.tsx
+++ b/tests/components/Lobby.test.tsx
@@ -439,6 +439,7 @@ describe('Lobby component', () => {
     const removeAiButtons = screen.getAllByRole('button', {
       name: /Remove AI/i,
     });
+    expect(removeAiButtons[0]).toHaveClass('h-11', 'w-11');
 
     // Act
     await user.click(removeAiButtons[0]);

--- a/tests/components/RoomChrome.test.tsx
+++ b/tests/components/RoomChrome.test.tsx
@@ -200,6 +200,24 @@ describe('RoomChrome component', () => {
     });
   });
 
+  it('surfaces room-code clipboard failures and recovers on retry', async () => {
+    mockWriteText.mockRejectedValueOnce(new Error('clipboard blocked'));
+    renderRoomChrome();
+
+    fireEvent.click(screen.getByRole('button', { name: /Room code AB CD/i }));
+    fireEvent.click(screen.getByRole('button', { name: /copy room code/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /couldn.t copy the room code/i
+    );
+
+    mockWriteText.mockResolvedValueOnce(undefined);
+    fireEvent.click(
+      screen.getByRole('button', { name: /retry copying room code/i })
+    );
+    expect(await screen.findByText('Copied!')).toBeInTheDocument();
+  });
+
   it('uses native share when available', async () => {
     const nativeShare = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'share', {

--- a/tests/components/WritingScreen.test.tsx
+++ b/tests/components/WritingScreen.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { getFunctionName } from 'convex/server';
 
@@ -124,6 +130,23 @@ describe('WritingScreen component', () => {
 
     const wordSlots = document.getElementById('word-slots');
     expect(wordSlots).toBeInTheDocument();
+  });
+
+  it('declares the one-line 500-character mobile input contract', () => {
+    render(<WritingScreen roomCode="ABCD" />);
+
+    const textarea = screen.getByTestId(E2E_TEST_IDS.writingLineInput);
+    expect(textarea).toHaveAttribute('maxlength', '500');
+    expect(textarea).toHaveAttribute('inputmode', 'text');
+    expect(textarea).toHaveAttribute('autocapitalize', 'sentences');
+    expect(textarea).toHaveAttribute('autocorrect', 'on');
+    expect(textarea).toHaveAttribute('enterkeyhint', 'done');
+    expect(textarea).toHaveAttribute('wrap', 'soft');
+    expect(screen.getByText('0/500 characters')).toBeInTheDocument();
+
+    fireEvent.change(textarea, { target: { value: 'one\ntwo' } });
+    expect(textarea).toHaveValue('one two');
+    expect(screen.getByText('7/500 characters')).toBeInTheDocument();
   });
 
   it('owns the dynamic game viewport and reserves a non-overlapping action zone', () => {
@@ -292,6 +315,17 @@ describe('WritingScreen component', () => {
 
     expect(screen.getByRole('textbox')).toHaveValue('Recovered');
     expect(screen.getByText('Draft restored')).toBeInTheDocument();
+  });
+
+  it('normalizes a legacy multiline draft before rendering', () => {
+    sessionStorage.setItem(
+      'linejam:writing-draft:ABCD:poem_123:0',
+      '  Recovered\nline  '
+    );
+
+    render(<WritingScreen roomCode="ABCD" />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('Recovered line');
   });
 
   it('clears the saved draft once Convex confirms the line', async () => {

--- a/tests/convex/game.test.ts
+++ b/tests/convex/game.test.ts
@@ -1264,6 +1264,35 @@ describe('submitLine', () => {
     expect(line!.wordCount).toBe(1);
   });
 
+  it('collapses pasted whitespace before storing a line', async () => {
+    const t = setupConvexTest();
+    const { poemIds } = await seedInProgressGame(t, {
+      players: [
+        { name: 'Alice', clerkUserId: 'clerk_aliceSLWS' },
+        { name: 'Bob', clerkUserId: 'clerk_bobSLWS' },
+      ],
+      code: 'SLWS',
+      currentRound: 1,
+    });
+
+    await asUser(t, 'bobSLWS').mutation(api.game.submitLine, {
+      poemId: poemIds[0],
+      lineIndex: 1,
+      text: 'hello\nworld',
+    });
+
+    const line = await t.run((ctx) =>
+      ctx.db
+        .query('lines')
+        .withIndex('by_poem_index', (q) =>
+          q.eq('poemId', poemIds[0]).eq('indexInPoem', 1)
+        )
+        .first()
+    );
+    expect(line?.text).toBe('hello world');
+    expect(line?.wordCount).toBe(2);
+  });
+
   it('succeeds silently if line already submitted (idempotent)', async () => {
     const t = setupConvexTest();
     const { poemIds } = await seedInProgressGame(t, {

--- a/tests/e2e/game-mobile-viewport.spec.ts
+++ b/tests/e2e/game-mobile-viewport.spec.ts
@@ -521,7 +521,7 @@ test('the complete mobile game holds primary actions through keyboard, rotation,
     await session.hostPage.keyboard.press('Escape');
 
     await session.hostPage
-      .getByRole('button', { name: /Room code .*scan QR/i })
+      .getByRole('button', { name: /Open QR and copy options for room code/i })
       .click();
     const qrPopover = session.hostPage.locator('.lj-room-popover').filter({
       visible: true,


### PR DESCRIPTION
## Summary
- polish mobile room recovery, touch targets, writing input, and room-code QR/copy feedback
- normalize writing drafts and server-submitted lines to the one-line 500-character contract
- update mobile viewport selector and regression coverage

## Verification
- pnpm vitest run tests/components/WritingScreen.test.tsx tests/components/RoomChrome.test.tsx tests/components/Lobby.test.tsx tests/app/room-page.test.tsx tests/convex/game.test.ts
- pnpm typecheck:app
- pre-push gate: typecheck, lint, and full test suite (149 files, 1658 passed, 1 skipped)

Handoff: RevealPhase/PoemDisplay touch targets remain with linejam-972.