### PR TITLE
fix(migrations): preserve retained room hosts

### DIFF
--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -231,9 +231,19 @@ export const cleanupMachineAuthorship = internalMutation({
                 const playerUsers = await Promise.all(
                   roomPlayers.map((player) => ctx.db.get(player.userId))
                 );
-                const hasHumanPlayer = playerUsers.some(
-                  (player) => player !== null && player.kind !== 'AI'
+                const currentHumanHost = roomPlayers.find(
+                  (player, index) =>
+                    player.userId === room?.hostUserId &&
+                    playerUsers[index] !== null &&
+                    playerUsers[index]?.kind !== 'AI'
                 );
+                const survivingHumanPlayer =
+                  currentHumanHost ??
+                  roomPlayers.find(
+                    (_, index) =>
+                      playerUsers[index] !== null &&
+                      playerUsers[index]?.kind !== 'AI'
+                  );
                 await Promise.all([
                   ctx.db.patch(game._id, {
                     status: 'ABANDONED',
@@ -248,8 +258,9 @@ export const cleanupMachineAuthorship = internalMutation({
                     ? [
                         ctx.db.patch(
                           room._id,
-                          hasHumanPlayer
+                          survivingHumanPlayer
                             ? {
+                                hostUserId: survivingHumanPlayer.userId,
                                 status: 'LOBBY' as const,
                                 currentGameId: undefined,
                                 completedAt: undefined,
@@ -390,19 +401,28 @@ export const cleanupMachineAuthorship = internalMutation({
         const results = await Promise.all(
           page.page.map(async (user) => {
             if (user.kind !== 'AI') return { changed: 0, blocked: 0 };
-            const [membership, readerAssignment] = await Promise.all([
-              ctx.db
-                .query('roomPlayers')
-                .withIndex('by_user', (q) => q.eq('userId', user._id))
-                .first(),
-              ctx.db
-                .query('poems')
-                .withIndex('by_reader', (q) =>
-                  q.eq('assignedReaderId', user._id)
-                )
-                .first(),
-            ]);
-            if (membership !== null || readerAssignment !== null) {
+            const [membership, readerAssignment, hostedRoom] =
+              await Promise.all([
+                ctx.db
+                  .query('roomPlayers')
+                  .withIndex('by_user', (q) => q.eq('userId', user._id))
+                  .first(),
+                ctx.db
+                  .query('poems')
+                  .withIndex('by_reader', (q) =>
+                    q.eq('assignedReaderId', user._id)
+                  )
+                  .first(),
+                ctx.db
+                  .query('rooms')
+                  .withIndex('by_host', (q) => q.eq('hostUserId', user._id))
+                  .first(),
+              ]);
+            if (
+              membership !== null ||
+              readerAssignment !== null ||
+              hostedRoom !== null
+            ) {
               return { changed: 0, blocked: 1 };
             }
             await ctx.db.delete(user._id);

--- a/tests/convex/migrations.test.ts
+++ b/tests/convex/migrations.test.ts
@@ -446,6 +446,10 @@ describe('cleanupMachineAuthorship', () => {
   it('revokes publication and protection when reclassifying legacy abandonment', async () => {
     const t = setupConvexTest();
     const seeded = await t.run(async (ctx) => {
+      const formerHostUserId = await ctx.db.insert('users', {
+        displayName: 'Former host',
+        createdAt: 0,
+      });
       const hostUserId = await ctx.db.insert('users', {
         displayName: 'Host',
         createdAt: 0,
@@ -457,6 +461,12 @@ describe('cleanupMachineAuthorship', () => {
         completedAt: 200,
         retentionState: 'protected',
         createdAt: 0,
+      });
+      await ctx.db.insert('roomPlayers', {
+        roomId,
+        userId: formerHostUserId,
+        displayName: 'Former host',
+        joinedAt: 0,
       });
       await ctx.db.insert('roomPlayers', {
         roomId,
@@ -488,7 +498,7 @@ describe('cleanupMachineAuthorship', () => {
         retentionState: 'protected',
         createdAt: 0,
       });
-      return { gameId, poemId, roomId };
+      return { gameId, hostUserId, poemId, roomId };
     });
 
     await runMachineCleanupPhase(t, 'games');
@@ -508,6 +518,7 @@ describe('cleanupMachineAuthorship', () => {
       expect(room).not.toHaveProperty('currentGameId');
       expect(room).not.toHaveProperty('completedAt');
       expect(room).toMatchObject({
+        hostUserId: seeded.hostUserId,
         status: 'LOBBY',
         retentionState: 'active',
       });
@@ -522,7 +533,7 @@ describe('cleanupMachineAuthorship', () => {
 
   it('keeps a legacy-abandoned room closed when only AI memberships remain', async () => {
     const t = setupConvexTest();
-    const roomId = await t.run(async (ctx) => {
+    const seeded = await t.run(async (ctx) => {
       const aiUserId = await ctx.db.insert('users', {
         displayName: 'Legacy AI host',
         kind: 'AI',
@@ -552,26 +563,105 @@ describe('cleanupMachineAuthorship', () => {
         createdAt: 0,
       });
       await ctx.db.patch(id, { currentGameId: gameId });
-      return id;
+      return { aiUserId, roomId: id };
     });
 
     await runMachineCleanupPhase(t, 'games');
     await runMachineCleanupPhase(t, 'roomPlayers');
+    const aiUserReceipts = await runMachineCleanupPhase(t, 'aiUsers');
 
-    const room = await t.run((ctx) => ctx.db.get(roomId));
+    const room = await t.run((ctx) => ctx.db.get(seeded.roomId));
     expect(room).not.toHaveProperty('currentGameId');
     expect(room).toMatchObject({
+      hostUserId: seeded.aiUserId,
       status: 'COMPLETED',
       retentionState: 'pending',
     });
     expect(
+      aiUserReceipts.reduce((sum, receipt) => sum + receipt.blocked, 0)
+    ).toBe(1);
+    expect(await t.run((ctx) => ctx.db.get(seeded.aiUserId))).not.toBeNull();
+    expect(
+      await t.run(async (ctx) => {
+        const retainedRoom = await ctx.db.get(seeded.roomId);
+        return retainedRoom === null
+          ? null
+          : await ctx.db.get(retainedRoom.hostUserId);
+      })
+    ).not.toBeNull();
+    expect(
       await t.run((ctx) =>
         ctx.db
           .query('roomPlayers')
-          .withIndex('by_room', (q) => q.eq('roomId', roomId))
+          .withIndex('by_room', (q) => q.eq('roomId', seeded.roomId))
           .collect()
       )
     ).toEqual([]);
+  });
+
+  it('promotes a surviving human before deleting a legacy AI host', async () => {
+    const t = setupConvexTest();
+    const seeded = await t.run(async (ctx) => {
+      const aiUserId = await ctx.db.insert('users', {
+        displayName: 'Legacy AI host',
+        kind: 'AI',
+        createdAt: 0,
+      });
+      const humanUserId = await ctx.db.insert('users', {
+        displayName: 'Surviving human',
+        createdAt: 1,
+      });
+      const roomId = await ctx.db.insert('rooms', {
+        code: 'AIHM',
+        hostUserId: aiUserId,
+        status: 'COMPLETED',
+        completedAt: 200,
+        createdAt: 0,
+      });
+      await Promise.all([
+        ctx.db.insert('roomPlayers', {
+          roomId,
+          userId: aiUserId,
+          displayName: 'Legacy AI host',
+          joinedAt: 0,
+        }),
+        ctx.db.insert('roomPlayers', {
+          roomId,
+          userId: humanUserId,
+          displayName: 'Surviving human',
+          joinedAt: 1,
+        }),
+      ]);
+      const gameId = await ctx.db.insert('games', {
+        roomId,
+        status: 'COMPLETED',
+        completionKind: 'abandoned',
+        cycle: 1,
+        currentRound: 4,
+        assignmentMatrix: [],
+        completedAt: 200,
+        createdAt: 0,
+      });
+      await ctx.db.patch(roomId, { currentGameId: gameId });
+      return { aiUserId, humanUserId, roomId };
+    });
+
+    await runMachineCleanupPhase(t, 'games');
+    await runMachineCleanupPhase(t, 'roomPlayers');
+    const aiUserReceipts = await runMachineCleanupPhase(t, 'aiUsers');
+
+    expect(await t.run((ctx) => ctx.db.get(seeded.roomId))).toMatchObject({
+      hostUserId: seeded.humanUserId,
+      status: 'LOBBY',
+      retentionState: 'active',
+    });
+    expect(await t.run((ctx) => ctx.db.get(seeded.aiUserId))).toBeNull();
+    expect(
+      aiUserReceipts.reduce((sum, receipt) => sum + receipt.changed, 0)
+    ).toBe(1);
+    expect(
+      aiUserReceipts.reduce((sum, receipt) => sum + receipt.blocked, 0)
+    ).toBe(0);
   });
 
   it('abandons active games whose immutable matrix contains an AI user', async () => {


### PR DESCRIPTION
## Problem
The ordered machine-authorship cleanup could delete an AI identity still required by a retained room, or reopen a mixed-membership room with an AI host that the next phases remove.

## Fix
- block aiUsers deletion on rooms.by_host references
- when an abandoned room retains humans, promote the first surviving human before reopening
- exercise games -> roomPlayers -> aiUsers for both AI-only and mixed-membership rooms
- prove every retained room host still resolves and the mixed room reaches zero blocked

## Verification
- pnpm vitest run tests/convex/migrations.test.ts (16 passed)
- pnpm ci:prepush (143 files, 1,571 tests passed; 1 skipped)

Required before any production cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy room cleanup to preserve rooms hosted by AI accounts when no human participant is available.
  * Prevented deletion of AI accounts that still host a room.
  * Promoted an eligible human participant to host and restored the room to an active lobby when possible.

* **Tests**
  * Added coverage for AI-hosted room retention, host preservation, and human host promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->