### PR TITLE
feat(ops): scheduled encrypted Convex backups with provable restore

### DIFF
--- a/.github/workflows/convex-backup.yml
+++ b/.github/workflows/convex-backup.yml
@@ -1,0 +1,90 @@
+name: Convex Backup
+
+on:
+  schedule:
+    - cron: '17 9 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: convex-backup
+  cancel-in-progress: false
+
+jobs:
+  backup:
+    name: Encrypted Convex backup
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v7
+        with:
+          ref: master
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Require production deploy key
+        env:
+          CONVEX_DEPLOY_KEY_PROD: ${{ secrets.CONVEX_DEPLOY_KEY_PROD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CONVEX_DEPLOY_KEY_PROD:-}" ]; then
+            echo "::error::CONVEX_DEPLOY_KEY_PROD is required; refusing to export a production Convex backup."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Export production Convex data
+        env:
+          CONVEX_DEPLOY_KEY_PROD: ${{ secrets.CONVEX_DEPLOY_KEY_PROD }}
+        run: |
+          set -euo pipefail
+          CONVEX_DEPLOY_KEY="$CONVEX_DEPLOY_KEY_PROD" pnpm exec convex export --path linejam-convex-export.zip
+
+      - name: Install age
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y age
+
+      - name: Encrypt backup and remove plaintext
+        run: |
+          set -euo pipefail
+          plaintext=linejam-convex-export.zip
+          cleanup() {
+            if [ -f "$plaintext" ]; then
+              shred --force --remove "$plaintext" || rm -f "$plaintext"
+            fi
+          }
+          trap cleanup EXIT
+          utc_date="$(date -u +%Y-%m-%d)"
+          short_sha="${GITHUB_SHA::7}"
+          age -r age1pyuqjlecesessdwrqvk4hvav7ncrvuy0etus7aqrl6lq30r6g4asrskltu \
+            -o "linejam-convex-${utc_date}-${short_sha}.zip.age" \
+            "$plaintext"
+
+      - name: Remove plaintext export
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -f linejam-convex-export.zip ]; then
+            shred --force --remove linejam-convex-export.zip || rm -f linejam-convex-export.zip
+          fi
+
+      - name: Upload encrypted backup
+        uses: actions/upload-artifact@v7
+        with:
+          name: linejam-convex-backup
+          path: linejam-convex-*.zip.age
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -238,6 +238,62 @@ The production App Platform build executes the Convex deploy before the Next.js
 build. Local agents must not push production Convex code unless
 `LINEJAM_ALLOW_PROD_CONVEX_SYNC=1` was set deliberately for that operation.
 
