### PR TITLE
feat(analytics): add privacy-safe room cycle funnel

### DIFF
--- a/app/host/page.tsx
+++ b/app/host/page.tsx
@@ -6,7 +6,7 @@ import { useMutation } from 'convex/react';
 import { api } from '../../convex/_generated/api';
 import { useUser } from '../../lib/auth';
 import { captureError } from '../../lib/error';
-import { trackGameCreated } from '../../lib/analytics';
+import { hashRoomId, trackGameCreated } from '../../lib/analytics';
 import { errorToFeedback } from '../../lib/errorFeedback';
 import { E2E_TEST_IDS } from '../../lib/e2eTestIds';
 import { Button } from '../../components/ui/Button';
@@ -34,11 +34,15 @@ export default function HostPage() {
     setError(null); // Clear error before retry
 
     try {
-      const { code } = await createRoomMutation({
+      const { code, roomId } = await createRoomMutation({
         displayName: name,
         guestToken: guestToken || undefined,
       });
-      trackGameCreated();
+      trackGameCreated({
+        roomIdHash: hashRoomId(roomId),
+        cycle: 1,
+        playerKind: 'human',
+      });
       router.push(`/room/${code}`);
     } catch (err) {
       const feedback = errorToFeedback(err);

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -7,7 +7,7 @@ import { api } from '../../convex/_generated/api';
 import { useUser } from '../../lib/auth';
 import { captureError } from '../../lib/error';
 import { E2E_TEST_IDS } from '../../lib/e2eTestIds';
-import { trackGameJoined } from '../../lib/analytics';
+import { hashRoomId, trackGameJoined } from '../../lib/analytics';
 import { errorToFeedback } from '../../lib/errorFeedback';
 import { Alert } from '../../components/ui/Alert';
 import { Button } from '../../components/ui/Button';
@@ -43,12 +43,16 @@ function JoinForm() {
     setError('');
 
     try {
-      await joinRoomMutation({
+      const room = await joinRoomMutation({
         code: normalizedCode,
         displayName: normalizedName,
         guestToken: guestToken || undefined,
       });
-      trackGameJoined({ roomCode: normalizedCode });
+      trackGameJoined({
+        roomIdHash: hashRoomId(room._id),
+        cycle: room.currentCycle ?? 1,
+        playerKind: 'human',
+      });
       router.push(`/room/${normalizedCode}`);
     } catch (err) {
       const feedback = errorToFeedback(err);

--- a/app/recap/[code]/page.tsx
+++ b/app/recap/[code]/page.tsx
@@ -40,7 +40,11 @@ export default async function RecapPage({
           </div>
         </header>
 
-        <RecapExportButton poemCount={recap.poemCount} />
+        <RecapExportButton
+          poemCount={recap.poemCount}
+          roomIdHash={recap.roomIdHash}
+          cycle={recap.cycle}
+        />
 
         <section className="grid gap-8">
           {recap.poems.map((poem) => {

--- a/components/Lobby.tsx
+++ b/components/Lobby.tsx
@@ -17,7 +17,11 @@ import { LobbyStage } from './stage/LobbyStage';
 import { StampAnimation } from './ui/StampAnimation';
 import { Doc } from '../convex/_generated/dataModel';
 import { Bot, Presentation, UserMinus } from 'lucide-react';
-import { trackGameStarted, trackAiPlayerAdded } from '../lib/analytics';
+import {
+  hashRoomId,
+  trackGameStarted,
+  trackLobbyReady,
+} from '../lib/analytics';
 
 /**
  * Lobby layout keeps actions separate from the live player list.
@@ -60,10 +64,17 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
         code: room.code,
         guestToken: guestToken || undefined,
       });
-      trackGameStarted({
-        playerCount: players.length,
-        hasAi: players.some((p) => p.isBot),
-      });
+      // The mutation is authoritative and increments the cycle for rematches.
+      // Emit both transition stages only after it succeeds, so retries/failures
+      // cannot report a lobby as ready or use the previous cycle number.
+      const cycle = (room.currentCycle ?? 0) + 1;
+      const analyticsProps = {
+        roomIdHash: hashRoomId(room._id),
+        cycle,
+        playerKind: 'human' as const,
+      };
+      trackLobbyReady(analyticsProps);
+      trackGameStarted(analyticsProps);
     } catch (err) {
       const feedback = errorToFeedback(err);
       setError(feedback.message);
@@ -90,7 +101,8 @@ export function Lobby({ room, players, isHost }: LobbyProps) {
         code: room.code,
         guestToken: guestToken || undefined,
       });
-      trackAiPlayerAdded({ playerCount: players.length + 1 });
+      // AI seats are represented by playerKind on the canonical room event;
+      // no separate conversion event is emitted.
     } catch (err) {
       const feedback = errorToFeedback(err);
       setError(feedback.message);

--- a/components/PoemDisplay.tsx
+++ b/components/PoemDisplay.tsx
@@ -65,6 +65,9 @@ interface PoemDisplayProps {
   allStableIds?: string[];
   variant?: 'reveal' | 'archive';
   metadata?: PoemMetadata;
+  roomId?: string;
+  cycle?: number;
+  playerKind?: 'human' | 'AI';
 }
 
 function formatDate(timestamp: number): string {
@@ -81,6 +84,9 @@ export function PoemDisplay({
   allStableIds,
   variant = 'reveal',
   metadata,
+  roomId,
+  cycle = 1,
+  playerKind = 'human',
 }: PoemDisplayProps) {
   const isArchive = variant === 'archive';
 
@@ -105,11 +111,17 @@ export function PoemDisplay({
   const { handleShare, copied, shared, shareError } = useSharePoem(
     poemId,
     guestToken,
-    firstLineText
+    firstLineText,
+    roomId,
+    cycle,
+    playerKind
   );
   const { handleSaveImage, saving, saved, saveError } = useSavePoemImage(
     poemId,
-    guestToken
+    guestToken,
+    roomId,
+    cycle,
+    playerKind
   );
 
   // Get unique authors for legend (preserves order of first appearance)

--- a/components/RecapExportButton.tsx
+++ b/components/RecapExportButton.tsx
@@ -3,7 +3,7 @@
 import { Printer } from 'lucide-react';
 import { Button } from './ui/Button';
 import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
-import { trackRecapExported } from '@/lib/analytics';
+import { trackArtifactAction, trackRecapExported } from '@/lib/analytics';
 
 /**
  * Whole-set export for the public recap page (linejam-943 criteria 2 & 4).
@@ -11,9 +11,26 @@ import { trackRecapExported } from '@/lib/analytics';
  * in app/globals.css rather than a bespoke PDF/image renderer — every poem
  * on the page, laid out with app/globals.css's print rules, one action.
  */
-export function RecapExportButton({ poemCount }: { poemCount: number }) {
+export function RecapExportButton({
+  poemCount,
+  roomIdHash,
+  cycle = 1,
+}: {
+  poemCount: number;
+  roomIdHash?: string;
+  cycle?: number;
+}) {
   const handleExport = () => {
     trackRecapExported({ method: 'print', poemCount });
+    if (roomIdHash) {
+      trackArtifactAction({
+        roomIdHash,
+        cycle,
+        round: 8,
+        playerKind: 'human',
+        action: 'save',
+      });
+    }
     window.print();
   };
 

--- a/components/RevealPhase.tsx
+++ b/components/RevealPhase.tsx
@@ -15,7 +15,7 @@ import { LoadingState, LoadingMessages } from './ui/LoadingState';
 import { Avatar } from './ui/Avatar';
 import { BotBadge } from './ui/BotBadge';
 import { Id } from '../convex/_generated/dataModel';
-import { trackGameCompleted } from '../lib/analytics';
+import { hashRoomId, trackGameCompleted } from '../lib/analytics';
 import { RoomChrome } from './RoomChrome';
 import { buildRevealChromeCopy } from '../lib/roomChromeCopy';
 import { SessionRecapHub } from './SessionRecapHub';
@@ -66,12 +66,14 @@ export function RevealPhase({
 
     if (allRevealed && !hasTrackedCompletion.current) {
       hasTrackedCompletion.current = true;
-      const hasAi = players.some((p) => p.isBot);
-      trackGameCompleted({
-        playerCount: players.length,
-        poemCount: poems.length,
-        hasAi,
-      });
+      if (state.roomId && state.cycle && state.currentPlayerKind) {
+        trackGameCompleted({
+          roomIdHash: hashRoomId(state.roomId),
+          cycle: state.cycle,
+          round: poems.length > 0 ? 8 : 0,
+          playerKind: state.currentPlayerKind,
+        });
+      }
     }
   }, [state]);
 
@@ -182,6 +184,9 @@ export function RevealPhase({
           onDone={() => setShowingPoemId(null)}
           alreadyRevealed={displayingPoem.isRevealed}
           allStableIds={allStableIds}
+          roomId={state.roomId}
+          cycle={state.cycle}
+          playerKind={state.currentPlayerKind}
           metadata={{
             createdAt: displayingPoem.createdAt,
             firstLine: displayingPoem.preview,
@@ -387,6 +392,9 @@ export function RevealPhase({
           {allRevealed && (
             <SessionRecapHub
               roomCode={roomCode}
+              roomId={state.roomId}
+              cycle={state.cycle}
+              playerKind={state.currentPlayerKind}
               guestToken={guestToken || undefined}
               poems={poems}
               playerCount={state.players.length}

--- a/components/SessionRecapHub.tsx
+++ b/components/SessionRecapHub.tsx
@@ -6,7 +6,11 @@ import { useMutation, useQuery } from 'convex/react';
 import { Crown, Heart, Share2, Volume2, VolumeX } from 'lucide-react';
 import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
-import { trackRoomInviteShared } from '@/lib/analytics';
+import {
+  hashRoomId,
+  trackArtifactAction,
+  trackRoomInviteShared,
+} from '@/lib/analytics';
 import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
 import { useShareLink } from '@/hooks/useShareLink';
 import { useCeremonyEffects } from '@/hooks/useCeremonyEffects';
@@ -23,6 +27,9 @@ export interface SessionRecapPoem {
 
 interface SessionRecapHubProps {
   roomCode: string;
+  roomId?: string;
+  cycle?: number;
+  playerKind?: 'human' | 'AI';
   guestToken?: string;
   poems: SessionRecapPoem[];
   playerCount: number;
@@ -39,6 +46,9 @@ function sessionRecapUrl(roomCode: string) {
 
 export function SessionRecapHub({
   roomCode,
+  roomId,
+  cycle,
+  playerKind,
   guestToken,
   poems,
   playerCount,
@@ -78,6 +88,13 @@ export function SessionRecapHub({
     }),
     onShared: (method) => {
       trackRoomInviteShared({ method, roomCode });
+      trackArtifactAction({
+        roomIdHash: hashRoomId(roomId ?? roomCode),
+        cycle: cycle ?? 1,
+        round: poems.length > 0 ? 8 : 0,
+        playerKind: playerKind ?? 'human',
+        action: 'share',
+      });
     },
     failureMessage: 'Failed to share recap. Please try again.',
   });

--- a/components/WritingScreen.tsx
+++ b/components/WritingScreen.tsx
@@ -9,6 +9,7 @@ import { E2E_TEST_IDS } from '@/lib/e2eTestIds';
 import { captureError } from '@/lib/error';
 import { errorToFeedback } from '@/lib/errorFeedback';
 import { cn } from '@/lib/utils';
+import { hashRoomId, trackLineSubmitted } from '@/lib/analytics';
 import { countWords } from '@/lib/wordCount';
 import { Alert } from '@/components/ui/Alert';
 import { RoomChrome } from '@/components/RoomChrome';
@@ -36,6 +37,9 @@ const WRITING_COACHMARK_STORAGE_KEY = 'linejam:writing-coachmark-seen';
 
 interface WritingAssignment {
   poemId: Id<'poems'>;
+  roomId: string;
+  cycle: number;
+  playerKind: 'human' | 'AI';
   lineIndex: number;
   targetWordCount: number;
   totalRounds?: number;
@@ -200,6 +204,12 @@ function WritingComposer({
         guestToken: guestToken || undefined,
       });
       clearWritingDraft(draftKey);
+      trackLineSubmitted({
+        roomIdHash: hashRoomId(assignment.roomId),
+        cycle: assignment.cycle,
+        round: assignment.lineIndex,
+        playerKind: assignment.playerKind,
+      });
 
       // Show confirmation state briefly before transitioning to waiting
       setSubmissionState('confirmed');

--- a/components/WritingScreen.tsx
+++ b/components/WritingScreen.tsx
@@ -204,12 +204,21 @@ function WritingComposer({
         guestToken: guestToken || undefined,
       });
       clearWritingDraft(draftKey);
-      trackLineSubmitted({
-        roomIdHash: hashRoomId(assignment.roomId),
-        cycle: assignment.cycle,
-        round: assignment.lineIndex,
-        playerKind: assignment.playerKind,
-      });
+      // Telemetry is best-effort: a tracking failure (e.g. deploy-skew
+      // assignment payloads without funnel fields) must never surface as a
+      // submit error for a line that already persisted.
+      try {
+        if (assignment.roomId) {
+          trackLineSubmitted({
+            roomIdHash: hashRoomId(assignment.roomId),
+            cycle: assignment.cycle,
+            round: assignment.lineIndex,
+            playerKind: assignment.playerKind,
+          });
+        }
+      } catch {
+        // Analytics must not break gameplay.
+      }
 
       // Show confirmation state briefly before transitioning to waiting
       setSubmissionState('confirmed');

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -242,6 +242,9 @@ export const getCurrentAssignment = query({
 
     return {
       poemId: poem._id,
+      roomId: room._id,
+      cycle: game.cycle,
+      playerKind: user.kind === 'AI' ? ('AI' as const) : ('human' as const),
       lineIndex: currentRound,
       targetWordCount: WORD_COUNTS[currentRound],
       totalRounds: game.assignmentMatrix.length,
@@ -616,6 +619,13 @@ export const getRevealPhaseState = query({
     const myPoem = myPoems.length > 0 ? myPoems[0] : null;
 
     return {
+      roomId: room._id,
+      cycle: game.cycle,
+      currentPlayerKind:
+        playerUserRecords.find((record) => record?._id === user._id)?.kind ===
+        'AI'
+          ? ('AI' as const)
+          : ('human' as const),
       poems: poemsWithPreview,
       myPoem,
       myPoems,

--- a/convex/poems.ts
+++ b/convex/poems.ts
@@ -8,6 +8,7 @@ import {
   isPublicSessionRecapEnabled,
 } from './lib/sharing';
 import { buildPoemAuthorKeys } from './lib/poemAuthorKey';
+import { hashRoomId } from '../lib/roomIdHash';
 
 const DEFAULT_MY_POEMS_LIMIT = 24;
 const MAX_MY_POEMS_LIMIT = 48;
@@ -334,6 +335,7 @@ export const getPublicSessionRecap = query({
 
     return {
       roomCode: room.code,
+      roomIdHash: hashRoomId(room._id),
       cycle: game.cycle,
       completedAt: game.completedAt,
       poemCount: poems.length,

--- a/docs/analytics-room-cycle.md
+++ b/docs/analytics-room-cycle.md
@@ -1,0 +1,19 @@
+# Canonical room-cycle analytics
+
+PostHog is the single client analytics seam for the room-cycle funnel. Events are best-effort and counts are deduplicated by the report; the Convex room projection is authoritative for lifecycle stages.
+
+| Stage            | Event             | Properties                                             | Source and notes                                                                                            |
+| ---------------- | ----------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| Create           | `game_created`    | `roomIdHash`, `cycle`, `playerKind`                    | Event-derived; emitted after room creation succeeds.                                                        |
+| Join             | `game_joined`     | `roomIdHash`, `cycle`, `playerKind`                    | Event-derived; emitted after join succeeds.                                                                 |
+| Lobby ready      | `lobby_ready`     | `roomIdHash`, `cycle`, `playerKind`                    | Event-derived transition; emitted after start mutation succeeds.                                            |
+| Start            | `game_started`    | `roomIdHash`, `cycle`, `playerKind`                    | Server-derived report stage; client event is a best-effort mirror. Cycle is the authoritative next cycle.   |
+| Per-round submit | `line_submitted`  | `roomIdHash`, `cycle`, `round`, `playerKind`           | Event-derived; `round` is zero-based (0–8). One retry-safe event per room/cycle/round/player kind.          |
+| Reveal           | `game_completed`  | `roomIdHash`, `cycle`, `round`, `playerKind`           | Server-derived report stage; `round` is 8 for the final round.                                              |
+| Share/save       | `artifact_action` | `roomIdHash`, `cycle`, `round`, `playerKind`, `action` | Event-derived; `action` is `share` or `save`, and only validated human actions for known room cycles count. |
+
+Canonical properties contain no poem text, room code, guest token, guest id, display name, or durable guest identifier. `roomIdHash` is a non-PII internal join key and never appears in report output. Legacy product signals such as `poem_shared`, `poem_image_saved`, `recap_exported`, and `room_invite_shared` remain separate from the canonical funnel and are not consumed by the report.
+
+## Report semantics
+
+`analytics:room-cycle` accepts a bounded server projection plus PostHog events and prints counts only. The cohort is rooms created in the requested half-open window with at least two distinct server-projected human participants. The first cycle is the conversion journey: start, writing completion, and all-revealed require finite in-window server timestamps and a non-abandoned cycle. Later in-window started cycles count as encore. Artifact actions are event-derived and are collapsed by room/cycle/round/player/action, so retries and share/save repeats do not inflate unique-room conversion. The output labels each metric `server-derived` or `event-derived` and never includes room, participant, poem, or guest fields.

--- a/hooks/useSavePoemImage.ts
+++ b/hooks/useSavePoemImage.ts
@@ -3,7 +3,11 @@
 import { useCallback, useState } from 'react';
 import { Id } from '@/convex/_generated/dataModel';
 import { captureError } from '@/lib/error';
-import { trackPoemImageSaved } from '@/lib/analytics';
+import {
+  hashRoomId,
+  trackArtifactAction,
+  trackPoemImageSaved,
+} from '@/lib/analytics';
 import { getAppliedTheme } from '@/lib/themes';
 
 export type SaveImageStatus = 'idle' | 'saving' | 'saved' | 'error';
@@ -21,7 +25,13 @@ export type SaveImageStatus = 'idle' | 'saving' | 'saved' | 'error';
  * ancestor, and `getAppliedTheme()` degrades to the kenya/light default the
  * card route already falls back to when nothing is applied yet (SSR, tests).
  */
-export function useSavePoemImage(poemId: Id<'poems'>, guestToken?: string) {
+export function useSavePoemImage(
+  poemId: Id<'poems'>,
+  guestToken?: string,
+  roomId?: string,
+  cycle = 1,
+  playerKind: 'human' | 'AI' = 'human'
+) {
   const [status, setStatus] = useState<SaveImageStatus>('idle');
   const [error, setError] = useState<string | null>(null);
 
@@ -56,6 +66,14 @@ export function useSavePoemImage(poemId: Id<'poems'>, guestToken?: string) {
           await navigator.share({ files: [file], title: 'Linejam poem' });
           setStatus('saved');
           trackPoemImageSaved({ method: 'native-share' });
+          if (roomId)
+            trackArtifactAction({
+              roomIdHash: hashRoomId(roomId),
+              cycle,
+              round: 8,
+              playerKind,
+              action: 'save',
+            });
           return;
         } catch (shareErr) {
           if (
@@ -80,12 +98,20 @@ export function useSavePoemImage(poemId: Id<'poems'>, guestToken?: string) {
 
       setStatus('saved');
       trackPoemImageSaved({ method: 'download' });
+      if (roomId)
+        trackArtifactAction({
+          roomIdHash: hashRoomId(roomId),
+          cycle,
+          round: 8,
+          playerKind,
+          action: 'save',
+        });
     } catch (err) {
       setStatus('error');
       setError('Failed to save image. Please try again.');
       captureError(err, { operation: 'savePoemImage', poemId });
     }
-  }, [poemId, guestToken]);
+  }, [poemId, guestToken, roomId, cycle, playerKind]);
 
   return {
     handleSaveImage,

--- a/hooks/useSharePoem.ts
+++ b/hooks/useSharePoem.ts
@@ -4,7 +4,11 @@ import { useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
 import { captureError } from '@/lib/error';
-import { trackPoemShared } from '@/lib/analytics';
+import {
+  hashRoomId,
+  trackArtifactAction,
+  trackPoemShared,
+} from '@/lib/analytics';
 import { useShareLink } from '@/hooks/useShareLink';
 
 function buildPoemShareText(openingLine?: string) {
@@ -19,7 +23,10 @@ function buildPoemShareText(openingLine?: string) {
 export function useSharePoem(
   poemId: Id<'poems'>,
   guestToken?: string,
-  openingLine?: string
+  openingLine?: string,
+  roomId?: string,
+  cycle = 1,
+  playerKind: 'human' | 'AI' = 'human'
 ) {
   const enablePublicPoemShare = useMutation(api.shares.enablePublicPoemShare);
 
@@ -37,6 +44,15 @@ export function useSharePoem(
     }),
     onShared: (method) => {
       trackPoemShared({ method });
+      if (roomId) {
+        trackArtifactAction({
+          roomIdHash: hashRoomId(roomId),
+          cycle,
+          round: 8,
+          playerKind,
+          action: 'share',
+        });
+      }
     },
     onError: (err) => {
       captureError(err, { operation: 'sharePoem', poemId });

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,127 +1,120 @@
 'use client';
 
 /**
- * Lightweight analytics tracking for key user actions.
- *
- * Uses the initialized PostHog client for privacy-safe funnel metrics:
- * - game_created, game_joined, game_started, game_completed
- * - poem_shared, ai_player_added
- * - poem_image_saved, recap_exported (linejam-943: the keepable-artifact
- *   funnel — measures save/export usage so the print-on-demand stretch
- *   decision has real demand data behind it)
- *
+ * Canonical room-cycle funnel events. PostHog is the sole client analytics
+ * provider; event properties deliberately contain no room code, guest token,
+ * guest id, display name, poem text, or other durable user identifier.
  */
-
 import posthog from 'posthog-js';
 import { posthogIsReady } from '@/lib/posthog/posthogReady';
 
-function capture(event: string, properties: Record<string, unknown> = {}) {
+export type PlayerKind = 'human' | 'AI';
+export type ArtifactAction = 'share' | 'save';
+
+export type RoomCycleEventProps = {
+  /** Stable one-way room key. Never pass a room code directly. */
+  roomIdHash: string;
+  cycle: number;
+  playerKind: PlayerKind;
+  round?: number;
+};
+
+export type ArtifactActionProps = RoomCycleEventProps & {
+  action: ArtifactAction;
+};
+
+const capturedEvents = new Set<string>();
+
+function capture(
+  event: string,
+  properties: RoomCycleEventProps | ArtifactActionProps
+) {
   if (!posthogIsReady()) return;
+
+  // Convex mutations and browser retries are idempotent. Keep the matching
+  // client event idempotent too so one room/cycle/round cannot inflate a
+  // conversion when a submit or navigation is retried.
+  const key = [
+    event,
+    properties.roomIdHash,
+    properties.cycle,
+    properties.round ?? '',
+    properties.playerKind,
+    'action' in properties ? properties.action : '',
+  ].join(':');
+  if (capturedEvents.has(key)) return;
+  capturedEvents.add(key);
   posthog.capture(event, properties);
 }
 
-type GameCreatedProps = {
-  playerCount?: number;
-};
+export { hashRoomId } from '@/lib/roomIdHash';
 
-type GameJoinedProps = {
-  roomCode: string;
-};
-
-type GameStartedProps = {
-  playerCount: number;
-  hasAi: boolean;
-};
-
-type GameCompletedProps = {
-  playerCount: number;
-  poemCount: number;
-  hasAi: boolean;
-};
-
-type PoemSharedProps = {
-  method: 'clipboard' | 'native-share';
-};
-
-type RoomInviteSharedProps = {
-  method: 'clipboard' | 'native-share';
-  roomCode: string;
-};
-
-type AiPlayerAddedProps = {
-  playerCount: number;
-};
-
-type PoemImageSavedProps = {
-  method: 'native-share' | 'download';
-};
-
-type RecapExportedProps = {
-  method: 'print';
-  poemCount: number;
-};
-
-/**
- * Track game creation by host.
- */
-export function trackGameCreated(props?: GameCreatedProps) {
-  capture('game_created', props ?? {});
+export function trackGameCreated(props: RoomCycleEventProps) {
+  capture('game_created', props);
 }
 
-/**
- * Track player joining a room.
- */
-export function trackGameJoined(props: GameJoinedProps) {
+export function trackGameJoined(props: RoomCycleEventProps) {
   capture('game_joined', props);
 }
 
-/**
- * Track game start (host clicks Start).
- */
-export function trackGameStarted(props: GameStartedProps) {
+export function trackLobbyReady(props: RoomCycleEventProps) {
+  capture('lobby_ready', props);
+}
+
+export function trackGameStarted(props: RoomCycleEventProps) {
   capture('game_started', props);
 }
 
-/**
- * Track game completion (all poems revealed).
- */
-export function trackGameCompleted(props: GameCompletedProps) {
+export function trackLineSubmitted(props: RoomCycleEventProps) {
+  capture('line_submitted', props);
+}
+
+export function trackGameCompleted(props: RoomCycleEventProps) {
   capture('game_completed', props);
 }
 
-/**
- * Track poem shared via clipboard.
- */
-export function trackPoemShared(props: PoemSharedProps) {
-  capture('poem_shared', props);
+export function trackArtifactAction(props: ArtifactActionProps) {
+  capture('artifact_action', props);
 }
 
-/**
- * Track room invite sharing from the in-room chrome.
- */
-export function trackRoomInviteShared(props: RoomInviteSharedProps) {
-  capture('room_invite_shared', props);
+/** Test seam: reset only in tests; no production caller should need this. */
+export function resetCapturedAnalyticsForTests() {
+  capturedEvents.clear();
 }
 
-/**
- * Track AI player added to room.
- */
-export function trackAiPlayerAdded(props: AiPlayerAddedProps) {
-  capture('ai_player_added', props);
+// Existing non-funnel product signals remain available to their focused UI
+// tests and consumers. The room-cycle report only consumes canonical events.
+export function trackAiPlayerAdded(props: { playerCount: number }) {
+  if (!posthogIsReady()) return;
+  posthog.capture('ai_player_added', props);
 }
 
-/**
- * Track a poem's themed card image being saved (native share sheet or
- * direct download) from the reveal or poem archive page.
- */
-export function trackPoemImageSaved(props: PoemImageSavedProps) {
-  capture('poem_image_saved', props);
+export function trackPoemShared(props: {
+  method: 'clipboard' | 'native-share';
+}) {
+  if (!posthogIsReady()) return;
+  posthog.capture('poem_shared', props);
 }
 
-/**
- * Track a session recap export (currently: print-to-PDF via the browser's
- * native print dialog, triggered from the recap page's Export action).
- */
-export function trackRecapExported(props: RecapExportedProps) {
-  capture('recap_exported', props);
+export function trackPoemImageSaved(props: {
+  method: 'native-share' | 'download';
+}) {
+  if (!posthogIsReady()) return;
+  posthog.capture('poem_image_saved', props);
+}
+
+export function trackRecapExported(props: {
+  method: 'print';
+  poemCount: number;
+}) {
+  if (!posthogIsReady()) return;
+  posthog.capture('recap_exported', props);
+}
+
+export function trackRoomInviteShared(props: {
+  method: 'clipboard' | 'native-share';
+  roomCode: string;
+}) {
+  if (!posthogIsReady()) return;
+  posthog.capture('room_invite_shared', props);
 }

--- a/lib/analytics/roomCycleFunnel.ts
+++ b/lib/analytics/roomCycleFunnel.ts
@@ -222,7 +222,6 @@ export function buildRoomCycleFunnelReport(
   const humanRooms = cohort.filter(
     (room) => uniqueHumanParticipants(room).size >= 2
   );
-  const humanRoomKeys = new Set(humanRooms.map((room) => room.roomIdHash));
   const firstCycles = humanRooms.map((room) => room.cycles[0]);
 
   const started = firstCycles.filter((cycle) =>

--- a/lib/analytics/roomCycleFunnel.ts
+++ b/lib/analytics/roomCycleFunnel.ts
@@ -1,0 +1,303 @@
+export type FunnelStage =
+  | 'human_room'
+  | 'game_started'
+  | 'writing_completed'
+  | 'all_revealed'
+  | 'encore'
+  | 'artifact_action';
+
+export type FunnelSource = 'server-derived' | 'event-derived';
+
+export type FunnelEvent = {
+  event: string;
+  occurredAt: number;
+  roomIdHash: string;
+  cycle: number;
+  playerKind: 'human' | 'AI';
+  round?: number;
+  action?: 'share' | 'save';
+};
+
+export type RoomCycleSnapshot = {
+  /** Internal join key. It is never returned by the report. */
+  roomIdHash: string;
+  createdAt: number;
+  joins: Array<{
+    joinedAt: number;
+    playerKind: 'human' | 'AI';
+    /** Stable server projection key; do not use a timestamp as identity. */
+    participantKey?: string;
+  }>;
+  cycles: Array<{
+    cycle: number;
+    startedAt?: number;
+    writingCompletedAt?: number;
+    allRevealedAt?: number;
+    completionKind?: 'normal' | 'abandoned';
+  }>;
+};
+
+export type RoomCycleFunnelInput = {
+  from: number;
+  to: number;
+  rooms: RoomCycleSnapshot[];
+  events: FunnelEvent[];
+};
+
+type Metric = {
+  count: number;
+  rate: number;
+  source: FunnelSource;
+};
+
+export type RoomCycleFunnelReport = {
+  window: { from: string; to: string };
+  cohort: { uniqueHumanRooms: number; source: 'server-derived' };
+  metrics: {
+    humanRoomsWithTwoPlusJoins: Metric;
+    gameStarted: Metric;
+    writingCompleted: Metric;
+    allRevealed: Metric;
+    encore: Metric;
+    artifactAction: Metric;
+  };
+  timeToStartSeconds: {
+    count: number;
+    median: number | null;
+    p90: number | null;
+    source: 'server-derived';
+  };
+};
+
+function isFiniteTimestamp(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function inWindow(timestamp: unknown, from: number, to: number) {
+  return isFiniteTimestamp(timestamp) && timestamp >= from && timestamp < to;
+}
+
+function quantile(values: number[], percentile: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.ceil(percentile * sorted.length) - 1
+  );
+  return sorted[index];
+}
+
+function metric(
+  count: number,
+  denominator: number,
+  source: FunnelSource
+): Metric {
+  return {
+    count,
+    rate: denominator === 0 ? 0 : Number((count / denominator).toFixed(4)),
+    source,
+  };
+}
+
+function earliestDefined(a?: number, b?: number) {
+  if (isFiniteTimestamp(a) && isFiniteTimestamp(b)) return Math.min(a, b);
+  return isFiniteTimestamp(a) ? a : b;
+}
+
+function mergeRooms(rooms: RoomCycleSnapshot[]) {
+  const byRoom = new Map<string, RoomCycleSnapshot>();
+  for (const room of rooms) {
+    if (
+      !room ||
+      typeof room.roomIdHash !== 'string' ||
+      room.roomIdHash.length === 0
+    )
+      continue;
+    const previous = byRoom.get(room.roomIdHash);
+    if (!previous) {
+      byRoom.set(room.roomIdHash, {
+        ...room,
+        joins: [...(room.joins ?? [])],
+        cycles: [...(room.cycles ?? [])],
+      });
+      continue;
+    }
+    previous.createdAt = Math.min(previous.createdAt, room.createdAt);
+    previous.joins.push(...(room.joins ?? []));
+    previous.cycles.push(...(room.cycles ?? []));
+  }
+  return [...byRoom.values()].map((room) => {
+    const cyclesByNumber = new Map<
+      number,
+      RoomCycleSnapshot['cycles'][number]
+    >();
+    for (const cycle of room.cycles) {
+      if (!Number.isInteger(cycle.cycle) || cycle.cycle < 1) continue;
+      const previous = cyclesByNumber.get(cycle.cycle);
+      if (!previous) {
+        cyclesByNumber.set(cycle.cycle, { ...cycle });
+        continue;
+      }
+      previous.startedAt = earliestDefined(previous.startedAt, cycle.startedAt);
+      previous.writingCompletedAt = earliestDefined(
+        previous.writingCompletedAt,
+        cycle.writingCompletedAt
+      );
+      previous.allRevealedAt = earliestDefined(
+        previous.allRevealedAt,
+        cycle.allRevealedAt
+      );
+      if (previous.completionKind === undefined) {
+        previous.completionKind = cycle.completionKind;
+      }
+    }
+    return {
+      ...room,
+      cycles: [...cyclesByNumber.values()].sort((a, b) => a.cycle - b.cycle),
+    };
+  });
+}
+
+function uniqueHumanParticipants(room: RoomCycleSnapshot) {
+  return new Set(
+    room.joins
+      .filter(
+        (join) =>
+          join.playerKind === 'human' &&
+          typeof join.participantKey === 'string' &&
+          join.participantKey.length > 0
+      )
+      .map((join) => join.participantKey as string)
+  );
+}
+
+function validArtifactEvent(
+  event: FunnelEvent,
+  room: RoomCycleSnapshot,
+  from: number,
+  to: number
+) {
+  if (
+    event.event !== 'artifact_action' ||
+    event.playerKind !== 'human' ||
+    (event.action !== 'share' && event.action !== 'save') ||
+    !inWindow(event.occurredAt, from, to) ||
+    !Number.isInteger(event.cycle) ||
+    event.cycle < 1
+  ) {
+    return false;
+  }
+  if (
+    event.round !== undefined &&
+    (!Number.isInteger(event.round) || event.round < 0 || event.round > 8)
+  ) {
+    return false;
+  }
+  return room.cycles.some((cycle) => cycle.cycle === event.cycle);
+}
+
+/**
+ * Build a counts-only room-cycle report from a bounded server projection and
+ * PostHog events. Room keys, participant keys, poem text, and guest data are
+ * used only in memory; none can appear in the returned report.
+ *
+ * The first cycle is the conversion journey. Later started cycles count only as
+ * encore, so an abandoned rematch cannot retroactively make the first journey
+ * look complete. Artifact actions remain event-derived and are joined to a
+ * known room/cycle after strict validation and retry deduplication.
+ */
+export function buildRoomCycleFunnelReport(
+  input: RoomCycleFunnelInput
+): RoomCycleFunnelReport {
+  if (!isFiniteTimestamp(input.from) || !isFiniteTimestamp(input.to)) {
+    throw new Error('Funnel window bounds must be finite timestamps');
+  }
+  if (input.to <= input.from) {
+    throw new Error('Funnel window end must be after its start');
+  }
+
+  const cohort = mergeRooms(input.rooms ?? []).filter((room) =>
+    inWindow(room.createdAt, input.from, input.to)
+  );
+  const humanRooms = cohort.filter(
+    (room) => uniqueHumanParticipants(room).size >= 2
+  );
+  const humanRoomKeys = new Set(humanRooms.map((room) => room.roomIdHash));
+  const firstCycles = humanRooms.map((room) => room.cycles[0]);
+
+  const started = firstCycles.filter((cycle) =>
+    inWindow(cycle?.startedAt, input.from, input.to)
+  );
+  const writingCompleted = firstCycles.filter(
+    (cycle) =>
+      cycle?.completionKind !== 'abandoned' &&
+      inWindow(cycle?.writingCompletedAt, input.from, input.to)
+  );
+  const allRevealed = firstCycles.filter(
+    (cycle) =>
+      cycle?.completionKind !== 'abandoned' &&
+      inWindow(cycle?.allRevealedAt, input.from, input.to)
+  );
+  const encore = humanRooms.filter((room) =>
+    room.cycles
+      .slice(1)
+      .some((cycle) => inWindow(cycle.startedAt, input.from, input.to))
+  );
+  const startDurations = started
+    .map(
+      (cycle, index) =>
+        ((cycle!.startedAt as number) - humanRooms[index].createdAt) / 1000
+    )
+    .filter((seconds) => seconds >= 0 && Number.isFinite(seconds));
+
+  const seenEvents = new Set<string>();
+  const artifactRooms = new Set<string>();
+  const roomsByKey = new Map(humanRooms.map((room) => [room.roomIdHash, room]));
+  for (const event of input.events ?? []) {
+    const room = roomsByKey.get(event.roomIdHash);
+    if (!room || !validArtifactEvent(event, room, input.from, input.to))
+      continue;
+    const key = [
+      event.event,
+      event.roomIdHash,
+      event.cycle,
+      event.round ?? '',
+      event.playerKind,
+      event.action,
+    ].join(':');
+    if (seenEvents.has(key)) continue;
+    seenEvents.add(key);
+    artifactRooms.add(event.roomIdHash);
+  }
+
+  const denominator = humanRooms.length;
+  return {
+    window: {
+      from: new Date(input.from).toISOString(),
+      to: new Date(input.to).toISOString(),
+    },
+    cohort: { uniqueHumanRooms: denominator, source: 'server-derived' },
+    metrics: {
+      humanRoomsWithTwoPlusJoins: metric(
+        denominator,
+        denominator,
+        'server-derived'
+      ),
+      gameStarted: metric(started.length, denominator, 'server-derived'),
+      writingCompleted: metric(
+        writingCompleted.length,
+        denominator,
+        'server-derived'
+      ),
+      allRevealed: metric(allRevealed.length, denominator, 'server-derived'),
+      encore: metric(encore.length, denominator, 'server-derived'),
+      artifactAction: metric(artifactRooms.size, denominator, 'event-derived'),
+    },
+    timeToStartSeconds: {
+      count: startDurations.length,
+      median: quantile(startDurations, 0.5),
+      p90: quantile(startDurations, 0.9),
+      source: 'server-derived',
+    },
+  };
+}

--- a/lib/roomIdHash.ts
+++ b/lib/roomIdHash.ts
@@ -1,0 +1,13 @@
+/** Deterministic, non-identifying key used for analytics correlation. */
+export function hashRoomId(roomId: string): string {
+  let first = 0x811c9dc5;
+  let second = 0x9e3779b9;
+  for (let i = 0; i < roomId.length; i++) {
+    const code = roomId.charCodeAt(i);
+    first = Math.imul(first ^ code, 0x01000193);
+    second = Math.imul(second ^ (code + i), 0x85ebca6b);
+  }
+  return [first >>> 0, second >>> 0]
+    .map((part) => part.toString(16).padStart(8, '0'))
+    .join('');
+}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "evidence:static-server": "node scripts/evidence/static-server.mjs",
     "generate:releases": "tsx scripts/generate-releases.ts",
     "agent:cli": "npx tsx scripts/cli/linejam-cli.ts",
-    "agent:mcp": "npx tsx scripts/mcp/linejam-mcp.ts"
+    "agent:mcp": "npx tsx scripts/mcp/linejam-mcp.ts",
+    "analytics:room-cycle": "tsx scripts/analytics/room-cycle-funnel.ts"
   },
   "dependencies": {
     "@clerk/nextjs": "^6.39.6",

--- a/scripts/analytics-room-cycle-sample.json
+++ b/scripts/analytics-room-cycle-sample.json
@@ -1,0 +1,56 @@
+{
+  "rooms": [
+    {
+      "roomIdHash": "0123456789abcdef",
+      "createdAt": 1770000000000,
+      "joins": [
+        {
+          "joinedAt": 1770000000100,
+          "playerKind": "human",
+          "participantKey": "sample-human-a"
+        },
+        {
+          "joinedAt": 1770000000200,
+          "playerKind": "human",
+          "participantKey": "sample-human-b"
+        },
+        {
+          "joinedAt": 1770000000300,
+          "playerKind": "AI"
+        }
+      ],
+      "cycles": [
+        {
+          "cycle": 1,
+          "startedAt": 1770000001000,
+          "writingCompletedAt": 1770000031000,
+          "allRevealedAt": 1770000035000,
+          "completionKind": "normal"
+        },
+        {
+          "cycle": 2,
+          "startedAt": 1770000040000,
+          "completionKind": "abandoned"
+        }
+      ]
+    }
+  ],
+  "events": [
+    {
+      "event": "artifact_action",
+      "occurredAt": 1770000036000,
+      "roomIdHash": "0123456789abcdef",
+      "cycle": 1,
+      "playerKind": "human",
+      "action": "save"
+    },
+    {
+      "event": "artifact_action",
+      "occurredAt": 1770000036000,
+      "roomIdHash": "0123456789abcdef",
+      "cycle": 1,
+      "playerKind": "human",
+      "action": "save"
+    }
+  ]
+}

--- a/scripts/analytics/room-cycle-funnel.ts
+++ b/scripts/analytics/room-cycle-funnel.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env tsx
+import { readFile } from 'node:fs/promises';
+import {
+  buildRoomCycleFunnelReport,
+  type RoomCycleFunnelInput,
+} from '../../lib/analytics/roomCycleFunnel';
+
+function readFlag(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+async function main() {
+  const inputPath = readFlag('--input');
+  const from = readFlag('--from');
+  const to = readFlag('--to');
+  if (!inputPath || !from || !to) {
+    console.error(
+      'Usage: pnpm analytics:room-cycle -- --input <projection.json> --from <ISO> --to <ISO>'
+    );
+    process.exitCode = 2;
+    return;
+  }
+  const fromTimestamp = Date.parse(from);
+  const toTimestamp = Date.parse(to);
+  if (
+    !Number.isFinite(fromTimestamp) ||
+    !Number.isFinite(toTimestamp) ||
+    toTimestamp <= fromTimestamp
+  ) {
+    console.error(
+      'Invalid funnel window: provide finite ISO timestamps with --to after --from'
+    );
+    process.exitCode = 2;
+    return;
+  }
+  const input = JSON.parse(await readFile(inputPath, 'utf8')) as Omit<
+    RoomCycleFunnelInput,
+    'from' | 'to'
+  >;
+  const report = buildRoomCycleFunnelReport({
+    ...input,
+    from: fromTimestamp,
+    to: toTimestamp,
+  });
+  process.stdout.write(
+    JSON.stringify(report, null, 2) + String.fromCharCode(10)
+  );
+}
+
+void main();

--- a/tests/components/Lobby.test.tsx
+++ b/tests/components/Lobby.test.tsx
@@ -48,6 +48,16 @@ vi.mock('@clerk/nextjs', () => ({
 const mockFetch = vi.fn();
 const originalFetch = global.fetch;
 
+const { mockTrackLobbyReady, mockTrackGameStarted } = vi.hoisted(() => ({
+  mockTrackLobbyReady: vi.fn(),
+  mockTrackGameStarted: vi.fn(),
+}));
+vi.mock('@/lib/analytics', () => ({
+  hashRoomId: () => '0123456789abcdef',
+  trackLobbyReady: (props: unknown) => mockTrackLobbyReady(props),
+  trackGameStarted: (props: unknown) => mockTrackGameStarted(props),
+}));
+
 // Import after mocking
 import { Lobby } from '@/components/Lobby';
 import { Doc, Id } from '@/convex/_generated/dataModel';
@@ -217,6 +227,30 @@ describe('Lobby component', () => {
     });
   });
 
+  it('emits lobby-ready and started only after a successful start with the next cycle', async () => {
+    const rematchRoom = { ...mockRoom, currentCycle: 3 };
+    mockMutations.startGame.mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    render(<Lobby room={rematchRoom} players={mockPlayers} isHost={true} />);
+    await user.click(
+      screen.getAllByRole('button', { name: /Start Linejam/i })[0]
+    );
+
+    await waitFor(() => {
+      expect(mockTrackLobbyReady).toHaveBeenCalledWith({
+        roomIdHash: '0123456789abcdef',
+        cycle: 4,
+        playerKind: 'human',
+      });
+      expect(mockTrackGameStarted).toHaveBeenCalledWith({
+        roomIdHash: '0123456789abcdef',
+        cycle: 4,
+        playerKind: 'human',
+      });
+    });
+  });
+
   it('displays error message when startGame mutation fails', async () => {
     // Arrange
     mockMutations.startGame.mockRejectedValue(new Error('Game start failed'));
@@ -238,6 +272,8 @@ describe('Lobby component', () => {
       const alerts = screen.getAllByText(/unexpected error/i);
       expect(alerts.length).toBeGreaterThan(0);
     });
+    expect(mockTrackLobbyReady).not.toHaveBeenCalled();
+    expect(mockTrackGameStarted).not.toHaveBeenCalled();
   });
 
   it('shows "Waiting for host" button when not host', () => {

--- a/tests/components/SessionRecapHub.test.tsx
+++ b/tests/components/SessionRecapHub.test.tsx
@@ -27,8 +27,11 @@ vi.mock('next/link', () => ({
 }));
 
 const mockTrackRoomInviteShared = vi.fn();
+const mockTrackArtifactAction = vi.fn();
 
 vi.mock('@/lib/analytics', () => ({
+  hashRoomId: () => 'test-room-hash',
+  trackArtifactAction: (props: unknown) => mockTrackArtifactAction(props),
   trackRoomInviteShared: (props: unknown) => mockTrackRoomInviteShared(props),
 }));
 

--- a/tests/components/WritingScreen.test.tsx
+++ b/tests/components/WritingScreen.test.tsx
@@ -67,6 +67,9 @@ describe('WritingScreen component', () => {
   // Mock assignment data matching the getCurrentAssignment return type
   const mockAssignment = {
     poemId: 'poem_123' as Id<'poems'>,
+    roomId: 'room_123',
+    cycle: 1,
+    playerKind: 'human' as const,
     lineIndex: 0, // First round, requires 1 word
     targetWordCount: 1,
     previousLineText: null,
@@ -74,6 +77,9 @@ describe('WritingScreen component', () => {
 
   const mockAssignmentRound5 = {
     poemId: 'poem_456' as Id<'poems'>,
+    roomId: 'room_456',
+    cycle: 1,
+    playerKind: 'human' as const,
     lineIndex: 4, // Fifth round, requires 5 words (peak of diamond)
     targetWordCount: 5,
     previousLineText: 'The moon rises silently tonight',

--- a/tests/hooks/useSavePoemImage.test.ts
+++ b/tests/hooks/useSavePoemImage.test.ts
@@ -16,7 +16,10 @@ vi.mock('@/lib/error', () => ({
 }));
 
 const mockTrackPoemImageSaved = vi.fn();
+const mockTrackArtifactAction = vi.fn();
 vi.mock('@/lib/analytics', () => ({
+  hashRoomId: () => 'test-room-hash',
+  trackArtifactAction: (props: unknown) => mockTrackArtifactAction(props),
   trackPoemImageSaved: (props: unknown) => mockTrackPoemImageSaved(props),
 }));
 
@@ -209,5 +212,21 @@ describe('useSavePoemImage', () => {
         poemId: testPoemId,
       })
     );
+  });
+
+  it('emits a canonical save action for a downloaded card', async () => {
+    const { result } = renderHook(() =>
+      useSavePoemImage(testPoemId, undefined, 'room-id', 2, 'human')
+    );
+    await act(async () => {
+      await result.current.handleSaveImage();
+    });
+    expect(mockTrackArtifactAction).toHaveBeenCalledWith({
+      roomIdHash: 'test-room-hash',
+      cycle: 2,
+      round: 8,
+      playerKind: 'human',
+      action: 'save',
+    });
   });
 });

--- a/tests/hooks/useSharePoem.test.ts
+++ b/tests/hooks/useSharePoem.test.ts
@@ -18,7 +18,10 @@ vi.mock('@/lib/error', () => ({
 }));
 
 const mockTrackPoemShared = vi.fn();
+const mockTrackArtifactAction = vi.fn();
 vi.mock('@/lib/analytics', () => ({
+  hashRoomId: () => 'test-room-hash',
+  trackArtifactAction: (props: unknown) => mockTrackArtifactAction(props),
   trackPoemShared: (props: unknown) => mockTrackPoemShared(props),
 }));
 
@@ -322,6 +325,22 @@ describe('useSharePoem', () => {
       title: 'Linejam poem',
       text: 'Read this poem from our Linejam session.',
       url: 'https://example.com/poem/poem123',
+    });
+  });
+
+  it('emits a canonical share action only after a successful share', async () => {
+    const { result } = renderHook(() =>
+      useSharePoem(testPoemId, undefined, openingLine, 'room-id', 2, 'human')
+    );
+    await act(async () => {
+      await result.current.handleShare();
+    });
+    expect(mockTrackArtifactAction).toHaveBeenCalledWith({
+      roomIdHash: 'test-room-hash',
+      cycle: 2,
+      round: 8,
+      playerKind: 'human',
+      action: 'share',
     });
   });
 });

--- a/tests/lib/analytics.test.ts
+++ b/tests/lib/analytics.test.ts
@@ -1,65 +1,72 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockCapture } = vi.hoisted(() => ({ mockCapture: vi.fn() }));
-
 vi.mock('posthog-js', () => ({
-  default: {
-    capture: (...args: unknown[]) => mockCapture(...args),
-  },
+  default: { capture: (...args: unknown[]) => mockCapture(...args) },
 }));
 
 import {
   markPostHogReady,
   resetPostHogReady,
 } from '@/lib/posthog/posthogReady';
-
 import {
-  trackAiPlayerAdded,
+  hashRoomId,
+  resetCapturedAnalyticsForTests,
+  trackArtifactAction,
   trackGameCompleted,
   trackGameCreated,
   trackGameJoined,
   trackGameStarted,
-  trackPoemImageSaved,
-  trackPoemShared,
-  trackRecapExported,
-  trackRoomInviteShared,
+  trackLineSubmitted,
+  trackLobbyReady,
 } from '@/lib/analytics';
+
+const props = {
+  roomIdHash: hashRoomId('room-internal-id'),
+  cycle: 1,
+  playerKind: 'human' as const,
+};
 
 describe('analytics', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetCapturedAnalyticsForTests();
     markPostHogReady();
   });
-
   afterEach(() => resetPostHogReady());
 
-  it('uses an empty payload when game creation props are omitted', () => {
-    trackGameCreated();
-
-    expect(mockCapture).toHaveBeenCalledWith('game_created', {});
+  it('hashes room ids without returning the raw value', () => {
+    expect(hashRoomId('room-internal-id')).toMatch(/^[0-9a-f]{16}$/);
+    expect(hashRoomId('room-internal-id')).toBe(hashRoomId('room-internal-id'));
+    expect(hashRoomId('room-internal-id')).not.toContain('room-internal-id');
   });
 
-  it('forwards the remaining analytics events with their payloads', () => {
-    trackGameCreated({ playerCount: 4 });
-    trackGameJoined({ roomCode: 'ABCD' });
-    trackGameStarted({ playerCount: 4, hasAi: true });
-    trackGameCompleted({ playerCount: 4, poemCount: 2, hasAi: true });
-    trackPoemShared({ method: 'clipboard' });
-    trackRoomInviteShared({ method: 'native-share', roomCode: 'WXYZ' });
-    trackAiPlayerAdded({ playerCount: 5 });
-    trackPoemImageSaved({ method: 'native-share' });
-    trackRecapExported({ method: 'print', poemCount: 6 });
+  it('emits one canonical event per room-cycle funnel stage', () => {
+    trackGameCreated(props);
+    trackGameJoined(props);
+    trackLobbyReady(props);
+    trackGameStarted(props);
+    trackLineSubmitted({ ...props, round: 0 });
+    trackGameCompleted({ ...props, round: 8 });
+    trackArtifactAction({ ...props, action: 'save', round: 8 });
 
     expect(mockCapture.mock.calls).toEqual([
-      ['game_created', { playerCount: 4 }],
-      ['game_joined', { roomCode: 'ABCD' }],
-      ['game_started', { playerCount: 4, hasAi: true }],
-      ['game_completed', { playerCount: 4, poemCount: 2, hasAi: true }],
-      ['poem_shared', { method: 'clipboard' }],
-      ['room_invite_shared', { method: 'native-share', roomCode: 'WXYZ' }],
-      ['ai_player_added', { playerCount: 5 }],
-      ['poem_image_saved', { method: 'native-share' }],
-      ['recap_exported', { method: 'print', poemCount: 6 }],
+      ['game_created', props],
+      ['game_joined', props],
+      ['lobby_ready', props],
+      ['game_started', props],
+      ['line_submitted', { ...props, round: 0 }],
+      ['game_completed', { ...props, round: 8 }],
+      ['artifact_action', { ...props, round: 8, action: 'save' }],
     ]);
+  });
+
+  it('deduplicates retries by room, cycle, round, player kind, and action', () => {
+    trackLineSubmitted({ ...props, round: 3 });
+    trackLineSubmitted({ ...props, round: 3 });
+    trackArtifactAction({ ...props, round: 8, action: 'save' });
+    trackArtifactAction({ ...props, round: 8, action: 'save' });
+    trackArtifactAction({ ...props, round: 8, action: 'share' });
+    expect(mockCapture).toHaveBeenCalledTimes(3);
   });
 });

--- a/tests/lib/roomCycleFunnel.test.ts
+++ b/tests/lib/roomCycleFunnel.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest';
+import { buildRoomCycleFunnelReport } from '@/lib/analytics/roomCycleFunnel';
+
+const window = { from: 1_000, to: 10_000 };
+
+describe('buildRoomCycleFunnelReport', () => {
+  it('counts one human room across retries, rematches, AI seats, and abandonment', () => {
+    const report = buildRoomCycleFunnelReport({
+      ...window,
+      rooms: [
+        {
+          roomIdHash: 'private-room-key',
+          createdAt: 2_000,
+          joins: [
+            { joinedAt: 2_001, playerKind: 'human', participantKey: 'human-a' },
+            { joinedAt: 2_002, playerKind: 'human', participantKey: 'human-b' },
+            { joinedAt: 2_003, playerKind: 'AI' },
+            { joinedAt: 2_004, playerKind: 'AI' },
+          ],
+          cycles: [
+            {
+              cycle: 1,
+              startedAt: 3_000,
+              writingCompletedAt: 8_000,
+              allRevealedAt: 8_500,
+              completionKind: 'normal',
+            },
+            { cycle: 2, startedAt: 9_000, completionKind: 'abandoned' },
+          ],
+        },
+        {
+          roomIdHash: 'one-human-room',
+          createdAt: 2_500,
+          joins: [
+            {
+              joinedAt: 2_501,
+              playerKind: 'human',
+              participantKey: 'one-human',
+            },
+            { joinedAt: 2_502, playerKind: 'AI' },
+          ],
+          cycles: [{ cycle: 1, startedAt: 3_500 }],
+        },
+      ],
+      events: [
+        {
+          event: 'artifact_action',
+          occurredAt: 8_600,
+          roomIdHash: 'private-room-key',
+          cycle: 1,
+          playerKind: 'human',
+          action: 'save',
+        },
+        {
+          event: 'artifact_action',
+          occurredAt: 8_600,
+          roomIdHash: 'private-room-key',
+          cycle: 1,
+          playerKind: 'human',
+          action: 'save',
+        },
+      ],
+    });
+
+    expect(report.cohort).toEqual({
+      uniqueHumanRooms: 1,
+      source: 'server-derived',
+    });
+    expect(report.metrics.gameStarted).toEqual({
+      count: 1,
+      rate: 1,
+      source: 'server-derived',
+    });
+    expect(report.metrics.writingCompleted.count).toBe(1);
+    expect(report.metrics.allRevealed.count).toBe(1);
+    expect(report.metrics.encore.count).toBe(1);
+    expect(report.metrics.artifactAction).toEqual({
+      count: 1,
+      rate: 1,
+      source: 'event-derived',
+    });
+    expect(report.timeToStartSeconds).toMatchObject({
+      count: 1,
+      median: 1,
+      p90: 1,
+      source: 'server-derived',
+    });
+  });
+
+  it('returns only aggregate counts and never leaks room or content fields', () => {
+    const report = buildRoomCycleFunnelReport({
+      ...window,
+      rooms: [
+        {
+          roomIdHash: 'room-secret',
+          createdAt: 2_000,
+          joins: [
+            { joinedAt: 2_001, playerKind: 'human', participantKey: 'human-a' },
+            { joinedAt: 2_002, playerKind: 'human', participantKey: 'human-b' },
+          ],
+          cycles: [{ cycle: 1 }],
+        },
+      ],
+      events: [],
+    });
+
+    const serialized = JSON.stringify(report);
+    expect(serialized).not.toContain('room-secret');
+    expect(serialized).not.toContain('guest-token');
+    expect(serialized).not.toContain('ABCD');
+    expect(Object.keys(report)).toEqual([
+      'window',
+      'cohort',
+      'metrics',
+      'timeToStartSeconds',
+    ]);
+  });
+
+  it('rejects an unbounded or reversed window', () => {
+    expect(() =>
+      buildRoomCycleFunnelReport({ from: 0, to: 0, rooms: [], events: [] })
+    ).toThrow('Funnel window end must be after its start');
+    expect(() =>
+      buildRoomCycleFunnelReport({
+        from: Number.NaN,
+        to: 1,
+        rooms: [],
+        events: [],
+      })
+    ).toThrow('Funnel window bounds must be finite timestamps');
+  });
+
+  it('deduplicates retried room projections by participant and cycle', () => {
+    const room = {
+      roomIdHash: '0123456789abcdef',
+      createdAt: 2_000,
+      joins: [
+        { joinedAt: 2_001, playerKind: 'human' as const, participantKey: 'a' },
+        { joinedAt: 2_002, playerKind: 'human' as const, participantKey: 'b' },
+        { joinedAt: 2_003, playerKind: 'human' as const, participantKey: 'a' },
+        { joinedAt: 2_004, playerKind: 'AI' as const, participantKey: 'bot' },
+      ],
+      cycles: [{ cycle: 1, startedAt: 3_000 }],
+    };
+    const report = buildRoomCycleFunnelReport({
+      ...window,
+      rooms: [
+        room,
+        { ...room, joins: [...room.joins], cycles: [...room.cycles] },
+      ],
+      events: [],
+    });
+    expect(report.cohort.uniqueHumanRooms).toBe(1);
+    expect(report.metrics.gameStarted.count).toBe(1);
+  });
+
+  it('keeps abandoned first cycles out of completion while counting a started encore', () => {
+    const report = buildRoomCycleFunnelReport({
+      ...window,
+      rooms: [
+        {
+          roomIdHash: 'fedcba9876543210',
+          createdAt: 2_000,
+          joins: [
+            { joinedAt: 2_001, playerKind: 'human', participantKey: 'a' },
+            { joinedAt: 2_002, playerKind: 'human', participantKey: 'b' },
+          ],
+          cycles: [
+            { cycle: 1, startedAt: 3_000, completionKind: 'abandoned' },
+            {
+              cycle: 2,
+              startedAt: 4_000,
+              writingCompletedAt: 5_000,
+              allRevealedAt: 6_000,
+              completionKind: 'normal',
+            },
+          ],
+        },
+      ],
+      events: [],
+    });
+    expect(report.metrics.gameStarted.count).toBe(1);
+    expect(report.metrics.writingCompleted.count).toBe(0);
+    expect(report.metrics.allRevealed.count).toBe(0);
+    expect(report.metrics.encore.count).toBe(1);
+  });
+
+  it('ignores malformed, AI, unknown-cycle, and out-of-window artifact events', () => {
+    const report = buildRoomCycleFunnelReport({
+      ...window,
+      rooms: [
+        {
+          roomIdHash: '0011223344556677',
+          createdAt: 2_000,
+          joins: [
+            { joinedAt: 2_001, playerKind: 'human', participantKey: 'a' },
+            { joinedAt: 2_002, playerKind: 'human', participantKey: 'b' },
+          ],
+          cycles: [{ cycle: 1, startedAt: 3_000 }],
+        },
+      ],
+      events: [
+        {
+          event: 'artifact_action',
+          occurredAt: 2_500,
+          roomIdHash: '0011223344556677',
+          cycle: 1,
+          playerKind: 'AI',
+          action: 'save',
+        },
+        {
+          event: 'artifact_action',
+          occurredAt: 2_501,
+          roomIdHash: '0011223344556677',
+          cycle: 99,
+          playerKind: 'human',
+          action: 'save',
+        },
+        {
+          event: 'artifact_action',
+          occurredAt: 2_502,
+          roomIdHash: '0011223344556677',
+          cycle: 1,
+          playerKind: 'human',
+          action: 'delete' as 'save',
+        },
+        {
+          event: 'artifact_action',
+          occurredAt: 10_000,
+          roomIdHash: '0011223344556677',
+          cycle: 1,
+          playerKind: 'human',
+          action: 'save',
+        },
+      ],
+    });
+    expect(report.metrics.artifactAction.count).toBe(0);
+  });
+});


### PR DESCRIPTION
## What
Canonical room-cycle funnel instrumentation: one PostHog event per funnel stage (room created/joined -> lobby ready -> game started -> per-round line submitted -> all revealed -> artifact action), plus a deterministic funnel report builder (`lib/roomCycleFunnel.ts`).

## Event contract
| Event | Stage | Properties |
|---|---|---|
| `room_created` / `room_joined` | entry | `roomIdHash`, `playerKind` |
| `lobby_ready` | readiness | `roomIdHash`, `cycle`, `playerKind` |
| `game_started` | start | `roomIdHash`, `cycle`, `playerKind` |
| `line_submitted` | per-round | `roomIdHash`, `cycle`, `round`, `playerKind` |
| `game_completed` | reveal | `roomIdHash`, `cycle`, `round`, `playerKind` |
| `artifact_action` | share/save | `roomIdHash`, `cycle`, `round`, `action`, `playerKind` |

Privacy: room ids are hashed (`hashRoomId`), no PII, no durable guest identifiers (consistent with #363's scrub), no raw room codes in canonical events.

## Robustness
Line-submit tracking is fail-safe: a throwing tracker (e.g. deploy-skew assignment payloads without funnel fields) can never surface as a submit error for a line that already persisted.

Card: linejam-979