### PR TITLE
test(e2e): assert late-join admission instead of dead started-rejection

### DIFF
--- a/lib/errorFeedback.ts
+++ b/lib/errorFeedback.ts
@@ -203,7 +203,10 @@ function isGameAlreadyStartedError(message: string): boolean {
   return (
     lowerMessage.includes('not in lobby status') ||
     lowerMessage.includes('already started') ||
-    lowerMessage.includes('game in progress')
+    lowerMessage.includes('game in progress') ||
+    // Live server message since linejam-974: joinRoom only rejects a game
+    // state when late join is not allowed (e.g. the game just completed).
+    lowerMessage.includes('cannot join this game state')
   );
 }
 

--- a/tests/e2e/errors.spec.ts
+++ b/tests/e2e/errors.spec.ts
@@ -12,7 +12,7 @@ import { E2E_TEST_IDS } from '../../lib/e2eTestIds';
  *
  * Test Cases:
  * - Invalid room code → friendly error message
- * - Game already started → join blocked with explanation
+ * - Game in progress → latecomer admitted to the room (linejam-974)
  * - Word count validation → submit disabled until correct
  */
 
@@ -183,9 +183,12 @@ function joinErrorAlert(page: Page) {
 }
 
 test.describe('Party-path error taxonomy', () => {
-  test('joining a room with a game in progress shows the started message', async ({
+  test('joining a room with a game in progress admits the latecomer', async ({
     browser,
   }) => {
+    // Contract changed by linejam-974: an in-progress game with open seats
+    // is a supported late-arrival path (spectator for the current round),
+    // not a rejection. The old "already started" taxonomy entry is dead.
     const session = await GuestFlowSession.create(browser, {
       hostName: 'Taxonomy Host',
       guestName: 'Taxonomy Guest',
@@ -198,10 +201,10 @@ test.describe('Party-path error taxonomy', () => {
       const { context, page } = await newGuestContext(browser);
       try {
         await submitJoin(page, session.roomCode, 'Latecomer');
-        await expect(joinErrorAlert(page)).toContainText(
-          'This game has already started. Please wait for the next session or ask the host to create a new room.',
-          { timeout: 30000 }
-        );
+        await page.waitForURL(new RegExp(`/room/${session.roomCode}$`), {
+          timeout: 30000,
+        });
+        await expect(joinErrorAlert(page)).toHaveCount(0);
       } finally {
         await context.close();
       }

--- a/tests/lib/errorFeedback.test.ts
+++ b/tests/lib/errorFeedback.test.ts
@@ -77,10 +77,10 @@ describe('errorToFeedback', () => {
   });
 
   describe('party-path error taxonomy', () => {
-    it('maps game-in-progress joins to the already-started message', () => {
-      const error = new ConvexError(
-        'Cannot join a room with a game in progress'
-      );
+    it('maps unjoinable-game-state rejections to the already-started message', () => {
+      // Live server message since linejam-974: in-progress games admit
+      // latecomers; joinRoom only rejects when late join is not allowed.
+      const error = new ConvexError('Cannot join this game state');
       const feedback = errorToFeedback(error);
 
       expect(feedback.message).toBe(


### PR DESCRIPTION
linejam-974 made joining an in-progress game with open seats a supported
late-arrival path, so the 'already started' taxonomy entry no longer
exists: the join succeeds and no error alert renders. Every PR since has
failed E2E Mirror on this stale assertion (masters own run passed only by
timing). Assert the live contract instead, map the live
'Cannot join this game state' server message (thrown when late join is
not allowed, e.g. completed games) to the existing friendly copy, and
update the unit taxonomy test to the live string.