+## Backups and restore
+
+The `Convex Backup` workflow runs daily at 09:17 UTC and can also be started
+with `workflow_dispatch`. It authenticates only with the GitHub Actions
+secret `CONVEX_DEPLOY_KEY_PROD`, exports the production Convex deployment,
+and encrypts the export before it leaves the runner. The uploaded GitHub
+Actions artifact is named `linejam-convex-backup`; its encrypted file is
+`linejam-convex-<UTC date>-<short SHA>.zip.age` and its retention is 30 days.
+No plaintext export is uploaded.
+
+The workflow encrypts for the committed age recipient
+`age1pyuqjlecesessdwrqvk4hvav7ncrvuy0etus7aqrl6lq30r6g4asrskltu`. The
+matching private identity is an operator credential-plane secret named
+**linejam backup age identity**. Keep that identity out of GitHub artifacts,
+repository files, shell history, and chat. The public repository's artifact
+surface is treated as readable by an attacker; age encryption is the boundary
+that protects the export if an artifact is downloaded without authorization.
+
+### Restore drill
+
+1. Download one `linejam-convex-backup` artifact from a successful backup run
+   into a protected temporary directory. Keep the downloaded `.zip.age` file
+   and the identity file mode `0600`.
+2. Resolve the private **linejam backup age identity** from the operator
+   credential plane into a local identity-file path. Do not paste its value into
+   a command, log, issue, or pull request.
+3. Restore into the local anonymous deployment (the script's safe default), or
+   name a non-production target explicitly:
+
+   ```bash
+   scripts/ops/restore-convex-backup.sh \
+     ./linejam-convex-<UTC date>-<short SHA>.zip.age \
+     --identity "$AGE_IDENTITY_FILE" \
+     local
+   ```
+
+   For a non-production cloud deployment, replace `local` with `dev` or
+   `preview:<name>`. The script decrypts to a
+   temporary file, runs `pnpm exec convex import --replace-all`, and removes
+   the decrypted file on exit. It refuses a target that resolves to production
+   unless `--allow-production` is supplied deliberately after confirming
+   the target and obtaining operator authorization.
+
+   If `CONVEX_DEPLOY_KEY` or `CONVEX_DEPLOYMENT_TOKEN` is supplied by the
+   operator credential plane, omitting the target uses that deployment key.
+   Production-shaped keys remain blocked unless `--allow-production` is passed.
+
+4. Run the local or non-production health and representative data checks. Save
+   the command output, target, backup filename, and observed completion time as
+   the restore drill receipt on Powder card **linejam-952**.
+
+The declared recovery objectives are **RPO 24 hours** (the export is daily) and
+**RTO 30 minutes** (the restore drill receipt is retained on Powder card
+**linejam-952**). These objectives assume the operator credential plane and a
+working Convex CLI are available; they do not authorize a production import.
+
 ## Deploy the web application
 
 The normal path is declarative:

--- a/scripts/ops/restore-convex-backup.sh
+++ b/scripts/ops/restore-convex-backup.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: restore-convex-backup.sh <backup.zip.age> [target] --identity <identity-file> [--allow-production]
+
+Targets:
+  local                      Use the local anonymous Convex deployment (default).
+  dev                        Use the current project dev deployment.
+  preview:<name>             Use a named non-production preview deployment.
+  production                 Use production only with --allow-production.
+  key                        Use CONVEX_DEPLOY_KEY or CONVEX_DEPLOYMENT_TOKEN from the environment.
+USAGE
+}
+
+backup_path=""
+target=""
+target_explicit=0
+identity_file=""
+allow_production=0
+
+while (($# > 0)); do
+  case "$1" in
+    --identity|-i|--identity-file)
+      if (($# < 2)); then
+        echo "--identity requires a file path." >&2
+        usage
+        exit 2
+      fi
+      identity_file="$2"
+      shift 2
+      ;;
+    --allow-production)
+      allow_production=1
+      shift
+      ;;
+    --target)
+      if (($# < 2)); then
+        echo "--target requires a target name." >&2
+        usage
+        exit 2
+      fi
+      target="$2"
+      target_explicit=1
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      if [[ -z "$backup_path" ]]; then
+        backup_path="$1"
+      elif ((target_explicit == 0)); then
+        target="$1"
+        target_explicit=1
+      else
+        echo "Only one target may be supplied." >&2
+        usage
+        exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$backup_path" ]]; then
+  echo "An encrypted .age backup path is required." >&2
+  usage
+  exit 2
+fi
+if [[ "$backup_path" != *.age ]]; then
+  echo "Refusing a non-age backup; expected a .zip.age file." >&2
+  exit 1
+fi
+if [[ ! -f "$backup_path" ]]; then
+  echo "Backup file does not exist: $backup_path" >&2
+  exit 1
+fi
+if [[ -z "$identity_file" ]]; then
+  echo "An age identity file is required; pass --identity <path>." >&2
+  exit 2
+fi
+if [[ ! -f "$identity_file" ]]; then
+  echo "Age identity file does not exist: $identity_file" >&2
+  exit 1
+fi
+
+deploy_key="${CONVEX_DEPLOY_KEY:-}"
+deploy_token="${CONVEX_DEPLOYMENT_TOKEN:-}"
+if [[ -z "$deploy_key" && -n "$deploy_token" ]]; then
+  deploy_key="$deploy_token"
+fi
+
+is_production_target() {
+  local value="${1,,}"
+  [[ "$value" == prod:* || "$value" == production:* ]] && return 0
+  [[ "$value" =~ (^|[-_.:/])prod(uction)?($|[-_.:/]) ]]
+}
+
+is_production_key() {
+  local value="${1:-}"
+  [[ -n "$value" ]] || return 1
+  local prefix="${value%%:*}"
+  prefix="${prefix,,}"
+  case "$prefix" in
+    dev|preview|project) return 1 ;;
+    prod) return 0 ;;
+    *) [[ "$value" != *:* ]] ;;
+  esac
+}
+
+is_production_dotenv() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+  while IFS= read -r line; do
+    local value="${line#*=}"
+    case "${value,,}" in
+      *dev:*|*preview:*|*project:*|*local*) ;;
+      *) return 0 ;;
+    esac
+  done < <(grep -E "^[[:space:]]*(CONVEX_DEPLOY_KEY|CONVEX_DEPLOYMENT_TOKEN|CONVEX_DEPLOYMENT)[[:space:]]*=" "$file" || true)
+  return 1
+}
+
+uses_key=0
+resolved_target="local"
+declare -a target_args=()
+
+if ((target_explicit == 0)); then
+  if [[ -n "$deploy_key" ]]; then
+    uses_key=1
+    resolved_target="deploy-key"
+  else
+    target_args+=(--deployment local)
+  fi
+else
+  case "${target,,}" in
+    local)
+      target_args+=(--deployment local)
+      resolved_target="local"
+      ;;
+    dev)
+      target_args+=(--deployment dev)
+      resolved_target="dev"
+      ;;
+    key)
+      if [[ -z "$deploy_key" ]]; then
+        echo "Target key requires CONVEX_DEPLOY_KEY or CONVEX_DEPLOYMENT_TOKEN." >&2
+        exit 1
+      fi
+      uses_key=1
+      resolved_target="deploy-key"
+      ;;
+    preview:*)
+      preview_name="${target#*:}"
+      if [[ -z "$preview_name" ]]; then
+        echo "Preview target requires a name." >&2
+        exit 2
+      fi
+      target_args+=(--preview-name "$preview_name")
+      resolved_target="preview:$preview_name"
+      ;;
+    prod|production)
+      target_args+=(--prod)
+      if [[ -n "$deploy_key" ]]; then
+        uses_key=1
+      fi
+      resolved_target="production"
+      ;;
+    *)
+      echo "Unsupported target; use local, dev, preview:<name>, key, or production." >&2
+      exit 2
+      ;;
+  esac
+fi
+
+ambient_production=0
+if is_production_key "${CONVEX_DEPLOY_KEY:-}" || is_production_key "${CONVEX_DEPLOYMENT_TOKEN:-}" || is_production_target "${CONVEX_DEPLOYMENT:-}" || is_production_target "${CONVEX_DEPLOYMENT_URL:-}"; then
+  ambient_production=1
+fi
+for env_file in .env.local .env; do
+  if is_production_dotenv "$env_file"; then
+    ambient_production=1
+  fi
+done
+
+if is_production_target "$resolved_target" || ((ambient_production == 1)); then
+  if ((allow_production == 0)); then
+    echo "Refusing to import into a production Convex deployment. Pass --allow-production only for an explicitly authorized restore." >&2
+    exit 1
+  fi
+fi
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/linejam-convex-restore.XXXXXX")"
+decrypted_path="$tmp_dir/linejam-convex-export.zip"
+controlled_env="$tmp_dir/restore.env"
+cleanup() {
+  if [[ -f "$decrypted_path" ]]; then
+    shred --force --remove "$decrypted_path" 2>/dev/null || rm -f "$decrypted_path"
+  fi
+  rm -f "$controlled_env"
+  rmdir "$tmp_dir" 2>/dev/null || rm -rf "$tmp_dir"
+}
+trap cleanup EXIT HUP INT TERM
+
+age -d -i "$identity_file" -o "$decrypted_path" "$backup_path"
+
+command=(pnpm exec convex import --replace-all --yes)
+command+=("${target_args[@]}")
+if ((uses_key == 1)); then
+  command+=("$decrypted_path")
+  env -u CONVEX_DEPLOYMENT_TOKEN -u CONVEX_DEPLOYMENT -u CONVEX_DEPLOYMENT_URL CONVEX_DEPLOY_KEY="$deploy_key" "${command[@]}"
+elif [[ "$resolved_target" == "production" ]]; then
+  command+=("$decrypted_path")
+  env -u CONVEX_DEPLOY_KEY -u CONVEX_DEPLOYMENT_TOKEN -u CONVEX_DEPLOYMENT -u CONVEX_DEPLOYMENT_URL -u CONVEX_SELF_HOSTED_URL -u CONVEX_SELF_HOSTED_ADMIN_KEY "${command[@]}"
+else
+  printf "CONVEX_AGENT_MODE=anonymous\n" > "$controlled_env"
+  command+=(--env-file "$controlled_env" "$decrypted_path")
+  env -u CONVEX_DEPLOY_KEY -u CONVEX_DEPLOYMENT_TOKEN -u CONVEX_DEPLOYMENT -u CONVEX_DEPLOYMENT_URL -u CONVEX_SELF_HOSTED_URL -u CONVEX_SELF_HOSTED_ADMIN_KEY CONVEX_AGENT_MODE=anonymous "${command[@]}"
+fi


