### PR TITLE
feat(auth): migrate Clerk from v6 to v7

### DIFF
--- a/app/poem/[id]/card/route.ts
+++ b/app/poem/[id]/card/route.ts
@@ -56,9 +56,16 @@ export async function POST(request: NextRequest, { params }: CardRouteContext) {
       ? body.guestToken
       : undefined;
 
-  const clerkToken = guestToken
-    ? null
-    : await (await auth()).getToken({ template: 'convex' });
+  let clerkToken: string | null = null;
+  if (!guestToken) {
+    try {
+      clerkToken = await (await auth()).getToken({ template: 'convex' });
+    } catch {
+      // Clerk v7 surfaces offline/token-service failures from getToken().
+      // Do not turn an auth outage into a 500 or probe Convex anonymously.
+      return renderCard(request, null);
+    }
+  }
   const poem = await (
     clerkToken
       ? fetchQuery(

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { SignedIn, SignedOut, UserButton } from '@clerk/nextjs';
+import { Show, UserButton } from '@clerk/nextjs';
 import { Palette, Archive, LogIn, MoreHorizontal } from 'lucide-react';
 import { HelpModal } from './HelpModal';
 import { isFocusedPlayRoute } from '@/lib/routes';
@@ -74,7 +74,7 @@ export function Header({ className = '' }: HeaderProps) {
 
         {/* Right: Auth + Theme */}
         <div className="flex shrink-0 items-center gap-1 min-[360px]:gap-2 sm:gap-4 ml-auto">
-          <SignedOut>
+          <Show when="signed-out">
             <Link
               href="/sign-in"
               className={`${headerIconClasses} flex`}
@@ -82,9 +82,9 @@ export function Header({ className = '' }: HeaderProps) {
             >
               <LogIn className="w-5 h-5" />
             </Link>
-          </SignedOut>
+          </Show>
 
-          <SignedIn>
+          <Show when="signed-in">
             <UserButton
               appearance={{
                 elements: {
@@ -94,7 +94,7 @@ export function Header({ className = '' }: HeaderProps) {
                 },
               }}
             />
-          </SignedIn>
+          </Show>
 
           {/* Archive link */}
           <Link

--- a/lib/clerk/appearance.ts
+++ b/lib/clerk/appearance.ts
@@ -65,7 +65,7 @@ export const linejamClerkAppearance = {
     modalBackdrop: 'bg-[var(--color-background)]/80',
     modalContent: 'bg-[var(--color-surface)]',
   },
-  layout: {
+  options: {
     socialButtonsPlacement: 'top' as const,
     socialButtonsVariant: 'blockButton' as const,
   },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "analytics:room-cycle": "tsx scripts/analytics/room-cycle-funnel.ts"
   },
   "dependencies": {
-    "@clerk/nextjs": "^6.39.6",
+    "@clerk/nextjs": "^7.5.20",
     "clsx": "^2.1.1",
     "convex": "^1.42.1",
     "lucide-react": "^1.24.0",
@@ -80,8 +80,8 @@
   },
   "devDependencies": {
     "@browserbasehq/stagehand": "3.6.0",
-    "@clerk/backend": "^3.11.2",
-    "@clerk/testing": "^2.2.5",
+    "@clerk/backend": "^3.11.7",
+    "@clerk/testing": "^2.2.10",
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
     "@edge-runtime/vm": "^5.0.0",
@@ -118,7 +118,7 @@
   "pnpm": {
     "overrides": {
       "@clerk/shared@3": "^3.47.7",
-      "@clerk/shared@4": "^4.15.0",
+      "@clerk/shared@4": "^4.25.5",
       "ajv@6": "^6.14.0",
       "esbuild@<0.28.1": ">=0.28.1",
       "flatted": "3.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@clerk/shared@3': ^3.47.7
-  '@clerk/shared@4': ^4.15.0
+  '@clerk/shared@4': ^4.25.5
   ajv@6: ^6.14.0
   esbuild@<0.28.1: '>=0.28.1'
   flatted: 3.4.2
@@ -31,14 +31,14 @@ importers:
   .:
     dependencies:
       '@clerk/nextjs':
-        specifier: ^6.39.6
-        version: 6.39.6(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^7.5.20
+        version: 7.5.20(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
       convex:
         specifier: ^1.42.1
-        version: 1.42.1(@clerk/clerk-react@5.61.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7)
+        version: 1.42.1(@clerk/clerk-react@5.61.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@clerk/react@6.12.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7)
       lucide-react:
         specifier: ^1.24.0
         version: 1.24.0(react@19.2.7)
@@ -68,11 +68,11 @@ importers:
         specifier: 3.6.0
         version: 3.6.0(playwright-core@1.61.1)(zod@4.4.3)
       '@clerk/backend':
-        specifier: ^3.11.2
-        version: 3.11.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^3.11.7
+        version: 3.11.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@clerk/testing':
-        specifier: ^2.2.5
-        version: 2.2.5(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^2.2.10
+        version: 2.2.10(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@commitlint/cli':
         specifier: ^21.2.1
         version: 21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.1.0)(typescript@5.9.3)
@@ -126,7 +126,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       convex-test:
         specifier: ^0.0.54
-        version: 0.0.54(convex@1.42.1(@clerk/clerk-react@5.61.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7))
+        version: 0.0.54(convex@1.42.1(@clerk/clerk-react@5.61.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@clerk/react@6.12.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7))
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.7.0)
@@ -755,12 +755,8 @@ packages:
   '@cacheable/utils@2.5.0':
     resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
 
-  '@clerk/backend@2.33.6':
-    resolution: {integrity: sha512-5foMmTHEQFt4mDv7AN0RDwUHZhGcg/JYe5hnl9SU/LFS8ZHY29Z2HDtIBmzKgjRfOJTMKj1AM81LgK2UFsGm9Q==}
-    engines: {node: '>=18.17.0'}
-
-  '@clerk/backend@3.11.2':
-    resolution: {integrity: sha512-HaHAnKzThRpdRi+QJkMo3+Cx/3hJUt+UdbQ62Ikzwwt0zIhUE0+qgG+zgUHjAdYhSbfiUzEWYsLdnBsfQ7yv7g==}
+  '@clerk/backend@3.11.7':
+    resolution: {integrity: sha512-il2wyzS2I10Gv8v+ECEKQqDfaW7gCD2BWUZp37LOMFBn6/DJ7FhHfe4XwgQLUDBkHyk2LxyTt3Lbg5GnpNJPUQ==}
     engines: {node: '>=20.9.0'}
 
   '@clerk/clerk-react@5.61.9':
@@ -770,11 +766,18 @@ packages:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
-  '@clerk/nextjs@6.39.6':
-    resolution: {integrity: sha512-bfB1mt1kFdlV2khNdJPP4Zynrz6XfXjqiJogEHWpeK0ch46uWX7lNN9wrstkokDMHTmvpVkDZPAKkncdK3vZ6w==}
-    engines: {node: '>=18.17.0'}
+  '@clerk/nextjs@7.5.20':
+    resolution: {integrity: sha512-ZyrRuYw9dAz7EnxDf0meb2O/rKlGJ6oB5UKcYu+BGqzORz5HK4i8zEhhjjF4PnTkRNl90eUDR2rxPWtgI2Q9wQ==}
+    engines: {node: '>=20.9.0'}
     peerDependencies:
-      next: ^13.5.7 || ^14.2.25 || ^15.2.3 || ^16
+      next: ^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/react@6.12.5':
+    resolution: {integrity: sha512-sPO67Ikeh+r9Mu0jEinEHlkmzYf0VSCGHNIf4ueCHT1H6+wDzrXZS08uFB3Tv4jd6IZJdXSEXDr51NAn+86Jiw==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
@@ -790,8 +793,8 @@ packages:
       react-dom:
         optional: true
 
-  '@clerk/shared@4.25.1':
-    resolution: {integrity: sha512-+FHoFEJ8zGenUymf03gARKEAYOLxOKm6B437tgukxP7oM5ORfI+ZND62W25S8ddVsDLlNTS0VEHlhDm3F+NF0A==}
+  '@clerk/shared@4.25.5':
+    resolution: {integrity: sha512-pb+pA+88OACHSuE0JhsnV7Qzl1j9UhI9KrXivS831x1BJOtNYORnDqRg3xss2SPFcC46clE9S5QqkRQqv1lSsg==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -802,8 +805,8 @@ packages:
       react-dom:
         optional: true
 
-  '@clerk/testing@2.2.5':
-    resolution: {integrity: sha512-61xa8Wo76IVOQdVbUbAQvUl5IYGj600ayQbEybb28h8aXGH9sNUgXKWqpzjwBP2ndT9whLG9pQD5mAD9ixOktQ==}
+  '@clerk/testing@2.2.10':
+    resolution: {integrity: sha512-6sP26Ei3kptaFwKpKFc5327qrzyF1h4cKUCRTlBPTzkEJ/OasoLWk+NH7ewdCB5pFqQ0/5ygykxvRykWreH6AQ==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       '@playwright/test': ^1
@@ -813,10 +816,6 @@ packages:
         optional: true
       cypress:
         optional: true
-
-  '@clerk/types@4.101.26':
-    resolution: {integrity: sha512-tUeiElAZoXu9Dxom9t6IjkEfsfP7aWSVf5x5mCoHnSr2w+wV4EtEwoLl9vexT5LL0di4qidROSfcrOnorzczIQ==}
-    engines: {node: '>=18.17.0'}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -8557,19 +8556,9 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
-  '@clerk/backend@2.33.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@clerk/backend@3.11.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@clerk/shared': 3.47.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@clerk/types': 4.101.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      standardwebhooks: 1.0.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - react
-      - react-dom
-
-  '@clerk/backend@3.11.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@clerk/shared': 4.25.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/shared': 4.25.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       standardwebhooks: 1.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -8582,17 +8571,24 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       tslib: 2.8.1
+    optional: true
 
-  '@clerk/nextjs@6.39.6(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@clerk/nextjs@7.5.20(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@clerk/backend': 2.33.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@clerk/clerk-react': 5.61.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@clerk/shared': 3.47.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@clerk/types': 4.101.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/backend': 3.11.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/react': 6.12.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/shared': 4.25.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       server-only: 0.0.1
+      tslib: 2.8.1
+
+  '@clerk/react@6.12.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@clerk/shared': 4.25.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       tslib: 2.8.1
 
   '@clerk/shared@3.47.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
@@ -8606,8 +8602,9 @@ snapshots:
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+    optional: true
 
-  '@clerk/shared@4.25.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@clerk/shared@4.25.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@tanstack/query-core': 5.101.2
       dequal: 2.0.3
@@ -8617,20 +8614,13 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@clerk/testing@2.2.5(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@clerk/testing@2.2.10(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@clerk/backend': 3.11.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@clerk/shared': 4.25.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/backend': 3.11.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/shared': 4.25.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       dotenv: 17.2.2
     optionalDependencies:
       '@playwright/test': 1.58.2
-    transitivePeerDependencies:
-      - react
-      - react-dom
-
-  '@clerk/types@4.101.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@clerk/shared': 3.47.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -11283,17 +11273,18 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  convex-test@0.0.54(convex@1.42.1(@clerk/clerk-react@5.61.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7)):
+  convex-test@0.0.54(convex@1.42.1(@clerk/clerk-react@5.61.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@clerk/react@6.12.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7)):
     dependencies:
-      convex: 1.42.1(@clerk/clerk-react@5.61.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7)
+      convex: 1.42.1(@clerk/clerk-react@5.61.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@clerk/react@6.12.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7)
 
-  convex@1.42.1(@clerk/clerk-react@5.61.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7):
+  convex@1.42.1(@clerk/clerk-react@5.61.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@clerk/react@6.12.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(bufferutil@4.1.0)(react@19.2.7):
     dependencies:
       esbuild: 0.28.1
       prettier: 3.9.5
       ws: 8.21.0(bufferutil@4.1.0)
     optionalDependencies:
       '@clerk/clerk-react': 5.61.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/react': 6.12.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
     transitivePeerDependencies:
       - bufferutil
@@ -11358,7 +11349,8 @@ snapshots:
 
   css.escape@1.5.1: {}
 
-  csstype@3.1.3: {}
+  csstype@3.1.3:
+    optional: true
 
   csstype@3.2.3: {}
 
@@ -12727,7 +12719,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.18.0)
+      retry-axios: 2.6.0(axios@1.18.0(debug@4.3.4))
       tough-cookie: 4.1.3
     transitivePeerDependencies:
       - supports-color
@@ -14680,7 +14672,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.18.0):
+  retry-axios@2.6.0(axios@1.18.0(debug@4.3.4)):
     dependencies:
       axios: 1.18.0(debug@4.3.4)
     optional: true
@@ -15159,7 +15151,8 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@3.10.0: {}
+  std-env@3.10.0:
+    optional: true
 
   std-env@4.2.0: {}
 
@@ -15345,6 +15338,7 @@ snapshots:
       dequal: 2.0.3
       react: 19.2.7
       use-sync-external-store: 1.6.0(react@19.2.7)
+    optional: true
 
   sylvester@0.0.21:
     optional: true
@@ -15669,6 +15663,7 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+    optional: true
 
   util-deprecate@1.0.2: {}
 

--- a/tests/app/api/poem-card-route.test.ts
+++ b/tests/app/api/poem-card-route.test.ts
@@ -164,6 +164,22 @@ describe('GET /poem/[id]/card', () => {
     expect(mockGetToken).not.toHaveBeenCalled();
   });
 
+  it('returns unavailable when Clerk cannot mint a Convex token', async () => {
+    mockGetToken.mockRejectedValue(new Error('Clerk is offline'));
+    const request = new NextRequest('https://linejam.app/poem/poem123/card', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ id: 'poem123' }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(mockFetchQuery).not.toHaveBeenCalled();
+  });
+
   it('forwards Clerk Convex auth for a signed-in participant card', async () => {
     mockGetToken.mockResolvedValue('convex-jwt');
     mockFetchQuery.mockResolvedValue(attributedPoem);

--- a/tests/app/mobile-entry-layout.test.tsx
+++ b/tests/app/mobile-entry-layout.test.tsx
@@ -5,6 +5,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 const mockUseSearchParams = vi.fn();
 const mockUsePathname = vi.fn();
+const mockClerkState = vi.hoisted(() => ({ isSignedIn: false }));
 
 vi.mock('next/navigation', () => ({
   usePathname: () => mockUsePathname(),
@@ -19,8 +20,13 @@ vi.mock('convex/react', () => ({
 }));
 
 vi.mock('@clerk/nextjs', () => ({
-  SignedIn: () => null,
-  SignedOut: ({ children }: { children: ReactNode }) => children,
+  Show: ({ when, children }: { when: string; children: ReactNode }) => {
+    const shouldShow =
+      when === 'signed-in'
+        ? mockClerkState.isSignedIn
+        : !mockClerkState.isSignedIn;
+    return shouldShow ? children : null;
+  },
   UserButton: () => <button type="button">Account</button>,
   useUser: () => ({ user: null, isLoaded: true }),
   SignIn: () => (
@@ -44,6 +50,7 @@ describe('mobile entry layout', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockClerkState.isSignedIn = false;
     mockUsePathname.mockReturnValue('/join');
     mockUseSearchParams.mockReturnValue(new URLSearchParams('code=ABCD'));
     global.fetch = vi.fn().mockResolvedValue({
@@ -128,6 +135,17 @@ describe('mobile entry layout', () => {
     expect(screen.getByRole('link', { name: 'Your poems' })).toHaveClass(
       'min-h-11'
     );
+  });
+
+  it('renders the signed-in account control through Show', () => {
+    mockClerkState.isSignedIn = true;
+
+    render(<Header />);
+
+    expect(screen.getByRole('button', { name: 'Account' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Sign in' })
+    ).not.toBeInTheDocument();
   });
 
   it('closes the mobile header menu outside or with Escape and restores focus', () => {

--- a/tests/lib/clerk-appearance.test.ts
+++ b/tests/lib/clerk-appearance.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { linejamClerkAppearance } from '@/lib/clerk/appearance';
+
+describe('Clerk appearance', () => {
+  it('uses the Core 3 options key for social button layout', () => {
+    expect(linejamClerkAppearance.options).toEqual({
+      socialButtonsPlacement: 'top',
+      socialButtonsVariant: 'blockButton',
+    });
+    expect(linejamClerkAppearance).not.toHaveProperty('layout');
+  });
+});


### PR DESCRIPTION
- @clerk/nextjs ^7.5.20, @clerk/backend ^3.11.7, @clerk/testing ^2.2.10,
  @clerk/shared@4 override ^4.25.5 (required by v7 peer graph)
- SignedIn/SignedOut -> Show when=signed-in|signed-out (Header)
- appearance.layout -> appearance.options (Clerk appearance contract test added)
- poem card route: getToken() failures fail closed to anonymous render
  instead of a 500 (v7 surfaces token-service outages from getToken)
- middleware's request-time dynamic Clerk resolution + nonce forwarding
  preserved; guest-only passthrough behavior unchanged

Card: linejam-933
