### PR TITLE
test(ai): pin mock clock mid-day to stop UTC-midnight day-bucket splits

### DIFF
--- a/tests/convex/aiLifecycle.test.ts
+++ b/tests/convex/aiLifecycle.test.ts
@@ -180,6 +180,11 @@ beforeEach(() => {
     vi.fn(() => Promise.reject(new Error('network disabled in test')))
   );
   vi.useFakeTimers();
+  // Pin the mock clock mid-day UTC: aiUsage rows are keyed by UTC day, and
+  // draining scheduled timers advances Date.now(). A suite starting near
+  // 00:00 UTC otherwise splits claims across two day buckets and the
+  // day-scoped assertions read partial counts (the 4-vs-17 CI flake).
+  vi.setSystemTime(new Date('2026-06-15T12:00:00Z'));
 });
 
 afterEach(() => {

--- a/tests/convex/ghostGenerationBudget.test.ts
+++ b/tests/convex/ghostGenerationBudget.test.ts
@@ -133,6 +133,11 @@ beforeEach(() => {
   delete process.env.AI_DAILY_CALL_ALERT_THRESHOLD;
   delete process.env.AI_PROVIDER_ENABLED;
   vi.useFakeTimers();
+  // Pin the mock clock mid-day UTC: aiUsage rows are keyed by UTC day, and
+  // draining scheduled timers advances Date.now(). A suite starting near
+  // 00:00 UTC otherwise splits claims across two day buckets and the
+  // day-scoped assertions read partial counts.
+  vi.setSystemTime(new Date('2026-06-15T12:00:00Z'));
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: string | URL | Request) => {


### PR DESCRIPTION
aiUsage rows are keyed by UTC day and the suites' fake timers start at
real wall-clock time; draining scheduled functions advances Date.now(),
so any run starting near 00:00 UTC records claims across two day buckets
while the assertions query only the first — the 4-vs-17 partial-count
failures that turned master red tonight (every CI run between 23:40 and
00:00 UTC failed; runs outside that window passed). Pin the mock clock
to 12:00 UTC so a drain would need 12h of advancement to cross a
boundary.
