### PR TITLE
docs: make GitHub Issues the work authority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,9 @@ Compact router for repository agents. Read only the depth your lane needs.
 - Read `VISION.md` and `project.md` before changing product direction.
 - Preserve user work: inspect `git status`, never overwrite unrelated changes,
   and never use destructive Git commands.
-- Powder is the only ledger. Before implementation, run
-  `source ~/.secrets`, `/usr/bin/env powder list-ready --repo linejam`, then
-  claim one shaped card as the authenticated actor. Keep its run current and
-  complete or release it; never create a repository-local ticket store.
+- GitHub Issues is the only work ledger. Before implementation, read the Issue
+  and follow the assignee plus `forest/<issue>-<slug>` branch/PR claim contract
+  in `CONTRIBUTING.md`. Never create or update Linejam work in Powder.
 - Base branch: `master`. Commits and PR titles use Conventional Commits.
 
 ## Sources of truth
@@ -87,5 +86,6 @@ every checkout path, including isolated harness worktrees.
 Before handoff, adversarially review the diff for stale claims, authority
 ambiguity, accidental scope, secret exposure, and safety regressions. Record
 exact tests, live evidence, residual risk, and commit/PR/deployment identifiers
-in Powder. Review, merge, deploy, monitor, and production verification are
-distinct acceptance surfaces; perform only the ones authorized by the lane.
+in the GitHub Issue or PR. Review, merge, deploy, monitor, and production
+verification are distinct acceptance surfaces; perform only the ones
+authorized by the lane.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,16 +13,34 @@ Fill `.env.local` with the Convex, Clerk, guest-token, and Canary values needed
 for the loop you are running. Keep `GUEST_TOKEN_SECRET` aligned across local,
 DigitalOcean App Platform, and Convex when testing room flows.
 
-For backlog work, claim one ready Powder card before starting:
+## Claiming Work
 