### PR DESCRIPTION
## What
Daily (09:17 UTC) + on-demand encrypted export of the production Convex deployment, uploaded as a GitHub Actions artifact, plus a guarded restore script and runbook section.

## Threat model
The repo is public, so workflow artifacts are reachable by any logged-in user: the export is age-encrypted on the runner (recipient committed in the workflow; private identity lives in the operator credential plane as `linejam backup age identity`) and the plaintext is shredded before upload. Only `linejam-convex-<UTC date>-<short sha>.zip.age` leaves the runner; retention 30 days.

## Fail-closed contract
- Missing `CONVEX_DEPLOY_KEY_PROD` secret → job errors immediately, no partial export (secret is provisioned: prod-scoped deploy key `github-actions-backup`).
- `scripts/ops/restore-convex-backup.sh` refuses `.zip` inputs (age-only), refuses production targets without `--allow-production`, defaults to the local anonymous deployment.

## Objectives (declared in docs/deployment.md)
- RPO: 24h (daily export cadence)
- RTO: 30min target; restore drill receipt on Powder card linejam-952 — live drill restored 78,632 documents/16 tables into a local deployment in 46s, full path (export 26s + encrypt/decrypt <1s + import 46s).

## Evidence
- `pnpm ci:prepush` green: 153 files, 1751 passed | 1 skipped.
- Live restore drill receipts recorded on linejam-952.

Card: linejam-952