-```bash
-source ~/.secrets
-powder list-ready --repo linejam
-powder claim linejam-NNN --agent <name>
-```
+[GitHub Issues](https://github.com/misty-step/linejam/issues) is Linejam's sole
+work ledger. Do not list, claim, update, or duplicate Linejam work in Powder.
+The cutover is tracked by
+[#393](https://github.com/misty-step/linejam/issues/393).
 
-Keep the returned run current, and complete the card or release the claim if
-you abandon the work. Powder is the only work ledger.
+A manual claim has exactly two parts:
+
+1. Assign the GitHub Issue to the contributor before changing the repository.
+   If self-assignment is unavailable, ask a maintainer to assign it rather than
+   starting an invisible claim.
+2. Create a `forest/<issue>-<slug>` branch. Open and link a draft pull request
+   as soon as the work has a pushable change.
+
+The assignee plus either that branch or its linked PR is the claim. An assignee
+with neither is only an intent to claim; a branch or PR with no assignee is
+unclaimed. Before starting, check both surfaces for an existing claim. On
+abandonment, remove the assignee and close or hand off the PR so the Issue is
+visibly available again. GitHub needs no lease, run record, or claim-status
+label.
+
+`forest:ready` is only an Iron Forest scheduling signal: it means an open,
+unclaimed Issue has executable acceptance criteria and no unresolved
+dependency or authority gate. It is not priority, status, or a manual claim.
+Linejam has no Iron Forest declaration yet, so Linejam cannot dispatch Iron
+Forest and no Linejam Issue may receive `forest:ready` until that declaration
+exists.
 
 ## Local Checks
 

--- a/README.md
+++ b/README.md
@@ -63,16 +63,12 @@ Keep `NEXT_PUBLIC_CONVEX_URL` pointed at the same backend you're running. For lo
 
 ### Work Ledger
 
-Powder is the work ledger for shaped Linejam tasks. Claim one card before
-starting work so parallel agents do not pick up the same item:
-
-```bash
-source ~/.secrets # loads POWDER_API_BASE_URL and POWDER_API_KEY
-powder list-ready --repo linejam
-powder claim linejam-NNN --agent <name>
-# ...work...
-powder release-claim linejam-NNN --run <run-id>
-```
+[GitHub Issues](https://github.com/misty-step/linejam/issues) is Linejam's sole
+work ledger. Before starting an issue, follow the single assignee plus
+`forest/<issue>-*` branch/PR claim contract in
+[CONTRIBUTING.md](CONTRIBUTING.md#claiming-work). Never create or update
+Linejam work in Powder. The authority cutover is tracked by
+[#393](https://github.com/misty-step/linejam/issues/393).
 
 ## Agent Faces
 

--- a/VISION.md
+++ b/VISION.md
@@ -88,6 +88,7 @@ visible before a player has to report them.
 - `AGENTS.md` is the agent router, gate contract, invariants, and environment
   boundary map.
 - `README.md` is the public project orientation and contributor entrypoint.
-- Powder is the sole work ledger (`powder list-cards --repo linejam`).
+- GitHub Issues is the sole work ledger; `CONTRIBUTING.md` defines manual
+  claims and the gated `forest:ready` scheduling signal.
 - `docs/testing.md`, Dagger code, and hosted `merge-gate` define the validation
   surface.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -286,13 +286,14 @@ that protects the export if an artifact is downloaded without authorization.
    Production-shaped keys remain blocked unless `--allow-production` is passed.
 
 4. Run the local or non-production health and representative data checks. Save
-   the command output, target, backup filename, and observed completion time as
-   the restore drill receipt on Powder card **linejam-952**.
+   the command output, target, backup filename, and observed completion time in
+   the GitHub Issue or pull request that commissioned the restore drill. Link
+   the retained workflow artifact rather than pasting credential-bearing logs.
 
 The declared recovery objectives are **RPO 24 hours** (the export is daily) and
-**RTO 30 minutes** (the restore drill receipt is retained on Powder card
-**linejam-952**). These objectives assume the operator credential plane and a
-working Convex CLI are available; they do not authorize a production import.
+**RTO 30 minutes** (the restore drill receipt is retained with its canonical
+GitHub work record). These objectives assume the operator credential plane and
+a working Convex CLI are available; they do not authorize a production import.
 
 ## Deploy the web application
 

--- a/project.md
+++ b/project.md
@@ -29,7 +29,7 @@ A digital version of the paper-folding poetry game—casual multiplayer fun with
 
 - **Milestone:** Restore public trust — anonymous play must survive identity-provider failure, private poems must stay private until explicit publication, and functional smoke failures must page.
 - **Then:** prove repeatable party value with server-derived room-cycle facts and real in-person sessions → accessibility across every retained theme → evidence-led aesthetic polish → revenue stretch.
-- **Stance:** The 010–012 expansion arc (multiple modes, per-line sparks) was deliberately rolled back — Linejam is **one core mode, refined**. The reliability + infra foundation is laid (presence/self-heal, host migration, convex-test, Landmark releases). Powder is the sole work ledger.
+- **Stance:** The 010–012 expansion arc (multiple modes, per-line sparks) was deliberately rolled back — Linejam is **one core mode, refined**. The reliability + infra foundation is laid (presence/self-heal, host migration, convex-test, Landmark releases). [GitHub Issues](https://github.com/misty-step/linejam/issues) is the sole work ledger; `CONTRIBUTING.md` owns the claim and Iron Forest scheduling contract.
 - **Theme:** Restraint as the product — Kenya Hara minimalism applied to the mechanics as much as the visuals.
 
 ## Quality Bar
@@ -78,7 +78,6 @@ them, small revenue cut per book.
 
 ---
 
-_Last updated: 2026-07-08_
-_Updated during: Powder ledger closeout. `docs/vision.md` stays demoted to a_
-_pointer at root `VISION.md`, the actual north star. This section no longer_
-_restates AGENTS.md's code patterns._
+_Last updated: 2026-08-13_
+_Updated during: GitHub Issues authority cutover_
+_[#393](https://github.com/misty-step/linejam/issues/393)._


### PR DESCRIPTION
## Outcome
- make GitHub Issues the sole Linejam work ledger
- define the assignee plus `forest/<issue>-*` branch/PR claim
- reserve `forest:ready` for executable, unclaimed Iron Forest work
- prohibit new Linejam Powder mutations
- move restore-drill receipts from the retired Powder card to canonical GitHub work records

## Verification
- `git diff --check`
- full tracked-tree `Powder` audit: remaining references are explicit no-write rules, changelog/evidence history, product palette prose, and an implementation-shape comment; no contributor, agent, automation, or operations path writes Powder
- created the `forest:ready` repository label without applying it

Prerequisite slice of #393.